### PR TITLE
[SYNCOPE-1484]: syncope-ide-netbeans submodule fails to find netbeans dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1833,10 +1833,6 @@ under the License.
       </snapshots>
     </repository>
     <repository>
-      <id>netbeans</id>
-      <url>http://bits.netbeans.org/maven2/</url>
-    </repository>
-    <repository>
       <id>jitpack.io</id>
       <url>https://jitpack.io</url>
     </repository>

--- a/pom.xml
+++ b/pom.xml
@@ -478,7 +478,7 @@ under the License.
     
     <ianal-maven-plugin-version>1.0-alpha-1</ianal-maven-plugin-version>
 
-    <netbeans.version>RELEASE82</netbeans.version>
+    <netbeans.version>RELEASE111</netbeans.version>
 
     <antlr4.version>4.7.2</antlr4.version>
 


### PR DESCRIPTION
Coordinates show that the current available release version is RELEASE111.

See https://issues.apache.org/jira/browse/SYNCOPE-1484
Related: https://issues.apache.org/jira/browse/SYNCOPE-1464