### PR TITLE
SYNCOPE-1483: maven-enforcer-plugin: API incompatibility fails the build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2134,7 +2134,7 @@ under the License.
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.4.1</version>
+        <version>3.0.0-M2</version>
         <executions>
           <execution>
             <id>enforce-maven</id>


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/SYNCOPE-1483

Switching to 3.0.0.M2 version of plugin allows for a successful build.