### PR TITLE
Enable security-related HTTP headers in the console

### DIFF
--- a/client/console/src/main/java/org/apache/syncope/client/console/SyncopeConsoleApplication.java
+++ b/client/console/src/main/java/org/apache/syncope/client/console/SyncopeConsoleApplication.java
@@ -58,6 +58,9 @@ import org.apache.wicket.authroles.authorization.strategies.role.metadata.MetaDa
 import org.apache.wicket.markup.html.WebPage;
 import org.apache.wicket.protocol.http.CsrfPreventionRequestCycleListener;
 import org.apache.wicket.protocol.http.WebApplication;
+import org.apache.wicket.request.cycle.AbstractRequestCycleListener;
+import org.apache.wicket.request.cycle.RequestCycle;
+import org.apache.wicket.request.http.WebResponse;
 import org.apache.wicket.request.resource.AbstractResource;
 import org.apache.wicket.request.resource.IResource;
 import org.apache.wicket.request.resource.ResourceReference;
@@ -205,6 +208,17 @@ public class SyncopeConsoleApplication extends AuthenticatedWebApplication {
             getRequestCycleListeners().add(new CsrfPreventionRequestCycleListener());
         }
         getRequestCycleListeners().add(new SyncopeConsoleRequestCycleListener());
+
+        getRequestCycleListeners().add(new AbstractRequestCycleListener() {
+
+            @Override
+            public void onEndRequest(final RequestCycle cycle) {
+                WebResponse response = (WebResponse) cycle.getResponse();
+                response.setHeader("X-XSS-Protection", "1; mode=block");
+                response.setHeader("X-Content-Type-Options", "nosniff");
+                response.setHeader("X-Frame-Options", "sameorigin");
+            }
+        });
 
         mountPage("/login", getSignInPageClass());
 

--- a/client/enduser/src/main/java/org/apache/syncope/client/enduser/SyncopeEnduserApplication.java
+++ b/client/enduser/src/main/java/org/apache/syncope/client/enduser/SyncopeEnduserApplication.java
@@ -50,6 +50,9 @@ import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.protocol.http.WebApplication;
 import org.apache.wicket.request.Request;
 import org.apache.wicket.request.Response;
+import org.apache.wicket.request.cycle.AbstractRequestCycleListener;
+import org.apache.wicket.request.cycle.RequestCycle;
+import org.apache.wicket.request.http.WebResponse;
 import org.apache.wicket.request.resource.AbstractResource;
 import org.apache.wicket.request.resource.IResource;
 import org.apache.wicket.request.resource.ResourceReference;
@@ -304,6 +307,17 @@ public class SyncopeEnduserApplication extends WebApplication implements Seriali
                 }
             });
         }
+
+        getRequestCycleListeners().add(new AbstractRequestCycleListener() {
+
+            @Override
+            public void onEndRequest(final RequestCycle cycle) {
+                WebResponse response = (WebResponse) cycle.getResponse();
+                response.setHeader("X-XSS-Protection", "1; mode=block");
+                response.setHeader("X-Content-Type-Options", "nosniff");
+                response.setHeader("X-Frame-Options", "sameorigin");
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
It's good security practice to enable the HTTP headers included in the patch. See here:

https://ci.apache.org/projects/wicket/guide/8.x/single.html#_external_security_checks

I created the PR against 2.1.x, as I'm not sure what state master is currently in.