### PR TITLE
Missing line-continuation symbol

### DIFF
--- a/src/main/asciidoc/getting-started/obtain.adoc
+++ b/src/main/asciidoc/getting-started/obtain.adoc
@@ -127,7 +127,7 @@ sudo ln -s /usr/share/java/postgresql-jdbc4.jar /usr/share/tomcat8/lib/
 [source,bash]
 ----
 JAVA_OPTS="-Djava.awt.headless=true -Dfile.encoding=UTF-8 -server \
-  -Xms1536m -Xmx1536m -XX:NewSize=256m -XX:MaxNewSize=256m 
+  -Xms1536m -Xmx1536m -XX:NewSize=256m -XX:MaxNewSize=256m \
   -XX:PermSize=256m -XX:MaxPermSize=256m -XX:+DisableExplicitGC"
 ----
 +


### PR DESCRIPTION
The JAVA_OPTS in the Debian instructions appears to be missing a line-continuation symbol ('\\') at the end of the second line.