### PR TITLE
SYNCOPE-1448 add synchronized block for bean loading/register section

### DIFF
--- a/core/spring/src/main/java/org/apache/syncope/core/spring/ImplementationManager.java
+++ b/core/spring/src/main/java/org/apache/syncope/core/spring/ImplementationManager.java
@@ -104,10 +104,19 @@ public final class ImplementationManager {
                         rule = (AccountRule) ApplicationContextProvider.getBeanFactory().
                                 getSingleton(ruleClass.getName());
                     } else {
-                        rule = (AccountRule) ApplicationContextProvider.getBeanFactory().
-                                createBean(ruleClass, AbstractBeanDefinition.AUTOWIRE_BY_TYPE, false);
-                        ApplicationContextProvider.getBeanFactory().
-                                registerSingleton(ruleClass.getName(), rule);
+                        // to avoid concurrency issues
+                        synchronized (ImplementationManager.class) {
+                            // double check for performance reasons
+                            if (ApplicationContextProvider.getBeanFactory().containsSingleton(ruleClass.getName())) {
+                                rule = (AccountRule) ApplicationContextProvider.getBeanFactory().
+                                        getSingleton(ruleClass.getName());
+                            } else {
+                                rule = (AccountRule) ApplicationContextProvider.getBeanFactory().
+                                        createBean(ruleClass, AbstractBeanDefinition.AUTOWIRE_BY_TYPE, false);
+                                ApplicationContextProvider.getBeanFactory().
+                                        registerSingleton(ruleClass.getName(), rule);
+                            }
+                        }
                     }
                     rule.setConf(ruleConf);
                 }
@@ -138,10 +147,19 @@ public final class ImplementationManager {
                         rule = (PasswordRule) ApplicationContextProvider.getBeanFactory().
                                 getSingleton(ruleClass.getName());
                     } else {
-                        rule = (PasswordRule) ApplicationContextProvider.getBeanFactory().
-                                createBean(ruleClass, AbstractBeanDefinition.AUTOWIRE_BY_TYPE, false);
-                        ApplicationContextProvider.getBeanFactory().
-                                registerSingleton(ruleClass.getName(), rule);
+                        // to avoid concurrency issues
+                        synchronized (ImplementationManager.class) {
+                            // double check for performance reasons
+                            if (ApplicationContextProvider.getBeanFactory().containsSingleton(ruleClass.getName())) {
+                                rule = (PasswordRule) ApplicationContextProvider.getBeanFactory().
+                                        getSingleton(ruleClass.getName());
+                            } else {
+                                rule = (PasswordRule) ApplicationContextProvider.getBeanFactory().
+                                        createBean(ruleClass, AbstractBeanDefinition.AUTOWIRE_BY_TYPE, false);
+                                ApplicationContextProvider.getBeanFactory().
+                                        registerSingleton(ruleClass.getName(), rule);
+                            }
+                        }
                     }
                     rule.setConf(ruleConf);
                 }
@@ -173,10 +191,19 @@ public final class ImplementationManager {
                         rule = (PullCorrelationRule) ApplicationContextProvider.getBeanFactory().
                                 getSingleton(ruleClass.getName());
                     } else {
-                        rule = (PullCorrelationRule) ApplicationContextProvider.getBeanFactory().
-                                createBean(ruleClass, AbstractBeanDefinition.AUTOWIRE_BY_TYPE, false);
-                        ApplicationContextProvider.getBeanFactory().
-                                registerSingleton(ruleClass.getName(), rule);
+                        // to avoid concurrency issues
+                        synchronized (ImplementationManager.class) {
+                            // double check for performance reasons
+                            if (ApplicationContextProvider.getBeanFactory().containsSingleton(ruleClass.getName())) {
+                                rule = (PullCorrelationRule) ApplicationContextProvider.getBeanFactory().
+                                        getSingleton(ruleClass.getName());
+                            } else {
+                                rule = (PullCorrelationRule) ApplicationContextProvider.getBeanFactory().
+                                        createBean(ruleClass, AbstractBeanDefinition.AUTOWIRE_BY_TYPE, false);
+                                ApplicationContextProvider.getBeanFactory().
+                                        registerSingleton(ruleClass.getName(), rule);
+                            }
+                        }
                     }
                     rule.setConf(ruleConf);
                 }
@@ -208,10 +235,19 @@ public final class ImplementationManager {
                         rule = (PushCorrelationRule) ApplicationContextProvider.getBeanFactory().
                                 getSingleton(ruleClass.getName());
                     } else {
-                        rule = (PushCorrelationRule) ApplicationContextProvider.getBeanFactory().
-                                createBean(ruleClass, AbstractBeanDefinition.AUTOWIRE_BY_TYPE, false);
-                        ApplicationContextProvider.getBeanFactory().
-                                registerSingleton(ruleClass.getName(), rule);
+                        // to avoid concurrency issues
+                        synchronized (ImplementationManager.class) {
+                            // double check for performance reasons
+                            if (ApplicationContextProvider.getBeanFactory().containsSingleton(ruleClass.getName())) {
+                                rule = (PushCorrelationRule) ApplicationContextProvider.getBeanFactory().
+                                        getSingleton(ruleClass.getName());
+                            } else {
+                                rule = (PushCorrelationRule) ApplicationContextProvider.getBeanFactory().
+                                        createBean(ruleClass, AbstractBeanDefinition.AUTOWIRE_BY_TYPE, false);
+                                ApplicationContextProvider.getBeanFactory().
+                                        registerSingleton(ruleClass.getName(), rule);
+                            }
+                        }
                     }
                     rule.setConf(ruleConf);
                 }

--- a/core/spring/src/test/java/org/apache/syncope/core/spring/ImplementationManagerTest.java
+++ b/core/spring/src/test/java/org/apache/syncope/core/spring/ImplementationManagerTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.syncope.core.spring;
+
+import org.apache.syncope.common.lib.policy.DefaultPasswordRuleConf;
+import org.apache.syncope.core.persistence.api.dao.PasswordRule;
+import org.apache.syncope.core.provisioning.api.serialization.POJOHelper;
+import org.apache.syncope.core.spring.security.TestImplementation;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@SpringJUnitConfig(locations = {"classpath:springTest.xml"})
+class ImplementationManagerTest {
+
+    private DefaultPasswordRuleConf createBaseDefaultPasswordRuleConf() {
+        DefaultPasswordRuleConf baseDefaultPasswordRuleConf = new DefaultPasswordRuleConf();
+        baseDefaultPasswordRuleConf.setAlphanumericRequired(false);
+        baseDefaultPasswordRuleConf.setDigitRequired(false);
+        baseDefaultPasswordRuleConf.setLowercaseRequired(false);
+        baseDefaultPasswordRuleConf.setMaxLength(1000);
+        baseDefaultPasswordRuleConf.setMinLength(8);
+        baseDefaultPasswordRuleConf.setMustEndWithAlpha(false);
+        baseDefaultPasswordRuleConf.setMustEndWithDigit(false);
+        baseDefaultPasswordRuleConf.setMustEndWithNonAlpha(false);
+        baseDefaultPasswordRuleConf.setMustStartWithAlpha(false);
+        baseDefaultPasswordRuleConf.setMustStartWithDigit(false);
+        baseDefaultPasswordRuleConf.setMustStartWithNonAlpha(false);
+        baseDefaultPasswordRuleConf.setMustntEndWithAlpha(false);
+        baseDefaultPasswordRuleConf.setMustntEndWithDigit(false);
+        baseDefaultPasswordRuleConf.setMustntEndWithNonAlpha(false);
+        baseDefaultPasswordRuleConf.setMustntStartWithAlpha(false);
+        baseDefaultPasswordRuleConf.setMustntStartWithDigit(false);
+        baseDefaultPasswordRuleConf.setMustntStartWithNonAlpha(false);
+        baseDefaultPasswordRuleConf.setNonAlphanumericRequired(false);
+        baseDefaultPasswordRuleConf.setUppercaseRequired(false);
+        return baseDefaultPasswordRuleConf;
+    }
+
+
+    @Test
+    public void testConcurrentPasswordRuleBuilding() {
+        assertTimeoutPreemptively(Duration.ofSeconds(30), () -> {
+            TestImplementation implementation = new TestImplementation();
+            implementation.setBody(POJOHelper.serialize(createBaseDefaultPasswordRuleConf()));
+            ReentrantLock lock = new ReentrantLock();
+            lock.lock();
+            AtomicInteger runningThreads = new AtomicInteger(0);
+            AtomicInteger errorCount = new AtomicInteger(0);
+            List<String> errorMessages = Collections.synchronizedList(new LinkedList<>());
+            for (int i = 0; i < 10; i++) {
+                runningThreads.incrementAndGet();
+                new Thread(() -> {
+                    try {
+                        while (lock.isLocked()) {
+                            Thread.yield();
+                        }
+                        Optional<PasswordRule> passwordRule;
+                        try {
+                            passwordRule = ImplementationManager.buildPasswordRule(implementation);
+                            passwordRule.orElseThrow();
+                        } catch (Exception e) {
+                            errorMessages.add(e.getLocalizedMessage());
+                            errorCount.incrementAndGet();
+                        }
+                    } finally {
+                        runningThreads.decrementAndGet();
+                    }
+                }).start();
+            }
+            lock.unlock();
+            while (runningThreads.get() > 0) {
+                Thread.yield();
+            }
+
+            assertTrue(errorMessages.isEmpty(), errorMessages.stream().collect(Collectors.joining(System.lineSeparator())));
+        });
+    }
+
+
+    private static void sout(String text) {
+        System.err.println(System.nanoTime() + " " + text);
+
+    }
+}


### PR DESCRIPTION
Issue [SYNCOPE-1448](https://issues.apache.org/jira/projects/SYNCOPE/issues/SYNCOPE-1448)

When two threads (T1,T2) arrive the section `if (ApplicationContextProvider.getBeanFactory().containsSingleton(ruleClass.getName())) {`at the same time they will both assume that there is no bean, which is right so far.

T1 register the bean as it should here `ApplicationContextProvider.getBeanFactory().registerSingleton(ruleClass.getName(), rule);`. As soon as T2does the same, an exception is thrown. 

Solution:

When T1 and T2 found that a given bean is not there, they'll hit a synchronized section with double checking. This will prevent the duplicated creation and registration of a bean.