### PR TITLE
SYNCOPE-975: Search case insensitive ilike operator triggers search validation

### DIFF
--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/JPAAnySearchDAO.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/JPAAnySearchDAO.java
@@ -864,8 +864,8 @@ public class JPAAnySearchDAO extends AbstractDAO<Any<?>> implements AnySearchDAO
 
         PlainAttrValue attrValue = attrUtils.newPlainAttrValue();
         try {
-            if (cond.getType() != AttributeCond.Type.LIKE && cond.getType() != AttributeCond.Type.ISNULL
-                    && cond.getType() != AttributeCond.Type.ISNOTNULL) {
+            if (cond.getType() != AttributeCond.Type.LIKE && cond.getType() != AttributeCond.Type.ILIKE
+                    && cond.getType() != AttributeCond.Type.ISNULL && cond.getType() != AttributeCond.Type.ISNOTNULL) {
 
                 schema.getValidator().validate(cond.getExpression(), attrValue);
             }
@@ -960,6 +960,7 @@ public class JPAAnySearchDAO extends AbstractDAO<Any<?>> implements AnySearchDAO
 
         PlainAttrValue attrValue = attrUtils.newPlainAttrValue();
         if (condClone.getType() != AttributeCond.Type.LIKE
+                && condClone.getType() != AttributeCond.Type.ILIKE
                 && condClone.getType() != AttributeCond.Type.ISNULL
                 && condClone.getType() != AttributeCond.Type.ISNOTNULL) {
 


### PR DESCRIPTION
Using ilike in a search triggers search field
validation. It shouldn't be triggered.
This results in Syncope returning 0 records.

For instance: username=~*test*;(emails=~*test.com*)
tries to validate email *test.com*, which isn't
a valid email
