### PR TITLE
Add noopener noreferrer for target blank URLs

### DIFF
--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/commons/Constants.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/commons/Constants.java
@@ -212,7 +212,8 @@ public final class Constants {
             body.append("<li>").append(jexlExample).append("</li>");
         }
         body.append("</ul>").
-                append("<a href='https://commons.apache.org/proper/commons-jexl/reference/' target='_blank'>").
+                append("<a href='https://commons.apache.org/proper/commons-jexl/reference/' ").
+                append("target='_blank' rel='noopener noreferrer'>").
                 append(caller.getString("jexl_syntax_url")).
                 append("</a>");
 

--- a/client/idrepo/console/src/main/resources/org/apache/syncope/client/console/pages/BasePage.html
+++ b/client/idrepo/console/src/main/resources/org/apache/syncope/client/console/pages/BasePage.html
@@ -146,7 +146,7 @@ under the License.
 
       <footer class="main-footer">
         <strong>Copyright &copy; 2010&#45;<span id="spanYear"></span> 
-          <a href="http://www.apache.org/" target="_blank">The Apache Software Foundation</a>.</strong>
+          <a href="http://www.apache.org/" target="_blank" rel="noopener noreferrer">The Apache Software Foundation</a>.</strong>
         All rights reserved.
       </footer>
 


### PR DESCRIPTION
Best security practise is to add rel="noopener noreferrer" for links that usestarget="_blank". See for example: https://dev.to/ben/the-targetblank-vulnerability-by-example