### PR TITLE
Startup performance tweaks : restrict startup scanning to syncope packages

### DIFF
--- a/client/console/src/main/java/org/apache/syncope/client/console/init/ClassPathScanImplementationLookup.java
+++ b/client/console/src/main/java/org/apache/syncope/client/console/init/ClassPathScanImplementationLookup.java
@@ -20,12 +20,14 @@ package org.apache.syncope.client.console.init;
 
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import org.apache.commons.collections4.ComparatorUtils;
 import org.apache.commons.lang3.ArrayUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.syncope.client.console.pages.BaseExtPage;
 import org.apache.syncope.client.console.annotations.BinaryPreview;
 import org.apache.syncope.client.console.annotations.ExtPage;
@@ -51,6 +53,8 @@ public class ClassPathScanImplementationLookup {
     private List<Class<? extends BaseExtPage>> extPages;
 
     private List<Class<? extends BaseExtWidget>> extWidgets;
+    
+    private List<String> basePackages = Arrays.asList("org.apache.syncope.client.console");
 
     @SuppressWarnings("unchecked")
     public void load() {
@@ -65,7 +69,11 @@ public class ClassPathScanImplementationLookup {
         scanner.addIncludeFilter(new AssignableTypeFilter(BaseExtPage.class));
         scanner.addIncludeFilter(new AssignableTypeFilter(BaseExtWidget.class));
 
-        for (BeanDefinition bd : scanner.findCandidateComponents(StringUtils.EMPTY)) {
+        Set<BeanDefinition> beanDefinitions = new HashSet<>();
+        for (String basePackage: getBasePackages()) {
+            beanDefinitions.addAll(scanner.findCandidateComponents(basePackage));
+        }
+        for (BeanDefinition bd : beanDefinitions) {
             try {
                 Class<?> clazz = ClassUtils.resolveClassName(
                         bd.getBeanClassName(), ClassUtils.getDefaultClassLoader());
@@ -161,5 +169,15 @@ public class ClassPathScanImplementationLookup {
     public List<Class<? extends BaseExtWidget>> getExtWidgetClasses() {
         return extWidgets;
     }
+    
+    /**
+     * @return basePackages for syncope class classpath scanning
+     */
+    protected List<String> getBasePackages() {
+        return basePackages;
+    }
 
+    public void setBasePackages(final List<String> basePackages) {
+        this.basePackages = basePackages;
+    }
 }

--- a/client/console/src/main/java/org/apache/syncope/client/console/init/ClassPathScanImplementationLookup.java
+++ b/client/console/src/main/java/org/apache/syncope/client/console/init/ClassPathScanImplementationLookup.java
@@ -20,12 +20,9 @@ package org.apache.syncope.client.console.init;
 
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import org.apache.commons.collections4.ComparatorUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.syncope.client.console.pages.BaseExtPage;
@@ -54,7 +51,7 @@ public class ClassPathScanImplementationLookup {
 
     private List<Class<? extends BaseExtWidget>> extWidgets;
     
-    private List<String> basePackages = Arrays.asList("org.apache.syncope.client.console");
+    private final String basePackage = "org.apache.syncope.client.console";
 
     @SuppressWarnings("unchecked")
     public void load() {
@@ -69,11 +66,7 @@ public class ClassPathScanImplementationLookup {
         scanner.addIncludeFilter(new AssignableTypeFilter(BaseExtPage.class));
         scanner.addIncludeFilter(new AssignableTypeFilter(BaseExtWidget.class));
 
-        Set<BeanDefinition> beanDefinitions = new HashSet<>();
-        for (String basePackage: getBasePackages()) {
-            beanDefinitions.addAll(scanner.findCandidateComponents(basePackage));
-        }
-        for (BeanDefinition bd : beanDefinitions) {
+        for (BeanDefinition bd : scanner.findCandidateComponents(basePackage)) {
             try {
                 Class<?> clazz = ClassUtils.resolveClassName(
                         bd.getBeanClassName(), ClassUtils.getDefaultClassLoader());
@@ -171,13 +164,11 @@ public class ClassPathScanImplementationLookup {
     }
     
     /**
-     * @return basePackages for syncope class classpath scanning
+     * This method can be overridden by subclasses to customize classpath scan.
+     *
+     * @return basePackage for syncope class classpath scanning
      */
-    protected List<String> getBasePackages() {
-        return basePackages;
-    }
-
-    public void setBasePackages(final List<String> basePackages) {
-        this.basePackages = basePackages;
+    protected String getBasePackage() {
+        return basePackage;
     }
 }

--- a/core/logic/src/main/java/org/apache/syncope/core/logic/init/ClassPathScanImplementationLookup.java
+++ b/core/logic/src/main/java/org/apache/syncope/core/logic/init/ClassPathScanImplementationLookup.java
@@ -19,12 +19,10 @@
 package org.apache.syncope.core.logic.init;
 
 import java.lang.reflect.Modifier;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.syncope.common.lib.policy.AccountRuleConf;
@@ -76,7 +74,7 @@ public class ClassPathScanImplementationLookup implements ImplementationLookup {
 
     private Map<Class<? extends PasswordRuleConf>, Class<? extends PasswordRule>> passwordRuleClasses;
     
-    private List<String> basePackages = Arrays.asList("org.apache.syncope.fit.core", "org.apache.syncope.core");
+    private final String basePackage = "org.apache.syncope.core";
 
     @Override
     public Integer getPriority() {
@@ -110,11 +108,7 @@ public class ClassPathScanImplementationLookup implements ImplementationLookup {
         scanner.addIncludeFilter(new AssignableTypeFilter(Validator.class));
         scanner.addIncludeFilter(new AssignableTypeFilter(NotificationRecipientsProvider.class));
 
-        Set<BeanDefinition> beanDefinitions = new HashSet<>();
-        for (String basePackage: getBasePackages()) {
-            beanDefinitions.addAll(scanner.findCandidateComponents(basePackage));
-        }
-        for (BeanDefinition bd : beanDefinitions) {
+        for (BeanDefinition bd : scanner.findCandidateComponents(basePackage)) {
             try {
                 Class<?> clazz = ClassUtils.resolveClassName(
                         bd.getBeanClassName(), ClassUtils.getDefaultClassLoader());
@@ -233,15 +227,13 @@ public class ClassPathScanImplementationLookup implements ImplementationLookup {
 
         return passwordRuleClasses.get(passwordRuleConfClass);
     }
-    
-    /**
-     * @return basePackages for syncope class classpath scanning
-     */
-    protected List<String> getBasePackages() {
-        return basePackages;
-    }
 
-    public void setBasePackages(final List<String> basePackages) {
-        this.basePackages = basePackages;
+    /**
+     * This method can be overridden by subclasses to customize classpath scan.
+     *
+     * @return basePackage for syncope class classpath scanning
+     */
+    protected String getBasePackage() {
+        return basePackage;
     }
 }

--- a/core/logic/src/main/java/org/apache/syncope/core/logic/init/ClassPathScanImplementationLookup.java
+++ b/core/logic/src/main/java/org/apache/syncope/core/logic/init/ClassPathScanImplementationLookup.java
@@ -19,13 +19,14 @@
 package org.apache.syncope.core.logic.init;
 
 import java.lang.reflect.Modifier;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.syncope.common.lib.policy.AccountRuleConf;
 import org.apache.syncope.common.lib.policy.PasswordRuleConf;
 import org.apache.syncope.common.lib.report.ReportletConf;
@@ -74,6 +75,8 @@ public class ClassPathScanImplementationLookup implements ImplementationLookup {
     private Map<Class<? extends AccountRuleConf>, Class<? extends AccountRule>> accountRuleClasses;
 
     private Map<Class<? extends PasswordRuleConf>, Class<? extends PasswordRule>> passwordRuleClasses;
+    
+    private List<String> basePackages = Arrays.asList("org.apache.syncope.fit.core", "org.apache.syncope.core");
 
     @Override
     public Integer getPriority() {
@@ -107,7 +110,11 @@ public class ClassPathScanImplementationLookup implements ImplementationLookup {
         scanner.addIncludeFilter(new AssignableTypeFilter(Validator.class));
         scanner.addIncludeFilter(new AssignableTypeFilter(NotificationRecipientsProvider.class));
 
-        for (BeanDefinition bd : scanner.findCandidateComponents(StringUtils.EMPTY)) {
+        Set<BeanDefinition> beanDefinitions = new HashSet<>();
+        for (String basePackage: getBasePackages()) {
+            beanDefinitions.addAll(scanner.findCandidateComponents(basePackage));
+        }
+        for (BeanDefinition bd : beanDefinitions) {
             try {
                 Class<?> clazz = ClassUtils.resolveClassName(
                         bd.getBeanClassName(), ClassUtils.getDefaultClassLoader());
@@ -226,5 +233,15 @@ public class ClassPathScanImplementationLookup implements ImplementationLookup {
 
         return passwordRuleClasses.get(passwordRuleConfClass);
     }
+    
+    /**
+     * @return basePackages for syncope class classpath scanning
+     */
+    protected List<String> getBasePackages() {
+        return basePackages;
+    }
 
+    public void setBasePackages(final List<String> basePackages) {
+        this.basePackages = basePackages;
+    }
 }


### PR DESCRIPTION
Without this PR, standalone tomcat startup takes 135s (by default, syncope scans all packages).
With this PR, it takes 32s.

Startup scanning is restricted to packages : 
 * org.apache.syncope.client.console
 * org.apache.syncope.fit.core
 * org.apache.syncope.core