### PR TITLE
Update Appveyor config to use Maven 3.5.3

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,12 +23,12 @@ install:
   - ps: |
       Add-Type -AssemblyName System.IO.Compression.FileSystem
       if (!(Test-Path -Path "C:\maven" )) {
-        (new-object System.Net.WebClient).DownloadFile('http://www.us.apache.org/dist/maven/maven-3/3.5.2/binaries/apache-maven-3.5.2-bin.zip', 'C:\maven-bin.zip')
+        (new-object System.Net.WebClient).DownloadFile('https://www.apache.org/dist/maven/maven-3/3.5.3/binaries/apache-maven-3.5.3-bin.zip', 'C:\maven-bin.zip')
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
       }
-  - cmd: SET PATH=C:\maven\apache-maven-3.5.2\bin;%JAVA_HOME%\bin;=%;
+  - cmd: SET PATH=C:\maven\apache-maven-3.5.3\bin;%JAVA_HOME%\bin;=%;
   - cmd: SET JAVA_HOME=C:\Program Files\Java\jdk1.8.0
-  - cmd: SET M2_HOME=C:\maven\apache-maven-3.5.2
+  - cmd: SET M2_HOME=C:\maven\apache-maven-3.5.3
   - cmd: SET MAVEN_OPTS=-Xmx4g
   - cmd: SET JAVA_OPTS=-Xmx4g
 build_script:


### PR DESCRIPTION
Fixes Appveyor build - 404 error while installing Maven