### PR TITLE
SYNCOPE-971: Case insensitive search

### DIFF
--- a/client/console/src/main/java/org/apache/syncope/client/console/panels/search/SearchUtils.java
+++ b/client/console/src/main/java/org/apache/syncope/client/console/panels/search/SearchUtils.java
@@ -35,6 +35,7 @@ import org.apache.syncope.common.lib.search.AbstractFiqlSearchConditionBuilder;
 import org.apache.syncope.common.lib.search.AnyObjectFiqlSearchConditionBuilder;
 import org.apache.syncope.common.lib.search.GroupFiqlSearchConditionBuilder;
 import org.apache.syncope.common.lib.search.SpecialAttr;
+import org.apache.syncope.common.lib.search.SyncopeFiqlParser;
 import org.apache.syncope.common.lib.search.SyncopeProperty;
 import org.apache.syncope.common.lib.search.UserFiqlSearchConditionBuilder;
 import org.slf4j.Logger;
@@ -65,7 +66,7 @@ public final class SearchUtils implements Serializable {
         final List<SearchClause> res = new ArrayList<>();
         if (StringUtils.isNotBlank(fiql)) {
             try {
-                FiqlParser<SearchBean> fiqlParser = new FiqlParser<>(
+                FiqlParser<SearchBean> fiqlParser = new SyncopeFiqlParser<>(
                         SearchBean.class, AbstractFiqlSearchConditionBuilder.CONTEXTUAL_PROPERTIES);
                 res.addAll(getSearchClauses(fiqlParser.parse(fiql)));
             } catch (Exception e) {

--- a/common/lib/src/main/java/org/apache/syncope/common/lib/search/AbstractFiqlSearchConditionBuilder.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/search/AbstractFiqlSearchConditionBuilder.java
@@ -109,5 +109,15 @@ public abstract class AbstractFiqlSearchConditionBuilder extends FiqlSearchCondi
             this.result = SpecialAttr.RESOURCES.toString();
             return condition(FiqlParser.NEQ, resource, (Object[]) moreResources);
         }
+
+        @Override
+        public CompleteCondition equalIgnoreCaseTo(final String value, final String... moreValues) {
+            return condition(SyncopeFiqlParser.IEQ, value, (Object[]) moreValues);
+        }
+
+        @Override
+        public CompleteCondition notEqualIgnoreCaseTo(final String literalOrPattern) {
+            return condition(SyncopeFiqlParser.NIEQ, literalOrPattern);
+        }
     }
 }

--- a/common/lib/src/main/java/org/apache/syncope/common/lib/search/SyncopeFiqlParser.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/search/SyncopeFiqlParser.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.syncope.common.lib.search;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.cxf.jaxrs.ext.search.ConditionType;
+import org.apache.cxf.jaxrs.ext.search.SearchBean;
+import org.apache.cxf.jaxrs.ext.search.SearchCondition;
+import org.apache.cxf.jaxrs.ext.search.SearchParseException;
+import org.apache.cxf.jaxrs.ext.search.fiql.FiqlParser;
+
+
+/**
+ * This parser introduces 2 new operands {@link #IEQ} (equalsIgnoreCase)
+ * and {@link #NIEQ} not equalsIgnoreCase to the native FIQL operands.
+ *
+ * @param <T>
+ */
+public class SyncopeFiqlParser<T> extends FiqlParser<T> {
+
+    public static final String IEQ = "=~";
+
+    public static final String NIEQ = "!~";
+
+    public SyncopeFiqlParser(
+            final Class<T> tclass,
+            final Map<String, String> contextProperties) {
+
+        this(tclass, contextProperties, null);
+    }
+
+    public SyncopeFiqlParser(
+            final Class<T> tclass,
+            final Map<String, String> contextProperties,
+            final Map<String, String> beanProperties) {
+
+        super(tclass, contextProperties, beanProperties);
+
+        operatorsMap.put(IEQ, ConditionType.CUSTOM);
+        operatorsMap.put(NIEQ, ConditionType.CUSTOM);
+
+        CONDITION_MAP.put(ConditionType.CUSTOM, IEQ);
+        CONDITION_MAP.put(ConditionType.CUSTOM, NIEQ);
+
+        String comparators = GT + "|" + GE + "|" + LT + "|" + LE + "|" + EQ + "|" + NEQ + "|" + IEQ + "|" + NIEQ;
+        String s1 = "[\\p{ASCII}]+(" + comparators + ")";
+        comparatorsPattern = Pattern.compile(s1);
+    }
+
+    @Override
+    protected ASTNode<T> parseComparison(final String expr) throws SearchParseException {
+        Matcher m = comparatorsPattern.matcher(expr);
+        if (m.find()) {
+            String propertyName = expr.substring(0, m.start(1));
+            String operator = m.group(1);
+            String value = expr.substring(m.end(1));
+            if ("".equals(value)) {
+                throw new SearchParseException("Not a comparison expression: " + expr);
+            }
+
+            String name = unwrapSetter(propertyName);
+
+            name = getActualSetterName(name);
+            TypeInfoObject castedValue = parseType(propertyName, name, value);
+            if (castedValue != null) {
+                return new SyncopeComparison(name, operator, castedValue);
+            } else {
+                return null;
+            }
+        } else {
+            throw new SearchParseException("Not a comparison expression: " + expr);
+        }
+    }
+
+    private class SyncopeComparison implements ASTNode<T> {
+
+        private final String name;
+
+        private final String operator;
+
+        private final TypeInfoObject tvalue;
+
+        SyncopeComparison(final String name, final String operator, final TypeInfoObject value) {
+            this.name = name;
+            this.operator = operator;
+            this.tvalue = value;
+        }
+
+        @Override
+        public String toString() {
+            return name + " " + operator + " " + tvalue.getObject()
+                    + " (" + tvalue.getObject().getClass().getSimpleName() + ")";
+        }
+
+        @Override
+        public SearchCondition<T> build() throws SearchParseException {
+            String templateName = getSetter(name);
+            T cond = createTemplate(templateName);
+            ConditionType ct = operatorsMap.get(operator);
+            if (isPrimitive(cond)) {
+                return new SyncopeFiqlSearchCondition<>(ct, cond);
+            } else {
+                String templateNameLCase = templateName.toLowerCase();
+                return new SyncopeFiqlSearchCondition<>(Collections.singletonMap(templateNameLCase, ct),
+                        Collections.singletonMap(templateNameLCase, name),
+                        Collections.singletonMap(templateNameLCase, tvalue.getTypeInfo()),
+                        cond, operator);
+            }
+        }
+
+        private boolean isPrimitive(final T pojo) {
+            return pojo.getClass().getName().startsWith("java.lang");
+        }
+
+        @SuppressWarnings("unchecked")
+        private T createTemplate(final String setter) throws SearchParseException {
+            try {
+                if (beanspector != null) {
+                    beanspector.instantiate().setValue(setter, tvalue.getObject());
+                    return beanspector.getBean();
+                } else {
+                    SearchBean bean = (SearchBean) conditionClass.newInstance();
+                    bean.set(setter, tvalue.getObject().toString());
+                    return (T) bean;
+                }
+            } catch (Throwable e) {
+                throw new SearchParseException(e);
+            }
+        }
+    }
+
+}

--- a/common/lib/src/main/java/org/apache/syncope/common/lib/search/SyncopeFiqlSearchCondition.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/search/SyncopeFiqlSearchCondition.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.syncope.common.lib.search;
+
+import java.util.Map;
+
+import org.apache.cxf.jaxrs.ext.search.Beanspector;
+import org.apache.cxf.jaxrs.ext.search.ConditionType;
+import org.apache.cxf.jaxrs.ext.search.SimpleSearchCondition;
+
+public class SyncopeFiqlSearchCondition<T> extends SimpleSearchCondition<T> {
+
+    static {
+        SUPPORTED_TYPES.add(ConditionType.CUSTOM);
+    }
+
+    private String operator;
+
+    public SyncopeFiqlSearchCondition(final ConditionType cType, final T condition) {
+        super(cType, condition);
+    }
+
+    public SyncopeFiqlSearchCondition(
+            final Map<String, ConditionType> getters2operators,
+            final Map<String, String> realGetters,
+            final Map<String, Beanspector.TypeInfo> propertyTypeInfo,
+            final T condition,
+            final String operator) {
+
+        super(getters2operators, realGetters, propertyTypeInfo, condition);
+        this.operator = operator;
+    }
+
+    public String getOperator() {
+        return operator;
+    }
+
+}

--- a/common/lib/src/main/java/org/apache/syncope/common/lib/search/SyncopeProperty.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/search/SyncopeProperty.java
@@ -35,4 +35,10 @@ public interface SyncopeProperty extends Property {
 
     CompleteCondition hasNotResources(String resource, String... moreResources);
 
+    /** Is textual property equal (ignoring case) to given literal or matching given pattern ? */
+    CompleteCondition equalIgnoreCaseTo(String value, String ...moreValues);
+
+    /** Is textual property different (ignoring case) than given literal or not matching given pattern? */
+    CompleteCondition notEqualIgnoreCaseTo(String literalOrPattern);
+
 }

--- a/common/lib/src/test/java/org/apache/syncope/common/lib/search/SyncopeFiqlParserTest.java
+++ b/common/lib/src/test/java/org/apache/syncope/common/lib/search/SyncopeFiqlParserTest.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.syncope.common.lib.search;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.cxf.jaxrs.ext.search.ConditionType;
+import org.apache.cxf.jaxrs.ext.search.SearchBean;
+import org.apache.cxf.jaxrs.ext.search.SearchCondition;
+import org.apache.cxf.jaxrs.ext.search.fiql.FiqlParser;
+import org.junit.Test;
+
+public class SyncopeFiqlParserTest {
+
+    private SyncopeFiqlParser fiqlParser = new SyncopeFiqlParser<>(SearchBean.class,
+            AbstractFiqlSearchConditionBuilder.CONTEXTUAL_PROPERTIES, null);
+
+    @Test
+    public void testEqualsIgnoreCase() {
+        SyncopeFiqlSearchCondition<SearchBean> cond = parse("name=~ami*");
+        assertEquals(SyncopeFiqlParser.IEQ, cond.getOperator());
+        assertEquals(ConditionType.CUSTOM, cond.getConditionType());
+        assertEquals("ami*", cond.getCondition().get("name"));
+    }
+
+    @Test
+    public void testNotEqualsIgnoreCase() {
+        SyncopeFiqlSearchCondition<SearchBean> cond = parse("name!~ami*");
+        assertEquals(SyncopeFiqlParser.NIEQ, cond.getOperator());
+        assertEquals(ConditionType.CUSTOM, cond.getConditionType());
+        assertEquals("ami*", cond.getCondition().get("name"));
+    }
+
+    /**
+     * Simple test for ensuring there's no regression.
+     */
+    @Test
+    public void testEquals() {
+        SyncopeFiqlSearchCondition<SearchBean> cond = parse("name==ami*");
+        assertEquals(FiqlParser.EQ, cond.getOperator());
+        assertEquals(ConditionType.EQUALS, cond.getConditionType());
+        assertEquals("ami*", cond.getCondition().get("name"));
+    }
+
+    private SyncopeFiqlSearchCondition<SearchBean> parse(final String fiql) {
+        SearchCondition<SearchBean> parsed = fiqlParser.parse(fiql);
+        assertTrue(parsed instanceof SyncopeFiqlSearchCondition);
+        return (SyncopeFiqlSearchCondition) parsed;
+    }
+
+}

--- a/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/dao/search/AttributeCond.java
+++ b/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/dao/search/AttributeCond.java
@@ -28,7 +28,9 @@ public class AttributeCond extends AbstractSearchCond {
     public enum Type {
 
         LIKE,
+        ILIKE,
         EQ,
+        IEQ,
         GT,
         LT,
         GE,

--- a/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/search/SearchCondConverter.java
+++ b/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/search/SearchCondConverter.java
@@ -23,6 +23,7 @@ import org.apache.cxf.jaxrs.ext.search.SearchBean;
 import org.apache.cxf.jaxrs.ext.search.fiql.FiqlParser;
 import org.apache.syncope.common.lib.SyncopeClientException;
 import org.apache.syncope.common.lib.search.AbstractFiqlSearchConditionBuilder;
+import org.apache.syncope.common.lib.search.SyncopeFiqlParser;
 import org.apache.syncope.common.lib.types.ClientExceptionType;
 import org.apache.syncope.core.persistence.api.dao.search.SearchCond;
 
@@ -40,7 +41,7 @@ public final class SearchCondConverter {
      * @see FiqlParser
      */
     public static SearchCond convert(final String fiqlExpression, final String... realms) {
-        FiqlParser<SearchBean> fiqlParser = new FiqlParser<>(
+        FiqlParser<SearchBean> fiqlParser = new SyncopeFiqlParser<SearchBean>(
                 SearchBean.class, AbstractFiqlSearchConditionBuilder.CONTEXTUAL_PROPERTIES);
 
         try {

--- a/core/persistence-api/src/test/java/org/apache/syncope/core/persistence/api/search/SearchCondConverterTest.java
+++ b/core/persistence-api/src/test/java/org/apache/syncope/core/persistence/api/search/SearchCondConverterTest.java
@@ -53,11 +53,63 @@ public class SearchCondConverterTest {
     }
 
     @Test
+    public void ieq() {
+        String fiqlExpression = new UserFiqlSearchConditionBuilder().is("username").equalIgnoreCaseTo("rossini").query();
+        assertEquals("username=~rossini", fiqlExpression);
+
+        AnyCond attrCond = new AnyCond(AttributeCond.Type.IEQ);
+        attrCond.setSchema("username");
+        attrCond.setExpression("rossini");
+        SearchCond simpleCond = SearchCond.getLeafCond(attrCond);
+
+        assertEquals(simpleCond, SearchCondConverter.convert(fiqlExpression));
+    }
+
+    @Test
+    public void nieq() {
+        String fiqlExpression = new UserFiqlSearchConditionBuilder().is("username").notEqualIgnoreCaseTo("rossini").query();
+        assertEquals("username!~rossini", fiqlExpression);
+
+        AnyCond attrCond = new AnyCond(AttributeCond.Type.IEQ);
+        attrCond.setSchema("username");
+        attrCond.setExpression("rossini");
+        SearchCond simpleCond = SearchCond.getLeafCond(attrCond);
+
+        assertEquals(simpleCond, SearchCondConverter.convert(fiqlExpression));
+    }
+
+    @Test
     public void like() {
         String fiqlExpression = new UserFiqlSearchConditionBuilder().is("username").equalTo("ros*").query();
         assertEquals("username==ros*", fiqlExpression);
 
         AttributeCond attrCond = new AnyCond(AttributeCond.Type.LIKE);
+        attrCond.setSchema("username");
+        attrCond.setExpression("ros%");
+        SearchCond simpleCond = SearchCond.getLeafCond(attrCond);
+
+        assertEquals(simpleCond, SearchCondConverter.convert(fiqlExpression));
+    }
+
+    @Test
+    public void ilike() {
+        String fiqlExpression = new UserFiqlSearchConditionBuilder().is("username").equalIgnoreCaseTo("ros*").query();
+        assertEquals("username=~ros*", fiqlExpression);
+
+        AttributeCond attrCond = new AnyCond(AttributeCond.Type.ILIKE);
+        attrCond.setSchema("username");
+        attrCond.setExpression("ros%");
+        SearchCond simpleCond = SearchCond.getLeafCond(attrCond);
+
+        assertEquals(simpleCond, SearchCondConverter.convert(fiqlExpression));
+    }
+
+    @Test
+    public void nilike() {
+        String fiqlExpression = new UserFiqlSearchConditionBuilder().is("username").notEqualIgnoreCaseTo("ros*").query();
+        assertEquals("username!~ros*", fiqlExpression);
+
+        AttributeCond attrCond = new AnyCond(AttributeCond.Type.ILIKE);
         attrCond.setSchema("username");
         attrCond.setExpression("ros%");
         SearchCond simpleCond = SearchCond.getLeafCond(attrCond);

--- a/core/persistence-jpa/src/test/resources/domains/MasterContent.xml
+++ b/core/persistence-jpa/src/test/resources/domains/MasterContent.xml
@@ -124,7 +124,7 @@ under the License.
               owner_id="cd64d66f-6fff-4008-b966-a06b1cc1436d" schema_id="return.password.value"/>
   <CPlainAttrValue id="e5fa94db-b524-4309-908d-8198d0b3f779"
                    attribute_id="bcfd7efc-0605-4b5e-b4bb-85c1d5f6493a" booleanValue="0"/>
-  
+
   <!-- Identity Recertification interval in days -->                   
   <SyncopeSchema id="identity.recertification.day.interval"/>
   <PlainSchema id="identity.recertification.day.interval" type="Long"

--- a/core/persistence-jpa/src/test/resources/domains/TwoContent.xml
+++ b/core/persistence-jpa/src/test/resources/domains/TwoContent.xml
@@ -104,7 +104,7 @@ under the License.
               owner_id="cd64d66f-6fff-4008-b966-a06b1cc1436d" schema_id="return.password.value"/>
   <CPlainAttrValue id="e5fa94db-b524-4309-908d-8198d0b3f779"
                    attribute_id="bcfd7efc-0605-4b5e-b4bb-85c1d5f6493a" booleanValue="0"/>
-  
+
   <AnyType id="USER" kind="USER"/>
   <AnyTypeClass id="BaseUser"/>
   <AnyType_AnyTypeClass anyType_id="USER" anyTypeClass_id="BaseUser"/>

--- a/core/rest-cxf/src/main/resources/restCXFContext.xml
+++ b/core/rest-cxf/src/main/resources/restCXFContext.xml
@@ -120,8 +120,9 @@ under the License.
   <jaxrs:server id="restContainer" address="/"
                 basePackages="org.apache.syncope.common.rest.api.service, org.apache.syncope.core.rest.cxf.service" 
                 staticSubresourceResolution="true">
-    <jaxrs:properties> 
-      <entry key="search.lax.property.match" value="true"/> 
+    <jaxrs:properties>
+      <entry key="search.parser.class" value="org.apache.syncope.common.lib.search.SyncopeFiqlParser"/>
+      <entry key="search.lax.property.match" value="true"/>
       <entry key="convert.wadl.resources.to.dom" value="false"/>
     </jaxrs:properties> 
     <jaxrs:inInterceptors>

--- a/fit/core-reference/src/main/resources/jboss/restCXFContext.xml
+++ b/fit/core-reference/src/main/resources/jboss/restCXFContext.xml
@@ -132,8 +132,9 @@ under the License.
   <jaxrs:server id="restContainer" address="/"
                 basePackages="org.apache.syncope.common.rest.api.service, org.apache.syncope.core.rest.cxf.service" 
                 staticSubresourceResolution="true">
-    <jaxrs:properties> 
-      <entry key="search.lax.property.match" value="true"/> 
+    <jaxrs:properties>
+      <entry key="search.parser.class" value="org.apache.syncope.common.lib.search.SyncopeFiqlParser"/>
+      <entry key="search.lax.property.match" value="true"/>
       <entry key="convert.wadl.resources.to.dom" value="false"/>
     </jaxrs:properties> 
     <jaxrs:inInterceptors>

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/SearchITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/SearchITCase.java
@@ -86,6 +86,44 @@ public class SearchITCase extends AbstractITCase {
     }
 
     @Test
+    public void searchEqualsIgnoreCaseWithApi() {
+        PagedResult<UserTO> matchingUsers = userService.search(
+                new AnyQuery.Builder().realm(SyncopeConstants.ROOT_REALM).
+                        fiql(SyncopeClient.getUserSearchConditionBuilder().
+                                is("username").equalIgnoreCaseTo("RoSsINI").and("key").lessThan(2).query()).build());
+        assertNotNull(matchingUsers);
+        assertEquals(1, matchingUsers.getResult().size());
+        assertEquals("rossini", matchingUsers.getResult().iterator().next().getUsername());
+        assertEquals("1417acbe-cbf6-4277-9372-e75e04f97000", matchingUsers.getResult().iterator().next().getKey());
+    }
+
+    @Test
+    public void searchEqualsIgnoreCase() {
+        PagedResult<UserTO> matchingUsers = userService.search(
+                new AnyQuery.Builder().realm(SyncopeConstants.ROOT_REALM).
+                        fiql("(username=~RoSsINI)").page(1).size(2).build());
+        assertNotNull(matchingUsers);
+        assertEquals(1, matchingUsers.getResult().size());
+        assertFalse(matchingUsers.getResult().isEmpty());
+        for (UserTO user : matchingUsers.getResult()) {
+            assertNotNull(user);
+        }
+    }
+
+    @Test
+    public void searchLikeIgnoreCase() {
+        PagedResult<UserTO> matchingUsers = userService.search(
+                new AnyQuery.Builder().realm(SyncopeConstants.ROOT_REALM).
+                        fiql("(fullname=~*oSsINi)").page(1).size(2).build());
+        assertNotNull(matchingUsers);
+        assertEquals(1, matchingUsers.getResult().size());
+        assertFalse(matchingUsers.getResult().isEmpty());
+        for (UserTO user : matchingUsers.getResult()) {
+            assertNotNull(user);
+        }
+    }
+
+    @Test
     public void searchByGroupNameAndKey() {
         PagedResult<GroupTO> groups = groupService.search(new AnyQuery.Builder().realm(SyncopeConstants.ROOT_REALM).
                 fiql(SyncopeClient.getGroupSearchConditionBuilder().
@@ -443,12 +481,13 @@ public class SearchITCase extends AbstractITCase {
                 getTotalCount();
         assertEquals(nonOrdered, orderedByNullable);
     }
-    
+
     @Test
     public void issueSYNCOPE929() {
-        PagedResult<UserTO> matchingUsers = userService.search(new AnyQuery.Builder().realm(SyncopeConstants.ROOT_REALM).
+        PagedResult<UserTO> matchingUsers = userService.search(
+                new AnyQuery.Builder().realm(SyncopeConstants.ROOT_REALM).
                 fiql("(surname==Rossini,gender==M);surname==Bellini").build());
-        
+
         assertNotNull(matchingUsers);
 
         assertFalse(matchingUsers.getResult().isEmpty());


### PR DESCRIPTION
Global setting for activating global insensitive
search.

Insensitive search is activated when search.ignore.case
property is configured to true (default value: false).