### PR TITLE
NOJIRA: Update Oracle db client dependency coordinates; increase timeouts

### DIFF
--- a/fit/console-reference/pom.xml
+++ b/fit/console-reference/pom.xml
@@ -157,7 +157,7 @@ under the License.
             <deployable>
               <location>${basedir}/../core-reference/target/syncope-fit-core-reference-${project.version}</location>
               <pingURL>http://localhost:${cargo.servlet.port}/syncope/index.html</pingURL>
-              <pingTimeout>120000</pingTimeout>
+              <pingTimeout>60000</pingTimeout>
               <properties>
                 <context>syncope</context>
               </properties>

--- a/fit/console-reference/pom.xml
+++ b/fit/console-reference/pom.xml
@@ -157,7 +157,7 @@ under the License.
             <deployable>
               <location>${basedir}/../core-reference/target/syncope-fit-core-reference-${project.version}</location>
               <pingURL>http://localhost:${cargo.servlet.port}/syncope/index.html</pingURL>
-              <pingTimeout>60000</pingTimeout>
+              <pingTimeout>${cargo.deployable.ping.timeout}</pingTimeout>
               <properties>
                 <context>syncope</context>
               </properties>

--- a/fit/console-reference/pom.xml
+++ b/fit/console-reference/pom.xml
@@ -157,7 +157,7 @@ under the License.
             <deployable>
               <location>${basedir}/../core-reference/target/syncope-fit-core-reference-${project.version}</location>
               <pingURL>http://localhost:${cargo.servlet.port}/syncope/index.html</pingURL>
-              <pingTimeout>60000</pingTimeout>
+              <pingTimeout>120000</pingTimeout>
               <properties>
                 <context>syncope</context>
               </properties>

--- a/fit/core-reference/pom.xml
+++ b/fit/core-reference/pom.xml
@@ -327,7 +327,7 @@ under the License.
             <deployable>
               <location>${project.build.directory}/${project.build.finalName}</location>
               <pingURL>http://localhost:${cargo.servlet.port}/syncope/index.html</pingURL>
-              <pingTimeout>120000</pingTimeout>
+              <pingTimeout>${cargo.deployable.ping.timeout}</pingTimeout>
               <properties>
                 <context>syncope</context>
               </properties>
@@ -1214,13 +1214,14 @@ under the License.
       <properties>
         <jdbcdriver.groupId>com.oracle.ojdbc</jdbcdriver.groupId>
         <jdbcdriver.artifactId>ojdbc10</jdbcdriver.artifactId>
+        <cargo.deployable.ping.timeout>120000</cargo.deployable.ping.timeout>
       </properties>
 
       <dependencies>
         <dependency>
-          <groupId>${jdbcdriver.groupId}</groupId>
-          <artifactId>${jdbcdriver.artifactId}</artifactId>
-          <version>19.3.0.0</version>
+          <groupId>com.oracle.ojdbc</groupId>
+          <artifactId>ojdbc10</artifactId>
+          <version>${jdbc.oracle.version}</version>
           <scope>test</scope>
         </dependency>
       </dependencies>

--- a/fit/core-reference/pom.xml
+++ b/fit/core-reference/pom.xml
@@ -327,7 +327,7 @@ under the License.
             <deployable>
               <location>${project.build.directory}/${project.build.finalName}</location>
               <pingURL>http://localhost:${cargo.servlet.port}/syncope/index.html</pingURL>
-              <pingTimeout>60000</pingTimeout>
+              <pingTimeout>120000</pingTimeout>
               <properties>
                 <context>syncope</context>
               </properties>
@@ -1212,15 +1212,15 @@ under the License.
       <id>oracle-it</id>
       
       <properties>
-        <jdbcdriver.groupId>com.oracle.jdbc</jdbcdriver.groupId>
-        <jdbcdriver.artifactId>ojdbc8</jdbcdriver.artifactId>
+        <jdbcdriver.groupId>com.oracle.ojdbc</jdbcdriver.groupId>
+        <jdbcdriver.artifactId>ojdbc10</jdbcdriver.artifactId>
       </properties>
 
       <dependencies>
         <dependency>
-          <groupId>com.oracle.jdbc</groupId>
-          <artifactId>ojdbc8</artifactId>
-          <version>12.2.0.1</version>
+          <groupId>${jdbcdriver.groupId}</groupId>
+          <artifactId>${jdbcdriver.artifactId}</artifactId>
+          <version>19.3.0.0</version>
           <scope>test</scope>
         </dependency>
       </dependencies>
@@ -1235,7 +1235,7 @@ under the License.
             <configuration>
               <images>
                 <image>
-                  <name>oracle-xe-11g</name>
+                  <name>database-enterprise</name>
                   <build>
                     <dockerFileDir>${project.basedir}/src/main/resources/oracle</dockerFileDir>
                   </build>
@@ -1247,8 +1247,8 @@ under the License.
                       <port>1521:1521</port>
                     </ports>
                     <wait>
-                      <log>Disconnected from Oracle Database 11g Express Edition Release 11.2.0.2.0 - 64bit Production</log>
-                      <time>30000</time>
+                      <log>Disconnected from Oracle Database</log>
+                      <time>300000</time>
                     </wait>                
                   </run>
                 </image>

--- a/fit/core-reference/src/main/resources/oracle/Dockerfile
+++ b/fit/core-reference/src/main/resources/oracle/Dockerfile
@@ -15,6 +15,6 @@
 # specific language governing permissions and limitations
 # under the License.
 
-FROM wnameless/oracle-xe-11g
-
+# FROM wnameless/oracle-xe-11g
+FROM store/oracle/database-enterprise:12.2.0.1-slim
 ADD init.sql /docker-entrypoint-initdb.d/

--- a/fit/core-reference/src/main/resources/oracle/Dockerfile
+++ b/fit/core-reference/src/main/resources/oracle/Dockerfile
@@ -15,6 +15,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-# FROM wnameless/oracle-xe-11g
 FROM store/oracle/database-enterprise:12.2.0.1-slim
 ADD init.sql /docker-entrypoint-initdb.d/

--- a/fit/enduser-reference/pom.xml
+++ b/fit/enduser-reference/pom.xml
@@ -156,7 +156,7 @@ under the License.
             <deployable>
               <location>${basedir}/../core-reference/target/syncope-fit-core-reference-${project.version}</location>
               <pingURL>http://localhost:${cargo.servlet.port}/syncope/index.html</pingURL>
-              <pingTimeout>120000</pingTimeout>
+              <pingTimeout>${cargo.deployable.ping.timeout}</pingTimeout>
               <properties>
                 <context>syncope</context>
               </properties>

--- a/fit/enduser-reference/pom.xml
+++ b/fit/enduser-reference/pom.xml
@@ -156,7 +156,7 @@ under the License.
             <deployable>
               <location>${basedir}/../core-reference/target/syncope-fit-core-reference-${project.version}</location>
               <pingURL>http://localhost:${cargo.servlet.port}/syncope/index.html</pingURL>
-              <pingTimeout>60000</pingTimeout>
+              <pingTimeout>120000</pingTimeout>
               <properties>
                 <context>syncope</context>
               </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -498,6 +498,7 @@ under the License.
     <cargo.servlet.port>9080</cargo.servlet.port>
     <cargo.tomcat.ajp.port>9889</cargo.tomcat.ajp.port>
     <cargo.rmi.port>9805</cargo.rmi.port>
+    <cargo.deployable.ping.timeout>60000</cargo.deployable.ping.timeout>
     <cargo.log>${log.directory}/cargo.log</cargo.log>
     <cargo.output>${log.directory}/cargo-output.log</cargo.output>
 
@@ -511,7 +512,8 @@ under the License.
     <jdbc.mysql.version>8.0.16</jdbc.mysql.version>
     <jdbc.mariadb.version>2.4.1</jdbc.mariadb.version>
     <jdbc.mssql.version>7.2.2.jre</jdbc.mssql.version>
-
+    <jdbc.oracle.version>19.3.0.0</jdbc.oracle.version>
+    
     <adminUser>admin</adminUser>
     <anonymousUser>anonymous</anonymousUser>
     <adminPassword>DE088591C00CC98B36F5ADAAF7DA2B004CF7F2FE7BBB45B766B6409876E2F3DB13C7905C6AA59464</adminPassword>


### PR DESCRIPTION
- The Oracle database client is now available in Maven Central. This pull request updates the coordinates.
- Docker-based tests for Oracle are switched to use Oracle enterprise edition 12g (the slim variant of the image)
- Timeouts are increased to account for updates and startup time.