### PR TITLE
Added reference to the need for patch in building.

### DIFF
--- a/src/site/xdoc/building.xml
+++ b/src/site/xdoc/building.xml
@@ -58,6 +58,13 @@ under the License.
         <source>set MAVEN_OPTS=-Xms512m -Xmx1024m -XX:PermSize=256m -XX:MaxPermSize=512m</source>
       </p>
       <p>
+	You will also need the <a href="https://linux.die.net/man/1/patch">patch</a> program, 
+	on RPM yum style linux systems this can be installed with:
+	<source>sudo yum install patch</source>
+	and on RPM dnf style systems:
+	<source>sudo dnf install patch</source>
+      </p>
+      <p>
         To build Syncope simply execute (from within the top-level source directory):
         <source>$ mvn clean install</source>
       </p>

--- a/src/site/xdoc/building.xml
+++ b/src/site/xdoc/building.xml
@@ -50,8 +50,10 @@ under the License.
         Before building Syncope, you need to setup an environment variable to give Maven more memory.
       </p>
       <p>
-        On Unix
+        On Unix with JDK up to version 8.0
         <source>export MAVEN_OPTS="-Xms512m -Xmx1024m -XX:PermSize=256m -XX:MaxPermSize=512m"</source>
+        On Unix with JDK up after 8.0
+        <source>export MAVEN_OPTS="-Xms512m -Xmx1024m"</source>
       </p>
       <p>
         On Windows


### PR DESCRIPTION
I am trying to do a source build of Syncope on a fresh Centos 7 VM. I still can't get the 
tests to complete (some other problem but have the 

 mvn -PskipTests,all

and I think
 mvn -PskipTests,install

working. To do this I needed to add patch to the list of packages that my Ansible playbook installs on this system. I don't use Windows nor deb package systems much so can't update the site data to include that (nor do I know what will happen on a OSX build).
