### PR TITLE
SYNCOPE-871 Linked NumberWidgets to pages

### DIFF
--- a/client/console/src/main/java/org/apache/syncope/client/console/pages/Realms.java
+++ b/client/console/src/main/java/org/apache/syncope/client/console/pages/Realms.java
@@ -134,7 +134,11 @@ public class Realms extends BasePage {
             }
         });
 
-        updateRealmContent(realmChoicePanel.getCurrentRealm());
+        try {
+            updateRealmContent(realmChoicePanel.getCurrentRealm(), parameters.get("selectedIndex").toInteger());
+        } catch (Exception e) {
+            updateRealmContent(realmChoicePanel.getCurrentRealm(), 0);
+        }
     }
 
     @Override
@@ -144,7 +148,7 @@ public class Realms extends BasePage {
         if (event.getPayload() instanceof ChosenRealm) {
             @SuppressWarnings("unchecked")
             final ChosenRealm<RealmTO> choosenRealm = ChosenRealm.class.cast(event.getPayload());
-            updateRealmContent(choosenRealm.getObj());
+            updateRealmContent(choosenRealm.getObj(), 0);
             choosenRealm.getTarget().add(content);
         } else if (event.getPayload() instanceof AjaxWizard.NewItemEvent) {
             final AjaxWizard.NewItemEvent<?> newItemEvent = AjaxWizard.NewItemEvent.class.cast(event.getPayload());
@@ -166,11 +170,11 @@ public class Realms extends BasePage {
         }
     }
 
-    private WebMarkupContainer updateRealmContent(final RealmTO realmTO) {
+    private WebMarkupContainer updateRealmContent(final RealmTO realmTO, final int selectedIndex) {
         if (realmTO == null) {
             return content;
         }
-        content.addOrReplace(new Realm("body", realmTO, getPageReference()) {
+        content.addOrReplace(new Realm("body", realmTO, getPageReference(), selectedIndex) {
 
             private static final long serialVersionUID = 8221398624379357183L;
 
@@ -230,7 +234,7 @@ public class Realms extends BasePage {
                     target.add(realmChoicePanel.reloadRealmTree(target));
 
                     SyncopeConsoleSession.get().info(getString(Constants.OPERATION_SUCCEEDED));
-                    updateRealmContent(parent);
+                    updateRealmContent(parent, selectedIndex);
                     target.add(content);
                 } catch (Exception e) {
                     LOG.error("While deleting realm", e);

--- a/client/console/src/main/java/org/apache/syncope/client/console/panels/Realm.java
+++ b/client/console/src/main/java/org/apache/syncope/client/console/panels/Realm.java
@@ -56,12 +56,14 @@ public abstract class Realm extends Panel {
 
     private final AnyTypeRestClient anyTypeRestClient = new AnyTypeRestClient();
 
-    public Realm(final String id, final RealmTO realmTO, final PageReference pageRef) {
+    public Realm(final String id, final RealmTO realmTO, final PageReference pageRef, final int selectedIndex) {
         super(id);
         this.realmTO = realmTO;
         this.anyTypeTOs = anyTypeRestClient.list();
 
-        add(new AjaxBootstrapTabbedPanel<>("tabbedPanel", buildTabList(pageRef)));
+        AjaxBootstrapTabbedPanel tabbedPanel = new AjaxBootstrapTabbedPanel<>("tabbedPanel", buildTabList(pageRef));
+        tabbedPanel.setSelectedTab(selectedIndex);
+        add(tabbedPanel);
     }
 
     public RealmTO getRealmTO() {

--- a/client/console/src/main/java/org/apache/syncope/client/console/widgets/NumberWidget.java
+++ b/client/console/src/main/java/org/apache/syncope/client/console/widgets/NumberWidget.java
@@ -18,9 +18,20 @@
  */
 package org.apache.syncope.client.console.widgets;
 
+import java.util.Collections;
+import java.util.List;
+import org.apache.syncope.client.console.commons.AnyTypeComparator;
+import org.apache.syncope.common.lib.to.AnyTypeTO;
+import org.apache.syncope.client.console.rest.AnyTypeRestClient;
 import org.apache.wicket.behavior.AttributeAppender;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
+import org.apache.wicket.ajax.AjaxEventBehavior;
+import org.apache.wicket.ajax.AjaxRequestTarget;
+import org.apache.syncope.client.console.pages.Realms;
+import org.apache.syncope.client.console.pages.Roles;
+import org.apache.syncope.client.console.topology.Topology;
+import org.apache.wicket.request.mapper.parameter.PageParameters;
 
 public class NumberWidget extends BaseWidget {
 
@@ -37,6 +48,58 @@ public class NumberWidget extends BaseWidget {
 
         WebMarkupContainer box = new WebMarkupContainer("box");
         box.add(new AttributeAppender("class", " " + bg));
+        box.add(new AjaxEventBehavior("onmousedown") {
+            @Override 
+            protected void onEvent(final AjaxRequestTarget target) {
+                List<AnyTypeTO> anyTypeTOs = new AnyTypeRestClient().list();
+                PageParameters pageParameters = new PageParameters();
+                switch (id) {
+                    case "totalUsers":
+                        pageParameters.add("selectedIndex", 1);
+                        setResponsePage(Realms.class, pageParameters);
+                        break;
+                    case "totalGroups":
+                        pageParameters.add("selectedIndex", 2);
+                        setResponsePage(Realms.class, pageParameters);
+                        break;
+                    case "totalAny1OrRoles":
+                        if (icon.equals("ion ion-gear-a")) {
+                            Collections.sort(anyTypeTOs, new AnyTypeComparator());
+                            int selectedIndex = 1;
+                            for (final AnyTypeTO anyTypeTO : anyTypeTOs) {
+                                if (anyTypeTO.getKey().equals(label)) {
+                                    pageParameters.add("selectedIndex", selectedIndex);
+                                    break;
+                                }
+                                selectedIndex++;
+                            }
+                            setResponsePage(Realms.class, pageParameters);
+                        } else {
+                            setResponsePage(Roles.class);
+                        }
+                        break;
+                    case "totalAny2OrResources":
+                        if (icon.equals("ion ion-gear-a")) {
+                            Collections.sort(anyTypeTOs, new AnyTypeComparator());
+                            int selectedIndex = 1;
+                            for (final AnyTypeTO anyTypeTO : anyTypeTOs) {
+                                if (anyTypeTO.getKey().equals(label)) {
+                                    pageParameters.add("selectedIndex", selectedIndex);
+                                    break;
+                                }
+                                selectedIndex++;
+                            }
+                            setResponsePage(Realms.class, pageParameters);
+                        } else {
+                            setResponsePage(Topology.class);
+                        }
+                        break;
+                    default:
+                        pageParameters.add("selectedIndex", 0);
+                        setResponsePage(Realms.class, pageParameters);
+                }
+            }
+        });
         add(box);
 
         numberLabel = new Label("number", number);


### PR DESCRIPTION
Added events to NumberWidget that listen to mousedown events and open up the respective pages as discussed in the [SYNCOPE-871 issue](https://issues.apache.org/jira/browse/SYNCOPE-871).