### PR TITLE
Fixing HTMLEditor Resource Bundle location SYNCOPE-809

### DIFF
--- a/ide/eclipse/bundles/org.apache.syncope.ide.eclipse.plugin/build.properties
+++ b/ide/eclipse/bundles/org.apache.syncope.ide.eclipse.plugin/build.properties
@@ -16,7 +16,8 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-source.. = src/main/java/
+source.. = src/main/java/,\
+src/main/resources
 output.. = bin/
 bin.includes = plugin.xml,\
       META-INF/,\

--- a/ide/eclipse/bundles/org.apache.syncope.ide.eclipse.plugin/src/main/java/org/apache/syncope/ide/eclipse/plugin/editors/HTMLEditor.java
+++ b/ide/eclipse/bundles/org.apache.syncope.ide.eclipse.plugin/src/main/java/org/apache/syncope/ide/eclipse/plugin/editors/HTMLEditor.java
@@ -32,7 +32,7 @@ import org.eclipse.ui.texteditor.TextEditorAction;
 
 public class HTMLEditor extends TextEditor {
     
-    private static final String RESOURCE_BUNDLE = "/src/main/resources/HTMLEditor";
+    private static final String RESOURCE_BUNDLE = "HTMLEditor";
             
     public HTMLEditor() {
         super();


### PR DESCRIPTION
This also fixes the testing problem with the HTMLEditor as stated in #34 .
However, the StructuredTextEditor still malfunctions during the swtbot tests.