### PR TITLE
SYNCOPE-1332: Fix jdk11 build issues

### DIFF
--- a/client/idrepo/lib/pom.xml
+++ b/client/idrepo/lib/pom.xml
@@ -65,6 +65,12 @@ under the License.
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>javax.xml.ws</groupId>
+      <artifactId>jaxws-api</artifactId>
+    </dependency>
+    
     <dependency>
       <groupId>org.apache.syncope.common.idrepo</groupId>
       <artifactId>syncope-common-idrepo-rest-api</artifactId>

--- a/core/idrepo/rest-cxf/pom.xml
+++ b/core/idrepo/rest-cxf/pom.xml
@@ -50,6 +50,11 @@ under the License.
     </dependency>
 
     <dependency>
+      <groupId>javax.xml.ws</groupId>
+      <artifactId>jaxws-api</artifactId>
+    </dependency>
+    
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
     </dependency>

--- a/fit/build-tools/pom.xml
+++ b/fit/build-tools/pom.xml
@@ -88,6 +88,10 @@ under the License.
       <artifactId>jaxws-api</artifactId>
     </dependency>
     <dependency>
+      <groupId>javax.jws</groupId>
+      <artifactId>jsr181-api</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-core</artifactId>
       <version>${cxf.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -553,6 +553,16 @@ under the License.
 
     <dependencies>
       <dependency>
+        <groupId>javax.xml.ws</groupId>
+        <artifactId>jaxws-api</artifactId>
+        <version>2.3.0</version>
+      </dependency>
+      <dependency>
+        <groupId>javax.jws</groupId>
+        <artifactId>jsr181-api</artifactId>
+        <version>1.0-MR1</version>
+      </dependency>
+      <dependency>
         <groupId>javax.annotation</groupId>
         <artifactId>javax.annotation-api</artifactId>
         <version>1.3.2</version>
@@ -1870,6 +1880,7 @@ under the License.
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.0</version> 
           <configuration>
+            <source>${targetJdk}</source>
             <release>${targetJdk}</release>
             <useIncrementalCompilation>false</useIncrementalCompilation>
             <showWarnings>true</showWarnings>
@@ -2129,7 +2140,7 @@ under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.4.1</version>
+        <version>3.0.0-M2</version>
         <executions>
           <execution>
             <id>enforce-maven</id>
@@ -2142,7 +2153,7 @@ under the License.
                   <version>${targetJdk}</version>
                 </requireJavaVersion>
                 <requireMavenVersion>
-                  <version>3.5.0</version>
+                  <version>[3.5.0,)</version>
                 </requireMavenVersion>
               </rules>    
             </configuration>


### PR DESCRIPTION
Make sure the project can build against JDK 11 by:

1. Including required `javax.jws` modules in the build.
2. Bump the enforcer plugin version
3. Allow Maven 3.5+ to run the build.