### PR TITLE
[SYNCOPE-721] adds cookieStore usage for angular translate

### DIFF
--- a/client/enduser/pom.xml
+++ b/client/enduser/pom.xml
@@ -94,6 +94,10 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.webjars.bower</groupId>
+      <artifactId>angular-translate-storage-cookie</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.webjars.bower</groupId>
       <artifactId>ng-password-strength</artifactId>    
     </dependency>
     <dependency>

--- a/client/enduser/src/main/resources/META-INF/resources/app/index.html
+++ b/client/enduser/src/main/resources/META-INF/resources/app/index.html
@@ -55,69 +55,70 @@ under the License.
 
     <span id="notifications" kendo-notification="notifications"></span>
 
-    <treasure-overlay-spinner active='spinner.active'>
-      <div ui-view ng-cloak ng-controller="ApplicationController" ng-init="initApplication()">      
-      </div>    
-    </treasure-overlay-spinner>
+  <treasure-overlay-spinner active='spinner.active'>
+    <div ui-view ng-cloak ng-controller="ApplicationController" ng-init="initApplication()">      
+    </div>    
+  </treasure-overlay-spinner>
 
-    <script src="../webjars/jquery/${jquery.version}/jquery.js"></script>
-    <script src="../webjars/angular/${angular.version}/angular.js"></script>
-    <script src="../webjars/angular-ui-router/${angular-ui-router.version}/angular-ui-router.js"></script>
-    <script src="../webjars/angular-animate/${angular.version}/angular-animate.js"></script>
-    <script src="../webjars/angular-resource/${angular.version}/angular-resource.js"></script>
-    <script src="../webjars/angular-cookies/${angular.version}/angular-cookies.js"></script>
-    <script src="../webjars/angular-sanitize/${angular.version}/angular-sanitize.js"></script>
-    <script src="../webjars/angular-ui-bootstrap/${angular-ui-bootstrap.version}/ui-bootstrap-tpls.js"></script>
-    <script src="../webjars/angular-ui-select/${angular-ui-select.version}/select.js"></script>
-    <script src="../webjars/kendo-ui-core/${kendo-ui-core.version}/js/kendo.ui.core.min.js"></script>
-    <script src="../webjars/kendo-ui-core/${kendo-ui-core.version}/js/kendo.notification.min.js"></script>
-    <script src="../webjars/kendo-ui-core/${kendo-ui-core.version}/js/kendo.angular.js"></script>
-    <script src="../webjars/angular-treasure-overlay-spinner/${angular-treasure-overlay-spinner.version}/dist/treasure-overlay-spinner.min.js"></script>
-    <script src="../webjars/ng-password-strength/${ng-password-strength.version}/dist/scripts/ng-password-strength.min.js"></script>
-    <script type="text/javascript" src="../webjars/bootstrap-select/${bootstrap-select.version}/js/bootstrap-select.min.js"></script>
-    <script src="../webjars/FileSaver.js/${fileSaver.version}/FileSaver.js"></script>
-    <script src="../webjars/lodash/${lodash.version}/lodash.min.js"></script>
-    <script src="../webjars/angular-translate/${angular-translate.version}/angular-translate.js"></script>
-    <script src="../webjars/angular-translate-loader-partial/${angular-translate.version}/angular-translate-loader-partial.js"></script>
-    <!--main angular application-->
-    <script src="js/app.js"></script>
-    <!--services-->
-    <script src="js/services/authService.js"></script>
-    <script src="js/services/userSelfService.js"></script>
-    <script src="js/services/schemaService.js"></script>
-    <script src="js/services/realmService.js"></script>
-    <script src="js/services/securityQuestionService.js"></script>
-    <script src="js/services/infoService.js"></script>
-    <script src="js/services/resourceService.js"></script>
-    <script src="js/services/groupService.js"></script>
-    <script src="js/services/anyService.js"></script>
-    <!--controllers-->
-    <script src="js/controllers/HomeController.js"></script>
-    <script src="js/controllers/LoginController.js"></script>
-    <script src="js/controllers/LanguageController.js"></script>
-    <script src="js/controllers/UserController.js"></script>
-    <!--directives-->
-    <script src="js/directives/dynamicPlainAttribute.js"></script>
-    <script src="js/directives/dynamicDerivedAttribute.js"></script>
-    <script src="js/directives/dynamicVirtualAttribute.js"></script>
-    <script src="js/directives/dynamicPlainAttributes.js"></script>
-    <script src="js/directives/dynamicDerivedAttributes.js"></script>
-    <script src="js/directives/dynamicVirtualAttributes.js"></script>
-    <script src="js/directives/navigationButtons.js"></script>
-    <script src="js/directives/loader.js"></script>
-    <script src="js/directives/captcha.js"></script>
-    <script src="js/directives/resources.js"></script>
-    <script src="js/directives/groups.js"></script>
-    <script src="js/directives/auxClasses.js"></script>
-    <script src="js/directives/validate.js"></script>
-    <script src="js/directives/validationMessage.js"></script>
-    <!--validator-->
-    <script src="js/validator/validationRules.js"></script>
-    <script src="js/validator/validationExecutor.js"></script>
-    <!--filters-->
-    <script src="js/filters/propsFilter.js"></script>
-    <!--util-->
-    <script src="js/util/userUtil.js"></script>
-    <script src="js/util/genericUtil.js"></script>
-  </body>
+  <script src="../webjars/jquery/${jquery.version}/jquery.js"></script>
+  <script src="../webjars/angular/${angular.version}/angular.js"></script>
+  <script src="../webjars/angular-ui-router/${angular-ui-router.version}/angular-ui-router.js"></script>
+  <script src="../webjars/angular-animate/${angular.version}/angular-animate.js"></script>
+  <script src="../webjars/angular-resource/${angular.version}/angular-resource.js"></script>
+  <script src="../webjars/angular-cookies/${angular.version}/angular-cookies.js"></script>
+  <script src="../webjars/angular-sanitize/${angular.version}/angular-sanitize.js"></script>
+  <script src="../webjars/angular-ui-bootstrap/${angular-ui-bootstrap.version}/ui-bootstrap-tpls.js"></script>
+  <script src="../webjars/angular-ui-select/${angular-ui-select.version}/select.js"></script>
+  <script src="../webjars/kendo-ui-core/${kendo-ui-core.version}/js/kendo.ui.core.min.js"></script>
+  <script src="../webjars/kendo-ui-core/${kendo-ui-core.version}/js/kendo.notification.min.js"></script>
+  <script src="../webjars/kendo-ui-core/${kendo-ui-core.version}/js/kendo.angular.js"></script>
+  <script src="../webjars/angular-treasure-overlay-spinner/${angular-treasure-overlay-spinner.version}/dist/treasure-overlay-spinner.min.js"></script>
+  <script src="../webjars/ng-password-strength/${ng-password-strength.version}/dist/scripts/ng-password-strength.min.js"></script>
+  <script type="text/javascript" src="../webjars/bootstrap-select/${bootstrap-select.version}/js/bootstrap-select.min.js"></script>
+  <script src="../webjars/FileSaver.js/${fileSaver.version}/FileSaver.js"></script>
+  <script src="../webjars/lodash/${lodash.version}/lodash.min.js"></script>
+  <script src="../webjars/angular-translate/${angular-translate.version}/angular-translate.js"></script>
+  <script src="../webjars/angular-translate-loader-partial/${angular-translate.version}/angular-translate-loader-partial.js"></script>
+  <script src="../webjars/angular-translate-storage-cookie/${angular-translate.version}/angular-translate-storage-cookie.js"></script>
+  <!--main angular application-->
+  <script src="js/app.js"></script>
+  <!--services-->
+  <script src="js/services/authService.js"></script>
+  <script src="js/services/userSelfService.js"></script>
+  <script src="js/services/schemaService.js"></script>
+  <script src="js/services/realmService.js"></script>
+  <script src="js/services/securityQuestionService.js"></script>
+  <script src="js/services/infoService.js"></script>
+  <script src="js/services/resourceService.js"></script>
+  <script src="js/services/groupService.js"></script>
+  <script src="js/services/anyService.js"></script>
+  <!--controllers-->
+  <script src="js/controllers/HomeController.js"></script>
+  <script src="js/controllers/LoginController.js"></script>
+  <script src="js/controllers/LanguageController.js"></script>
+  <script src="js/controllers/UserController.js"></script>
+  <!--directives-->
+  <script src="js/directives/dynamicPlainAttribute.js"></script>
+  <script src="js/directives/dynamicDerivedAttribute.js"></script>
+  <script src="js/directives/dynamicVirtualAttribute.js"></script>
+  <script src="js/directives/dynamicPlainAttributes.js"></script>
+  <script src="js/directives/dynamicDerivedAttributes.js"></script>
+  <script src="js/directives/dynamicVirtualAttributes.js"></script>
+  <script src="js/directives/navigationButtons.js"></script>
+  <script src="js/directives/loader.js"></script>
+  <script src="js/directives/captcha.js"></script>
+  <script src="js/directives/resources.js"></script>
+  <script src="js/directives/groups.js"></script>
+  <script src="js/directives/auxClasses.js"></script>
+  <script src="js/directives/validate.js"></script>
+  <script src="js/directives/validationMessage.js"></script>
+  <!--validator-->
+  <script src="js/validator/validationRules.js"></script>
+  <script src="js/validator/validationExecutor.js"></script>
+  <!--filters-->
+  <script src="js/filters/propsFilter.js"></script>
+  <!--util-->
+  <script src="js/util/userUtil.js"></script>
+  <script src="js/util/genericUtil.js"></script>
+</body>
 </html>

--- a/client/enduser/src/main/resources/META-INF/resources/app/js/app.js
+++ b/client/enduser/src/main/resources/META-INF/resources/app/js/app.js
@@ -41,6 +41,7 @@ var app = angular.module('SyncopeEnduserApp', [
   'language',
   'self',
   'info',
+  'ngCookies',
   'pascalprecht.translate'
 ]);
 
@@ -52,7 +53,8 @@ app.config(['$stateProvider', '$urlRouterProvider', '$httpProvider', '$translate
     $translateProvider.useLoader('$translatePartialLoader', {
       urlTemplate: 'languages/{lang}/{part}.json'
     })
-            .preferredLanguage('en');
+            .preferredLanguage('en')
+            .useCookieStorage();
 
     // route configuration
     $stateProvider

--- a/pom.xml
+++ b/pom.xml
@@ -1189,6 +1189,11 @@ under the License.
       </dependency>      
       <dependency>
         <groupId>org.webjars.bower</groupId>
+        <artifactId>angular-translate-storage-cookie</artifactId>
+        <version>${angular-translate.version}</version>
+      </dependency>      
+      <dependency>
+        <groupId>org.webjars.bower</groupId>
         <artifactId>ng-password-strength</artifactId>
         <version>${ng-password-strength.version}</version>
         <exclusions>


### PR DESCRIPTION
angular-translate-storage-cookie is used when telling angular-translate to use cookieStore as storage.