### PR TITLE
[SYNCOPE-1162] The changes of Connector's display name is now reflected to contextual menu in Admin Console

### DIFF
--- a/client/console/src/main/java/org/apache/syncope/client/console/topology/TopologyTogglePanel.java
+++ b/client/console/src/main/java/org/apache/syncope/client/console/topology/TopologyTogglePanel.java
@@ -315,7 +315,8 @@ public class TopologyTogglePanel extends TogglePanel<Serializable> {
                 target.add(modal.setContent(new ConnectorWizardBuilder(modelObject, pageRef).
                         build(BaseModal.CONTENT_ID, AjaxWizard.Mode.EDIT)));
 
-                modal.header(new Model<>(MessageFormat.format(getString("connector.edit"), node.getDisplayName())));
+                modal.header(
+                        new Model<>(MessageFormat.format(getString("connector.edit"), modelObject.getDisplayName())));
 
                 MetaDataRoleAuthorizationStrategy.
                         authorize(modal.getForm(), RENDER, StandardEntitlement.CONNECTOR_UPDATE);


### PR DESCRIPTION
Hi,

this fixes [[SYNCOPE-1162]](https://issues.apache.org/jira/browse/SYNCOPE-1162).

Regards,
Matteo
