### PR TITLE
SYNCOPE-1393 jexl function fullPath2Dn(final String fullPath, final S…

### DIFF
--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/jexl/SyncopeJexlFunctions.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/jexl/SyncopeJexlFunctions.java
@@ -57,7 +57,7 @@ public class SyncopeJexlFunctions {
     public String fullPath2Dn(final String fullPath, final String attr, final String prefix) {
         String[] fullPathSplitted = fullPath.split("/");
         if (fullPathSplitted == null || fullPathSplitted.length <= 1) {
-            return prefix;
+            return StringUtils.EMPTY;
         }
 
         List<String> headless = Arrays.asList(fullPathSplitted).subList(1, fullPathSplitted.length);


### PR DESCRIPTION
…tring attr, final String prefix) should return empty string for ROOT realm