### PR TITLE
Added Exception for existing key (SYNCOPE-866)

### DIFF
--- a/core/logic/src/main/java/org/apache/syncope/core/logic/MailTemplateLogic.java
+++ b/core/logic/src/main/java/org/apache/syncope/core/logic/MailTemplateLogic.java
@@ -31,6 +31,7 @@ import org.apache.syncope.common.lib.types.ClientExceptionType;
 import org.apache.syncope.common.lib.types.MailTemplateFormat;
 import org.apache.syncope.common.lib.types.StandardEntitlement;
 import org.apache.syncope.core.persistence.api.dao.NotFoundException;
+import org.apache.syncope.core.persistence.api.dao.DuplicateException;
 import org.apache.syncope.core.persistence.api.dao.MailTemplateDAO;
 import org.apache.syncope.core.persistence.api.dao.NotificationDAO;
 import org.apache.syncope.core.persistence.api.entity.EntityFactory;
@@ -83,6 +84,9 @@ public class MailTemplateLogic extends AbstractTransactionalLogic<MailTemplateTO
 
     @PreAuthorize("hasRole('" + StandardEntitlement.MAIL_TEMPLATE_CREATE + "')")
     public MailTemplateTO create(final String key) {
+        if (mailTemplateDAO.find(key) != null) {
+            throw new DuplicateException(key);
+        }
         MailTemplate mailTemplate = entityFactory.newEntity(MailTemplate.class);
         mailTemplate.setKey(key);
         mailTemplateDAO.save(mailTemplate);

--- a/core/logic/src/main/java/org/apache/syncope/core/logic/ReportTemplateLogic.java
+++ b/core/logic/src/main/java/org/apache/syncope/core/logic/ReportTemplateLogic.java
@@ -31,6 +31,7 @@ import org.apache.syncope.common.lib.types.ClientExceptionType;
 import org.apache.syncope.common.lib.types.ReportTemplateFormat;
 import org.apache.syncope.common.lib.types.StandardEntitlement;
 import org.apache.syncope.core.persistence.api.dao.NotFoundException;
+import org.apache.syncope.core.persistence.api.dao.DuplicateException;
 import org.apache.syncope.core.persistence.api.dao.ReportTemplateDAO;
 import org.apache.syncope.core.persistence.api.dao.ReportDAO;
 import org.apache.syncope.core.persistence.api.entity.EntityFactory;
@@ -84,6 +85,9 @@ public class ReportTemplateLogic extends AbstractTransactionalLogic<ReportTempla
 
     @PreAuthorize("hasRole('" + StandardEntitlement.REPORT_TEMPLATE_CREATE + "')")
     public ReportTemplateTO create(final String key) {
+        if (reportTemplateDAO.find(key) != null) {
+            throw new DuplicateException(key);
+        }
         ReportTemplate reportTemplate = entityFactory.newEntity(ReportTemplate.class);
         reportTemplate.setKey(key);
         reportTemplateDAO.save(reportTemplate);

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/MailTemplateITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/MailTemplateITCase.java
@@ -150,4 +150,16 @@ public class MailTemplateITCase extends AbstractITCase {
             assertEquals(ClientExceptionType.NotFound, e.getType());
         }
     }
+
+    @Test
+    public void issueSYNCOPE866() {
+        MailTemplateTO mailTemplateTO = new MailTemplateTO();
+        mailTemplateTO.setKey("optin");
+        try {
+            mailTemplateService.create(mailTemplateTO);
+            fail();
+        } catch (SyncopeClientException e) {
+            assertEquals(ClientExceptionType.EntityExists, e.getType());
+        }
+    }
 }

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/ReportTemplateITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/ReportTemplateITCase.java
@@ -152,4 +152,16 @@ public class ReportTemplateITCase extends AbstractITCase {
             assertEquals(ClientExceptionType.NotFound, e.getType());
         }
     }
+
+    @Test
+    public void issueSYNCOPE866() {
+        ReportTemplateTO reportTemplateTO = new ReportTemplateTO();
+        reportTemplateTO.setKey("empty");
+        try {
+            reportTemplateService.create(reportTemplateTO);
+            fail();
+        } catch (SyncopeClientException e) {
+            assertEquals(ClientExceptionType.EntityExists, e.getType());
+        }
+    }
 }


### PR DESCRIPTION
I have added a new Exception named **KeyAlreadyExistsException** and attached it to the **MailTemplateLogic** and **ReportTemplateLogic** classes to check for duplicate keys and throw the new Exception.

I have also tested this out on Swagger and attached screenshots of the error for both **MailTemplates**

![mailtemplatekeyalreadyexistsexception](https://cloud.githubusercontent.com/assets/9494086/15772586/843cf8dc-298f-11e6-9627-f05962c92fad.png)

and **ReportTemplates**.

![reporttemplatekeyalreadyexistsexception](https://cloud.githubusercontent.com/assets/9494086/15772587/844468e2-298f-11e6-9330-3fc0d40ebb94.png)