### PR TITLE
NOJIRA: Protect invocations against NPEs and illegal sort ops

### DIFF
--- a/client/am/console/src/main/java/org/apache/syncope/client/console/panels/GatewayRouteDirectoryPanel.java
+++ b/client/am/console/src/main/java/org/apache/syncope/client/console/panels/GatewayRouteDirectoryPanel.java
@@ -21,7 +21,6 @@ package org.apache.syncope.client.console.panels;
 import de.agilecoders.wicket.core.markup.html.bootstrap.dialog.Modal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.lang3.SerializationUtils;
@@ -179,7 +178,7 @@ public class GatewayRouteDirectoryPanel
         return AMConstants.PREF_GATEWAYROUTE_PAGINATOR_ROWS;
     }
 
-    protected final class GatewayRouteProvider extends DirectoryDataProvider<GatewayRouteTO> {
+    protected static final class GatewayRouteProvider extends DirectoryDataProvider<GatewayRouteTO> {
 
         private static final long serialVersionUID = 5282134321828253058L;
 
@@ -194,7 +193,7 @@ public class GatewayRouteDirectoryPanel
         @Override
         public Iterator<? extends GatewayRouteTO> iterator(final long first, final long count) {
             List<GatewayRouteTO> list = GatewayRouteRestClient.list();
-            Collections.sort(list, comparator);
+            list.sort(comparator);
             return list.subList((int) first, (int) first + (int) count).iterator();
         }
 

--- a/client/am/console/src/main/java/org/apache/syncope/client/console/panels/GatewayRouteWizardBuilder.java
+++ b/client/am/console/src/main/java/org/apache/syncope/client/console/panels/GatewayRouteWizardBuilder.java
@@ -65,7 +65,7 @@ public class GatewayRouteWizardBuilder extends BaseAjaxWizardBuilder<GatewayRout
         return wizardModel;
     }
 
-    public class Profile extends WizardStep {
+    public static class Profile extends WizardStep {
 
         private static final long serialVersionUID = 8610155719550948702L;
 
@@ -107,7 +107,7 @@ public class GatewayRouteWizardBuilder extends BaseAjaxWizardBuilder<GatewayRout
         }
     }
 
-    public class Predicates extends WizardStep {
+    public static class Predicates extends WizardStep {
 
         private static final long serialVersionUID = 5934389493874714599L;
 
@@ -117,7 +117,7 @@ public class GatewayRouteWizardBuilder extends BaseAjaxWizardBuilder<GatewayRout
         }
     }
 
-    public class Filters extends WizardStep {
+    public static class Filters extends WizardStep {
 
         private static final long serialVersionUID = -6552124285142294023L;
 

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/commons/IdMImplementationInfoProvider.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/commons/IdMImplementationInfoProvider.java
@@ -18,6 +18,7 @@
  */
 package org.apache.syncope.client.console.commons;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -47,7 +48,7 @@ public class IdMImplementationInfoProvider extends IdRepoImplementationInfoProvi
 
     @Override
     public List<String> getClasses(final ImplementationTO implementation, final ViewMode viewMode) {
-        List<String> classes = List.of();
+        List<String> classes = new ArrayList<>();
         if (viewMode == ViewMode.JSON_BODY) {
             switch (implementation.getType()) {
                 case IdMImplementationType.PULL_CORRELATION_RULE:

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/panels/ConnInstanceHistoryConfDirectoryPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/panels/ConnInstanceHistoryConfDirectoryPanel.java
@@ -20,7 +20,6 @@ package org.apache.syncope.client.console.panels;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
@@ -214,7 +213,7 @@ public abstract class ConnInstanceHistoryConfDirectoryPanel extends DirectoryPan
         public Iterator<ConnInstanceHistoryConfTO> iterator(final long first, final long count) {
             final List<ConnInstanceHistoryConfTO> configurations = ConnectorHistoryRestClient.list(entityKey);
 
-            Collections.sort(configurations, comparator);
+            configurations.sort(comparator);
             return configurations.iterator();
         }
 

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/panels/RemediationDirectoryPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/panels/RemediationDirectoryPanel.java
@@ -208,12 +208,12 @@ public class RemediationDirectoryPanel
                             AjaxWizard.EditItemActionEvent<UserTO> userEvent =
                                     new AjaxWizard.EditItemActionEvent<>(newUserTO, target);
                             userEvent.forceModalPanel(new RemediationUserWizardBuilder(
-                                    model.getObject(),
-                                    previousUserTO,
-                                    newUserTO,
-                                    AnyTypeRestClient.read(remediationTO.getAnyType()).getClasses(),
-                                    FormLayoutInfoUtils.fetch(List.of(remediationTO.getAnyType())).getLeft(),
-                                    pageRef
+                                model.getObject(),
+                                previousUserTO,
+                                newUserTO,
+                                AnyTypeRestClient.read(remediationTO.getAnyType()).getClasses(),
+                                FormLayoutInfoUtils.fetch(List.of(remediationTO.getAnyType())).getLeft(),
+                                pageRef
                             ).build(BaseModal.CONTENT_ID, AjaxWizard.Mode.EDIT));
                             send(RemediationDirectoryPanel.this, Broadcast.EXACT, userEvent);
                             break;
@@ -235,12 +235,12 @@ public class RemediationDirectoryPanel
                             AjaxWizard.EditItemActionEvent<GroupTO> groupEvent =
                                     new AjaxWizard.EditItemActionEvent<>(newGroupTO, target);
                             groupEvent.forceModalPanel(new RemediationGroupWizardBuilder(
-                                    model.getObject(),
-                                    previousGroupTO,
-                                    newGroupTO,
-                                    AnyTypeRestClient.read(remediationTO.getAnyType()).getClasses(),
-                                    FormLayoutInfoUtils.fetch(List.of(remediationTO.getAnyType())).getMiddle(),
-                                    pageRef
+                                model.getObject(),
+                                previousGroupTO,
+                                newGroupTO,
+                                AnyTypeRestClient.read(remediationTO.getAnyType()).getClasses(),
+                                FormLayoutInfoUtils.fetch(List.of(remediationTO.getAnyType())).getMiddle(),
+                                pageRef
                             ).build(BaseModal.CONTENT_ID, AjaxWizard.Mode.EDIT));
                             send(RemediationDirectoryPanel.this, Broadcast.EXACT, groupEvent);
                             break;
@@ -262,13 +262,13 @@ public class RemediationDirectoryPanel
                             AjaxWizard.EditItemActionEvent<AnyObjectTO> anyObjectEvent =
                                     new AjaxWizard.EditItemActionEvent<>(newAnyObjectTO, target);
                             anyObjectEvent.forceModalPanel(new RemediationAnyObjectWizardBuilder(
-                                    model.getObject(),
-                                    previousAnyObjectTO,
-                                    newAnyObjectTO,
-                                    AnyTypeRestClient.read(remediationTO.getAnyType()).getClasses(),
-                                    FormLayoutInfoUtils.fetch(List.of(remediationTO.getAnyType())).
-                                            getRight().values().iterator().next(),
-                                    pageRef
+                                model.getObject(),
+                                previousAnyObjectTO,
+                                newAnyObjectTO,
+                                AnyTypeRestClient.read(remediationTO.getAnyType()).getClasses(),
+                                FormLayoutInfoUtils.fetch(List.of(remediationTO.getAnyType())).
+                                    getRight().values().iterator().next(),
+                                pageRef
                             ).build(BaseModal.CONTENT_ID, AjaxWizard.Mode.EDIT));
                             send(RemediationDirectoryPanel.this, Broadcast.EXACT, anyObjectEvent);
                     }
@@ -349,7 +349,7 @@ public class RemediationDirectoryPanel
         }
     }
 
-    private class RemediationUserWizardBuilder extends UserWizardBuilder {
+    private static class RemediationUserWizardBuilder extends UserWizardBuilder {
 
         private static final long serialVersionUID = 6840699724316612700L;
 
@@ -404,7 +404,7 @@ public class RemediationDirectoryPanel
         }
     }
 
-    private class RemediationGroupWizardBuilder extends GroupWizardBuilder {
+    private static class RemediationGroupWizardBuilder extends GroupWizardBuilder {
 
         private static final long serialVersionUID = -5233791906979150786L;
 
@@ -452,7 +452,7 @@ public class RemediationDirectoryPanel
         }
     }
 
-    private class RemediationAnyObjectWizardBuilder extends AnyObjectWizardBuilder {
+    private static class RemediationAnyObjectWizardBuilder extends AnyObjectWizardBuilder {
 
         private static final long serialVersionUID = 6993139499479015083L;
 

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/panels/ResourceHistoryConfDirectoryPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/panels/ResourceHistoryConfDirectoryPanel.java
@@ -20,7 +20,6 @@ package org.apache.syncope.client.console.panels;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
@@ -215,7 +214,7 @@ public abstract class ResourceHistoryConfDirectoryPanel extends DirectoryPanel<
         public Iterator<ResourceHistoryConfTO> iterator(final long first, final long count) {
             final List<ResourceHistoryConfTO> configurations = ResourceHistoryRestClient.list(entityKey);
 
-            Collections.sort(configurations, comparator);
+            configurations.sort(comparator);
             return configurations.iterator();
         }
 

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/rest/ResourceRestClient.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/rest/ResourceRestClient.java
@@ -19,7 +19,6 @@
 package org.apache.syncope.client.console.rest;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.ObjectUtils;
@@ -91,7 +90,7 @@ public class ResourceRestClient extends BaseRestClient {
         List<ResourceTO> resources = List.of();
         try {
             resources = getService(ResourceService.class).list();
-            Collections.sort(resources, (o1, o2) -> ObjectUtils.compare(o1.getKey(), o2.getKey()));
+            resources.sort((o1, o2) -> ObjectUtils.compare(o1.getKey(), o2.getKey()));
         } catch (Exception e) {
             LOG.error("Could not fetch the Resource list", e);
         }

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/status/AnyStatusDirectoryPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/status/AnyStatusDirectoryPanel.java
@@ -20,7 +20,6 @@ package org.apache.syncope.client.console.status;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
@@ -326,7 +325,7 @@ public class AnyStatusDirectoryPanel
                 }
                 syncope.setStatus(syncopeStatus);
 
-                Collections.sort(statusBeans, comparator);
+                statusBeans.sort(comparator);
                 statusBeans.add(0, syncope);
             } else {
                 statusBeans.addAll(resources.stream().
@@ -340,7 +339,7 @@ public class AnyStatusDirectoryPanel
                             return statusBean;
                         }).collect(Collectors.toList()));
 
-                Collections.sort(statusBeans, comparator);
+                statusBeans.sort(comparator);
             }
 
             return first == -1 && count == -1

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/topology/TopologyTogglePanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/topology/TopologyTogglePanel.java
@@ -666,7 +666,7 @@ public class TopologyTogglePanel extends TogglePanel<Serializable> {
         }
     }
 
-    public final class UpdateEvent {
+    public static final class UpdateEvent {
 
         private final AjaxRequestTarget target;
 

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/topology/TopologyWebSocketBehavior.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/topology/TopologyWebSocketBehavior.java
@@ -252,7 +252,7 @@ public class TopologyWebSocketBehavior extends WebSocketBehavior {
         }
     }
 
-    abstract class Checker implements Callable<String> {
+    abstract static class Checker implements Callable<String> {
 
         protected final String key;
 

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/resources/AbstractMappingPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/resources/AbstractMappingPanel.java
@@ -22,7 +22,6 @@ import de.agilecoders.wicket.core.markup.html.bootstrap.components.PopoverBehavi
 import de.agilecoders.wicket.core.markup.html.bootstrap.components.PopoverConfig;
 import de.agilecoders.wicket.core.markup.html.bootstrap.components.TooltipConfig;
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.List;
 import org.apache.syncope.client.console.commons.ConnIdSpecialName;
 import org.apache.syncope.client.ui.commons.Constants;
@@ -121,7 +120,7 @@ public abstract class AbstractMappingPanel extends Panel {
 
         mappingContainer.add(Constants.getJEXLPopover(this, TooltipConfig.Placement.bottom));
 
-        Collections.sort(model.getObject(), (left, right) -> {
+        model.getObject().sort((left, right) -> {
             int compared;
             if (left == null && right == null) {
                 compared = 0;
@@ -142,17 +141,17 @@ public abstract class AbstractMappingPanel extends Panel {
             } else if (left.getPurpose() != MappingPurpose.BOTH && right.getPurpose() == MappingPurpose.BOTH) {
                 compared = 1;
             } else if (left.getPurpose() == MappingPurpose.PROPAGATION
-                    && (right.getPurpose() == MappingPurpose.PULL
-                    || right.getPurpose() == MappingPurpose.NONE)) {
+                && (right.getPurpose() == MappingPurpose.PULL
+                || right.getPurpose() == MappingPurpose.NONE)) {
                 compared = -1;
             } else if (left.getPurpose() == MappingPurpose.PULL
-                    && right.getPurpose() == MappingPurpose.PROPAGATION) {
+                && right.getPurpose() == MappingPurpose.PROPAGATION) {
                 compared = 1;
             } else if (left.getPurpose() == MappingPurpose.PULL
-                    && right.getPurpose() == MappingPurpose.NONE) {
+                && right.getPurpose() == MappingPurpose.NONE) {
                 compared = -1;
             } else if (left.getPurpose() == MappingPurpose.NONE
-                    && right.getPurpose() != MappingPurpose.NONE) {
+                && right.getPurpose() != MappingPurpose.NONE) {
                 compared = 1;
             } else {
                 compared = left.getIntAttrName().compareTo(right.getIntAttrName());

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/resources/ConnectorConfPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/resources/ConnectorConfPanel.java
@@ -18,7 +18,6 @@
  */
 package org.apache.syncope.client.console.wizards.resources;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.syncope.common.lib.to.ConnBundleTO;
@@ -46,7 +45,7 @@ public abstract class ConnectorConfPanel extends AbstractConnConfPanel<ConnInsta
                 ConnectorConfPanel.this.modelObject.getConf().clear();
 
                 // re-order properties
-                Collections.sort(properties, (o1, o2) -> {
+                properties.sort((o1, o2) -> {
                     if (o1 == null) {
                         return -1;
                     } else {

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/resources/ProvisionWizardBuilder.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/resources/ProvisionWizardBuilder.java
@@ -133,7 +133,7 @@ public class ProvisionWizardBuilder extends BaseAjaxWizardBuilder<ResourceProvis
     /**
      * AccountLink specification step.
      */
-    private final class ConnObjectLink extends WizardStep {
+    private static final class ConnObjectLink extends WizardStep {
 
         private static final long serialVersionUID = 2359955465172450478L;
 

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/resources/ResourceConnConfPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/resources/ResourceConnConfPanel.java
@@ -19,7 +19,6 @@
 package org.apache.syncope.client.console.wizards.resources;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,7 +57,7 @@ public abstract class ResourceConnConfPanel extends AbstractConnConfPanel<Resour
                         List<ConnConfProperty> res = new ArrayList<>(super.getObject());
 
                         // re-order properties
-                        Collections.sort(res, (left, right) -> {
+                        res.sort((left, right) -> {
                             if (left == null) {
                                 return -1;
                             } else {

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/resources/ResourceProvisionPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/resources/ResourceProvisionPanel.java
@@ -20,7 +20,6 @@ package org.apache.syncope.client.console.wizards.resources;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -301,8 +300,7 @@ public class ResourceProvisionPanel extends AbstractModalPanel<Serializable> {
     }
 
     private void sortProvisions() {
-        Collections.sort(provisions,
-                (o1, o2) -> AnyTypeRestClient.KEY_COMPARATOR.compare(o1.getAnyType(), o2.getAnyType()));
+        provisions.sort((o1, o2) -> AnyTypeRestClient.KEY_COMPARATOR.compare(o1.getAnyType(), o2.getAnyType()));
     }
 
     private LoadableDetachableModel<List<String>> getAnyTypes() {
@@ -319,7 +317,7 @@ public class ResourceProvisionPanel extends AbstractModalPanel<Serializable> {
                     anyTypes.add(SyncopeConstants.REALM_ANYTYPE);
                 }
 
-                Collections.sort(anyTypes, AnyTypeRestClient.KEY_COMPARATOR);
+                anyTypes.sort(AnyTypeRestClient.KEY_COMPARATOR);
                 return anyTypes;
             }
         };

--- a/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/HttpResourceStream.java
+++ b/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/HttpResourceStream.java
@@ -57,7 +57,7 @@ public class HttpResourceStream extends AbstractResourceStream implements IFixed
             String contentDisposition = response.getHeaderString(HttpHeaders.CONTENT_DISPOSITION);
             if (StringUtils.isNotBlank(contentDisposition)) {
                 String[] splitted = contentDisposition.split("=");
-                if (splitted != null && splitted.length > 1) {
+                if (splitted.length > 1) {
                     this.filename = splitted[1].trim();
                 }
             }

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/commons/AnyDataProvider.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/commons/AnyDataProvider.java
@@ -19,7 +19,8 @@
 package org.apache.syncope.client.console.commons;
 
 import org.apache.syncope.client.ui.commons.DirectoryDataProvider;
-import java.util.Collections;
+
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
@@ -93,14 +94,14 @@ public class AnyDataProvider<A extends AnyTO> extends DirectoryDataProvider<A> {
 
     @Override
     public Iterator<A> iterator(final long first, final long count) {
-        List<A> result = List.of();
+        List<A> result = new ArrayList<>();
 
         try {
-            final int page = ((int) first / paginatorRows);
+            final int page = (int) first / paginatorRows;
 
             if (filtered) {
                 result = fiql == null
-                        ? List.of()
+                        ? new ArrayList<>()
                         : restClient.search(realm, fiql, (page < 0 ? 0 : page) + 1, paginatorRows, getSort(), type);
             } else {
                 result = restClient.search(realm, null, (page < 0 ? 0 : page) + 1, paginatorRows, getSort(), type);
@@ -114,7 +115,7 @@ public class AnyDataProvider<A extends AnyTO> extends DirectoryDataProvider<A> {
                 ((BasePage) pageRef.getPage()).getNotificationPanel().refresh(ajaxRequestTarget));
         }
 
-        Collections.sort(result, comparator);
+        result.sort(comparator);
         return result.iterator();
     }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/init/ClassPathScanImplementationLookup.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/init/ClassPathScanImplementationLookup.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.ObjectUtils;
@@ -198,7 +199,7 @@ public class ClassPathScanImplementationLookup {
         scanner.findCandidateComponents(getBasePackage()).forEach(bd -> {
             try {
                 Class<?> clazz = ClassUtils.resolveClassName(
-                        bd.getBeanClassName(), ClassUtils.getDefaultClassLoader());
+                    Objects.requireNonNull(bd.getBeanClassName()), ClassUtils.getDefaultClassLoader());
                 boolean isAbstractClazz = Modifier.isAbstract(clazz.getModifiers());
                 if (!isAbstractClazz) {
                     if (BaseExtPage.class.isAssignableFrom(clazz)) {

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/notifications/MailTemplateDirectoryPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/notifications/MailTemplateDirectoryPanel.java
@@ -21,7 +21,6 @@ package org.apache.syncope.client.console.notifications;
 import de.agilecoders.wicket.core.markup.html.bootstrap.dialog.Modal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
@@ -206,7 +205,7 @@ public class MailTemplateDirectoryPanel
         @Override
         public Iterator<MailTemplateTO> iterator(final long first, final long count) {
             final List<MailTemplateTO> list = restClient.listTemplates();
-            Collections.sort(list, comparator);
+            list.sort(comparator);
             return list.subList((int) first, (int) first + (int) count).iterator();
         }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/notifications/NotificationDirectoryPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/notifications/NotificationDirectoryPanel.java
@@ -22,7 +22,6 @@ import de.agilecoders.wicket.core.markup.html.bootstrap.dialog.Modal;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
@@ -167,7 +166,7 @@ public class NotificationDirectoryPanel
         return List.of();
     }
 
-    protected class NotificationProvider extends DirectoryDataProvider<NotificationTO> {
+    protected static class NotificationProvider extends DirectoryDataProvider<NotificationTO> {
 
         private static final long serialVersionUID = -276043813563988590L;
 
@@ -183,7 +182,7 @@ public class NotificationDirectoryPanel
         @Override
         public Iterator<NotificationTO> iterator(final long first, final long count) {
             List<NotificationTO> list = NotificationRestClient.list();
-            Collections.sort(list, comparator);
+            list.sort(comparator);
             return list.subList((int) first, (int) first + (int) count).iterator();
         }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/notifications/NotificationWizardBuilder.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/notifications/NotificationWizardBuilder.java
@@ -156,7 +156,7 @@ public class NotificationWizardBuilder extends BaseAjaxWizardBuilder<Notificatio
 
     }
 
-    public class Events extends WizardStep {
+    public static class Events extends WizardStep {
 
         private static final long serialVersionUID = -7709805590497687958L;
 
@@ -184,7 +184,7 @@ public class NotificationWizardBuilder extends BaseAjaxWizardBuilder<Notificatio
 
     }
 
-    public class About extends Panel {
+    public static class About extends Panel {
 
         private static final long serialVersionUID = -9149543787708482882L;
 
@@ -323,7 +323,7 @@ public class NotificationWizardBuilder extends BaseAjaxWizardBuilder<Notificatio
         }
     }
 
-    public class Recipients extends WizardStep {
+    public static class Recipients extends WizardStep {
 
         private static final long serialVersionUID = -7709805590497687958L;
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/AccessTokenDirectoryPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/AccessTokenDirectoryPanel.java
@@ -157,7 +157,7 @@ public class AccessTokenDirectoryPanel
         }
     }
 
-    protected class AccessTokenDataProvider extends DirectoryDataProvider<AccessTokenTO> {
+    protected static class AccessTokenDataProvider extends DirectoryDataProvider<AccessTokenTO> {
 
         private static final long serialVersionUID = 6267494272884913376L;
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/AnyTypeClassesPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/AnyTypeClassesPanel.java
@@ -22,7 +22,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -103,7 +102,7 @@ public class AnyTypeClassesPanel extends TypesDirectoryPanel<
 
     @Override
     protected AnyTypeClassesPanel.AnyTypeClassProvider dataProvider() {
-        return new AnyTypeClassesPanel.AnyTypeClassProvider(rows);
+        return new AnyTypeClassProvider(rows);
     }
 
     @Override
@@ -193,7 +192,7 @@ public class AnyTypeClassesPanel extends TypesDirectoryPanel<
         return panel;
     }
 
-    protected final class AnyTypeClassProvider extends DirectoryDataProvider<AnyTypeClassTO> {
+    protected static final class AnyTypeClassProvider extends DirectoryDataProvider<AnyTypeClassTO> {
 
         private static final long serialVersionUID = -185944053385660794L;
 
@@ -207,7 +206,7 @@ public class AnyTypeClassesPanel extends TypesDirectoryPanel<
         @Override
         public Iterator<AnyTypeClassTO> iterator(final long first, final long count) {
             final List<AnyTypeClassTO> list = AnyTypeClassRestClient.list();
-            Collections.sort(list, comparator);
+            list.sort(comparator);
             return list.subList((int) first, (int) first + (int) count).iterator();
         }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/AnyTypesPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/AnyTypesPanel.java
@@ -22,7 +22,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -193,7 +192,7 @@ public class AnyTypesPanel extends TypesDirectoryPanel<AnyTypeTO, AnyTypesPanel.
         return panel;
     }
 
-    protected final class AnyTypeProvider extends DirectoryDataProvider<AnyTypeTO> {
+    protected static final class AnyTypeProvider extends DirectoryDataProvider<AnyTypeTO> {
 
         private static final long serialVersionUID = -185944053385660794L;
 
@@ -207,7 +206,7 @@ public class AnyTypesPanel extends TypesDirectoryPanel<AnyTypeTO, AnyTypesPanel.
         @Override
         public Iterator<AnyTypeTO> iterator(final long first, final long count) {
             final List<AnyTypeTO> list = AnyTypeRestClient.listAnyTypes();
-            Collections.sort(list, comparator);
+            list.sort(comparator);
             return list.subList((int) first, (int) first + (int) count).iterator();
         }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/ApplicationDirectoryPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/ApplicationDirectoryPanel.java
@@ -21,7 +21,6 @@ package org.apache.syncope.client.console.panels;
 import de.agilecoders.wicket.core.markup.html.bootstrap.dialog.Modal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -230,7 +229,7 @@ public class ApplicationDirectoryPanel extends
         }
     }
 
-    protected class ApplicationDataProvider extends DirectoryDataProvider<ApplicationTO> {
+    protected static class ApplicationDataProvider extends DirectoryDataProvider<ApplicationTO> {
 
         private static final long serialVersionUID = 3124431855954382273L;
 
@@ -244,7 +243,7 @@ public class ApplicationDirectoryPanel extends
         @Override
         public Iterator<ApplicationTO> iterator(final long first, final long count) {
             List<ApplicationTO> result = ApplicationRestClient.list();
-            Collections.sort(result, comparator);
+            result.sort(comparator);
             return result.subList((int) first, (int) first + (int) count).iterator();
         }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/ConsoleLogPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/ConsoleLogPanel.java
@@ -20,7 +20,6 @@ package org.apache.syncope.client.console.panels;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.logging.log4j.LogManager;
@@ -64,7 +63,7 @@ public class ConsoleLogPanel extends AbstractLogsPanel<LoggerTO> {
                     result.add(loggerTO);
                 }
             });
-            Collections.sort(result, (o1, o2) -> ObjectUtils.compare(o1.getKey(), o2.getKey()));
+            result.sort((o1, o2) -> ObjectUtils.compare(o1.getKey(), o2.getKey()));
 
             return result;
         }

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/DomainDirectoryPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/DomainDirectoryPanel.java
@@ -21,7 +21,6 @@ package org.apache.syncope.client.console.panels;
 import de.agilecoders.wicket.core.markup.html.bootstrap.dialog.Modal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
@@ -183,7 +182,7 @@ public class DomainDirectoryPanel extends DirectoryPanel<Domain, Domain, DomainP
         @Override
         public Iterator<? extends Domain> iterator(final long first, final long count) {
             List<Domain> list = domainOps.list();
-            Collections.sort(list, comparator);
+            list.sort(comparator);
             return list.subList((int) first, (int) first + (int) count).iterator();
         }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/DomainWizardBuilder.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/DomainWizardBuilder.java
@@ -83,7 +83,7 @@ public class DomainWizardBuilder extends BaseAjaxWizardBuilder<Domain> {
         return wizardModel;
     }
 
-    public class Storage extends WizardStep {
+    public static class Storage extends WizardStep {
 
         private static final long serialVersionUID = 3671044119870133102L;
 
@@ -155,7 +155,7 @@ public class DomainWizardBuilder extends BaseAjaxWizardBuilder<Domain> {
         }
     }
 
-    public class AdminCredentials extends WizardStep {
+    public static class AdminCredentials extends WizardStep {
 
         private static final long serialVersionUID = -7472243942630790243L;
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/DynRealmDirectoryPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/DynRealmDirectoryPanel.java
@@ -21,7 +21,6 @@ package org.apache.syncope.client.console.panels;
 import de.agilecoders.wicket.core.markup.html.bootstrap.dialog.Modal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
@@ -176,7 +175,7 @@ public class DynRealmDirectoryPanel extends
         }
     }
 
-    protected class DynRealmDataProvider extends DirectoryDataProvider<DynRealmTO> {
+    protected static class DynRealmDataProvider extends DirectoryDataProvider<DynRealmTO> {
 
         private static final long serialVersionUID = 3124431855954382273L;
 
@@ -190,7 +189,7 @@ public class DynRealmDirectoryPanel extends
         @Override
         public Iterator<DynRealmTO> iterator(final long first, final long count) {
             List<DynRealmTO> result = DynRealmRestClient.list();
-            Collections.sort(result, comparator);
+            result.sort(comparator);
             return result.subList((int) first, (int) first + (int) count).iterator();
         }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/ImplementationDirectoryPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/ImplementationDirectoryPanel.java
@@ -21,7 +21,6 @@ package org.apache.syncope.client.console.panels;
 import de.agilecoders.wicket.core.markup.html.bootstrap.dialog.Modal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
@@ -205,7 +204,7 @@ public class ImplementationDirectoryPanel extends DirectoryPanel<
         @Override
         public Iterator<ImplementationTO> iterator(final long first, final long count) {
             List<ImplementationTO> list = ImplementationRestClient.list(type);
-            Collections.sort(list, comparator);
+            list.sort(comparator);
             return list.subList((int) first, (int) first + (int) count).iterator();
         }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/ParametersDirectoryPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/ParametersDirectoryPanel.java
@@ -202,7 +202,7 @@ public class ParametersDirectoryPanel
                         return param;
                     }).collect(Collectors.toList());
 
-            Collections.sort(list, comparator);
+            list.sort(comparator);
             return list.iterator();
         }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/PrivilegeDirectoryPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/PrivilegeDirectoryPanel.java
@@ -20,7 +20,6 @@ package org.apache.syncope.client.console.panels;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
@@ -161,7 +160,7 @@ public class PrivilegeDirectoryPanel extends DirectoryPanel<
         @Override
         public Iterator<PrivilegeTO> iterator(final long first, final long count) {
             List<PrivilegeTO> list = application.getPrivileges();
-            Collections.sort(list, comparator);
+            list.sort(comparator);
             return list.subList((int) first, (int) first + (int) count).iterator();
         }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/PrivilegeWizardBuilder.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/PrivilegeWizardBuilder.java
@@ -62,7 +62,7 @@ public class PrivilegeWizardBuilder extends BaseAjaxWizardBuilder<PrivilegeTO> {
         return modelObject;
     }
 
-    public class Profile extends WizardStep {
+    public static class Profile extends WizardStep {
 
         private static final long serialVersionUID = 11881843064077955L;
 
@@ -84,7 +84,7 @@ public class PrivilegeWizardBuilder extends BaseAjaxWizardBuilder<PrivilegeTO> {
         }
     }
 
-    public class Spec extends WizardStep {
+    public static class Spec extends WizardStep {
 
         private static final long serialVersionUID = -3237113253888332643L;
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/Realm.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/Realm.java
@@ -288,7 +288,7 @@ public abstract class Realm extends WizardMgtPanel<RealmTO> {
 
     protected abstract void onClickDelete(AjaxRequestTarget target, RealmTO realmTO);
 
-    class RemoteRealmPanel extends RemoteObjectPanel {
+    static class RemoteRealmPanel extends RemoteObjectPanel {
 
         private static final long serialVersionUID = 4303365227411467563L;
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/RelationshipTypesPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/RelationshipTypesPanel.java
@@ -22,7 +22,6 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -195,7 +194,7 @@ public class RelationshipTypesPanel extends TypesDirectoryPanel<
         return panel;
     }
 
-    protected final class RelationshipTypeProvider extends DirectoryDataProvider<RelationshipTypeTO> {
+    protected static final class RelationshipTypeProvider extends DirectoryDataProvider<RelationshipTypeTO> {
 
         private static final long serialVersionUID = -185944053385660794L;
 
@@ -209,7 +208,7 @@ public class RelationshipTypesPanel extends TypesDirectoryPanel<
         @Override
         public Iterator<RelationshipTypeTO> iterator(final long first, final long count) {
             final List<RelationshipTypeTO> list = RelationshipTypeRestClient.list();
-            Collections.sort(list, comparator);
+            list.sort(comparator);
             return list.subList((int) first, (int) first + (int) count).iterator();
         }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/RoleDirectoryPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/RoleDirectoryPanel.java
@@ -278,7 +278,7 @@ public class RoleDirectoryPanel extends DirectoryPanel<RoleTO, RoleWrapper, Role
         }
     }
 
-    protected class RoleDataProvider extends DirectoryDataProvider<RoleTO> {
+    protected static class RoleDataProvider extends DirectoryDataProvider<RoleTO> {
 
         private static final long serialVersionUID = 6267494272884913376L;
 
@@ -292,7 +292,7 @@ public class RoleDirectoryPanel extends DirectoryPanel<RoleTO, RoleWrapper, Role
         @Override
         public Iterator<RoleTO> iterator(final long first, final long count) {
             List<RoleTO> result = RoleRestClient.list();
-            Collections.sort(result, comparator);
+            result.sort(comparator);
             return result.subList((int) first, (int) first + (int) count).iterator();
         }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/SchemaTypePanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/SchemaTypePanel.java
@@ -22,7 +22,6 @@ import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -221,7 +220,7 @@ public class SchemaTypePanel extends TypesDirectoryPanel<SchemaTO, SchemaProvide
         @Override
         public Iterator<SchemaTO> iterator(final long first, final long count) {
             List<SchemaTO> schemas = SchemaRestClient.getSchemas(this.schemaType, keyword);
-            Collections.sort(schemas, comparator);
+            schemas.sort(comparator);
 
             return schemas.subList((int) first, (int) first + (int) count).iterator();
         }

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/SecurityQuestionsPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/SecurityQuestionsPanel.java
@@ -21,7 +21,6 @@ package org.apache.syncope.client.console.panels;
 import de.agilecoders.wicket.core.markup.html.bootstrap.dialog.Modal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
@@ -173,7 +172,7 @@ public class SecurityQuestionsPanel extends DirectoryPanel<
         return panel;
     }
 
-    protected final class SecurityQuestionsProvider extends DirectoryDataProvider<SecurityQuestionTO> {
+    protected static final class SecurityQuestionsProvider extends DirectoryDataProvider<SecurityQuestionTO> {
 
         private static final long serialVersionUID = -185944053385660794L;
 
@@ -187,7 +186,7 @@ public class SecurityQuestionsPanel extends DirectoryPanel<
         @Override
         public Iterator<SecurityQuestionTO> iterator(final long first, final long count) {
             final List<SecurityQuestionTO> list = SecurityQuestionRestClient.list();
-            Collections.sort(list, comparator);
+            list.sort(comparator);
             return list.subList((int) first, (int) first + (int) count).iterator();
         }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/search/SearchClausePanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/search/SearchClausePanel.java
@@ -838,7 +838,7 @@ public class SearchClausePanel extends FieldPanel<SearchClause> {
         return panel;
     }
 
-    private class DefaultChoiceRender implements IChoiceRenderer<String> {
+    private static class DefaultChoiceRender implements IChoiceRenderer<String> {
 
         private static final long serialVersionUID = -8034248752951761058L;
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/policies/PolicyDirectoryPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/policies/PolicyDirectoryPanel.java
@@ -225,7 +225,7 @@ public abstract class PolicyDirectoryPanel<T extends PolicyTO>
         @Override
         public Iterator<T> iterator(final long first, final long count) {
             List<T> list = PolicyRestClient.getPolicies(type);
-            Collections.sort(list, comparator);
+            list.sort(comparator);
             return list.subList((int) first, (int) first + (int) count).iterator();
         }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/policies/PolicyRuleDirectoryPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/policies/PolicyRuleDirectoryPanel.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -261,9 +260,9 @@ public class PolicyRuleDirectoryPanel<T extends PolicyTO> extends DirectoryPanel
 
             List<PolicyRuleWrapper> rules = actual instanceof ComposablePolicy
                     ? getPolicyRuleWrappers((ComposablePolicy) actual)
-                    : List.of();
+                    : new ArrayList<>();
 
-            Collections.sort(rules, comparator);
+            rules.sort(comparator);
             return rules.subList((int) first, (int) (first + count)).iterator();
         }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/policies/PolicyRuleWizardBuilder.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/policies/PolicyRuleWizardBuilder.java
@@ -170,7 +170,7 @@ public class PolicyRuleWizardBuilder extends BaseAjaxWizardBuilder<PolicyRuleWra
         }
     }
 
-    public class Configuration extends WizardStep {
+    public static class Configuration extends WizardStep {
 
         private static final long serialVersionUID = -785981096328637758L;
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/reports/ReportDirectoryPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/reports/ReportDirectoryPanel.java
@@ -21,7 +21,6 @@ package org.apache.syncope.client.console.reports;
 import de.agilecoders.wicket.core.markup.html.bootstrap.dialog.Modal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.lang3.SerializationUtils;
@@ -280,7 +279,7 @@ public abstract class ReportDirectoryPanel
 
     protected abstract void viewReport(ReportTO reportTO, AjaxRequestTarget target);
 
-    protected class ReportDataProvider extends DirectoryDataProvider<ReportTO> {
+    protected static class ReportDataProvider extends DirectoryDataProvider<ReportTO> {
 
         private static final long serialVersionUID = 4725679400450513556L;
 
@@ -296,7 +295,7 @@ public abstract class ReportDirectoryPanel
         @Override
         public Iterator<ReportTO> iterator(final long first, final long count) {
             List<ReportTO> list = ReportRestClient.list();
-            Collections.sort(list, comparator);
+            list.sort(comparator);
             return list.subList((int) first, (int) first + (int) count).iterator();
         }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/reports/ReportTemplateDirectoryPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/reports/ReportTemplateDirectoryPanel.java
@@ -21,7 +21,6 @@ package org.apache.syncope.client.console.reports;
 import de.agilecoders.wicket.core.markup.html.bootstrap.dialog.Modal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
@@ -226,7 +225,7 @@ public class ReportTemplateDirectoryPanel
         @Override
         public Iterator<ReportTemplateTO> iterator(final long first, final long count) {
             List<ReportTemplateTO> list = restClient.listTemplates();
-            Collections.sort(list, comparator);
+            list.sort(comparator);
             return list.subList((int) first, (int) first + (int) count).iterator();
         }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/reports/ReportletDirectoryPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/reports/ReportletDirectoryPanel.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -247,7 +246,7 @@ public class ReportletDirectoryPanel extends DirectoryPanel<
 
             List<ReportletWrapper> reportlets = getReportletWrappers(actual);
 
-            Collections.sort(reportlets, comparator);
+            reportlets.sort(comparator);
             return reportlets.subList((int) first, (int) (first + count)).iterator();
         }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/reports/ReportletWizardBuilder.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/reports/ReportletWizardBuilder.java
@@ -87,7 +87,7 @@ public class ReportletWizardBuilder extends BaseAjaxWizardBuilder<ReportletWrapp
         return wizardModel;
     }
 
-    public class Profile extends WizardStep {
+    public static class Profile extends WizardStep {
 
         private static final long serialVersionUID = -3043839139187792810L;
 
@@ -123,7 +123,7 @@ public class ReportletWizardBuilder extends BaseAjaxWizardBuilder<ReportletWrapp
         }
     }
 
-    public class Configuration extends WizardStep {
+    public static class Configuration extends WizardStep {
 
         private static final long serialVersionUID = -785981096328637758L;
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/rest/AnyTypeRestClient.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/rest/AnyTypeRestClient.java
@@ -19,7 +19,6 @@
 package org.apache.syncope.client.console.rest;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import org.apache.commons.lang3.ObjectUtils;
@@ -52,7 +51,7 @@ public class AnyTypeRestClient extends BaseRestClient {
 
         try {
             types = getService(AnyTypeService.class).list();
-            Collections.sort(types, new AnyTypeComparator());
+            types.sort(new AnyTypeComparator());
         } catch (SyncopeClientException e) {
             LOG.error("While reading all any types", e);
         }
@@ -62,7 +61,7 @@ public class AnyTypeRestClient extends BaseRestClient {
 
     public static List<String> list() {
         List<String> types = getSyncopeService().platform().getAnyTypes();
-        Collections.sort(types, new AnyTypeKeyComparator());
+        types.sort(new AnyTypeKeyComparator());
         return types;
     }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/rest/LoggerRestClient.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/rest/LoggerRestClient.java
@@ -19,7 +19,6 @@
 package org.apache.syncope.client.console.rest;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -57,7 +56,7 @@ public class LoggerRestClient extends BaseRestClient {
 
     public static List<LoggerTO> listLogs() {
         List<LoggerTO> logs = getService(LoggerService.class).list(LoggerType.LOG);
-        Collections.sort(logs, (o1, o2) -> ObjectUtils.compare(o1.getKey(), o2.getKey()));
+        logs.sort((o1, o2) -> ObjectUtils.compare(o1.getKey(), o2.getKey()));
 
         return logs;
     }

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/tasks/NotificationTaskDirectoryPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/tasks/NotificationTaskDirectoryPanel.java
@@ -195,7 +195,7 @@ public abstract class NotificationTaskDirectoryPanel
         return IdRepoConstants.PREF_NOTIFICATION_TASKS_PAGINATOR_ROWS;
     }
 
-    protected class NotificationTasksProvider extends TaskDataProvider<NotificationTaskTO> {
+    protected static class NotificationTasksProvider extends TaskDataProvider<NotificationTaskTO> {
 
         private static final long serialVersionUID = 4725679400450513556L;
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/tasks/SchedTaskDirectoryPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/tasks/SchedTaskDirectoryPanel.java
@@ -293,7 +293,7 @@ public abstract class SchedTaskDirectoryPanel<T extends SchedTaskTO>
         return new SchedTasksProvider<>(reference, taskType, rows);
     }
 
-    protected class SchedTasksProvider<T extends SchedTaskTO> extends TaskDataProvider<T> {
+    protected static class SchedTasksProvider<T extends SchedTaskTO> extends TaskDataProvider<T> {
 
         private static final long serialVersionUID = 4725679400450513556L;
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/tasks/TaskDirectoryPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/tasks/TaskDirectoryPanel.java
@@ -65,7 +65,7 @@ public abstract class TaskDirectoryPanel<T extends TaskTO>
 
     protected abstract void viewTask(T taskTO, AjaxRequestTarget target);
 
-    protected abstract class TasksProvider<T extends TaskTO> extends DirectoryDataProvider<T> {
+    protected abstract static class TasksProvider<T extends TaskTO> extends DirectoryDataProvider<T> {
 
         private static final long serialVersionUID = -20112718133295756L;
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wicket/extensions/markup/html/repeater/data/table/BatchResponseColumn.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wicket/extensions/markup/html/repeater/data/table/BatchResponseColumn.java
@@ -20,6 +20,9 @@ package org.apache.syncope.client.console.wicket.extensions.markup.html.repeater
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Map;
+import java.util.Objects;
+
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.syncope.common.lib.types.ExecStatus;
 import org.apache.wicket.Component;
 import org.apache.wicket.extensions.markup.html.repeater.data.grid.ICellPopulator;
@@ -60,8 +63,9 @@ public class BatchResponseColumn<T, S> extends AbstractColumn<T, S> {
     @Override
     public void populateItem(final Item<ICellPopulator<T>> item, final String componentId, final IModel<T> rowModel) {
         try {
-            Object key = BeanUtils.getPropertyDescriptor(rowModel.getObject().getClass(), keyFieldName).
-                    getReadMethod().invoke(rowModel.getObject(), new Object[0]);
+            Object key = Objects.requireNonNull(
+                BeanUtils.getPropertyDescriptor(rowModel.getObject().getClass(), keyFieldName))
+                .getReadMethod().invoke(rowModel.getObject(), ArrayUtils.EMPTY_OBJECT_ARRAY);
             String status = results.containsKey(key.toString())
                     ? results.get(key.toString())
                     : ExecStatus.NOT_ATTEMPTED.name();

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wicket/extensions/markup/html/repeater/data/table/BooleanPropertyColumn.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wicket/extensions/markup/html/repeater/data/table/BooleanPropertyColumn.java
@@ -28,6 +28,8 @@ import org.apache.wicket.model.IModel;
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.BeanWrapperImpl;
 
+import java.util.Objects;
+
 /**
  * Format column's value as boolean.
  */
@@ -47,7 +49,7 @@ public class BooleanPropertyColumn<T> extends PropertyColumn<T, String> {
         Object obj = bwi.getPropertyValue(getPropertyExpression());
 
         item.add(new Label(componentId, StringUtils.EMPTY));
-        if (Boolean.valueOf(obj.toString())) {
+        if (Boolean.parseBoolean(Objects.requireNonNull(obj).toString())) {
             item.add(new AttributeModifier("class", "glyphicon glyphicon-ok"));
             item.add(new AttributeModifier("style", "display: table-cell; text-align: center;"));
         }

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wicket/extensions/markup/html/repeater/data/table/KeyPropertyColumn.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wicket/extensions/markup/html/repeater/data/table/KeyPropertyColumn.java
@@ -29,6 +29,8 @@ import org.apache.wicket.model.IModel;
 import org.springframework.beans.BeanWrapper;
 import org.springframework.beans.BeanWrapperImpl;
 
+import java.util.Objects;
+
 /**
  * Format column's UUID value.
  */
@@ -52,7 +54,7 @@ public class KeyPropertyColumn<T> extends PropertyColumn<T, String> {
         Object obj = bwi.getPropertyValue(getPropertyExpression());
 
         item.add(new Label(componentId, StringUtils.EMPTY));
-        item.add(new AttributeModifier("title", obj.toString()));
+        item.add(new AttributeModifier("title", Objects.requireNonNull(obj).toString()));
         item.add(new AttributeModifier("class", "fa fa-key"));
         item.add(new AttributeModifier("style", "display: table-cell; text-align: center;"));
     }

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/widgets/JobWidget.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/widgets/JobWidget.java
@@ -23,7 +23,6 @@ import de.agilecoders.wicket.core.markup.html.bootstrap.tabs.AjaxBootstrapTabbed
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
@@ -566,7 +565,7 @@ public class JobWidget extends BaseWidget {
 
         @Override
         public Iterator<JobTO> iterator(final long first, final long count) {
-            Collections.sort(available, comparator);
+            available.sort(comparator);
             return available.subList((int) first, (int) first + (int) count).iterator();
         }
 
@@ -664,7 +663,7 @@ public class JobWidget extends BaseWidget {
 
             @Override
             public Iterator<ExecTO> iterator(final long first, final long count) {
-                Collections.sort(recent, comparator);
+                recent.sort(comparator);
                 return recent.subList((int) first, (int) first + (int) count).iterator();
             }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/widgets/ReconDetailsModalPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/widgets/ReconDetailsModalPanel.java
@@ -20,7 +20,6 @@ package org.apache.syncope.client.console.widgets;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
@@ -161,7 +160,7 @@ public class ReconDetailsModalPanel extends AbstractModalPanel<Any> {
 
         @Override
         public Iterator<Misaligned> iterator(final long first, final long count) {
-            Collections.sort(misaligned, comparator);
+            misaligned.sort(comparator);
             return misaligned.subList((int) first, (int) first + (int) count).iterator();
         }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/widgets/ReconciliationWidget.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/widgets/ReconciliationWidget.java
@@ -401,7 +401,7 @@ public class ReconciliationWidget extends BaseWidget {
 
                         Component content;
                         if (missing.isEmpty()) {
-                            if (misaligned == null || misaligned.isEmpty()) {
+                            if (misaligned.isEmpty()) {
                                 content = new Label(componentId, StringUtils.EMPTY);
                             } else {
                                 Action<Any> action = new Action<>(new ActionLink<Any>() {
@@ -441,7 +441,7 @@ public class ReconciliationWidget extends BaseWidget {
         }
     }
 
-    protected final class AnysReconciliationProvider extends DirectoryDataProvider<Any> {
+    protected static final class AnysReconciliationProvider extends DirectoryDataProvider<Any> {
 
         private static final long serialVersionUID = -1500081449932597854L;
 
@@ -458,7 +458,7 @@ public class ReconciliationWidget extends BaseWidget {
 
         @Override
         public Iterator<Any> iterator(final long first, final long count) {
-            Collections.sort(anys.getAnys(), comparator);
+            anys.getAnys().sort(comparator);
             return anys.getAnys().subList((int) first, (int) first + (int) count).iterator();
         }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/AbstractAttrs.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/AbstractAttrs.java
@@ -151,7 +151,7 @@ public abstract class AbstractAttrs<S extends SchemaTO> extends WizardStep imple
     private void setSchemas(final List<String> anyTypeClasses, final Map<String, S> scs) {
         final List<S> allSchemas;
         if (anyTypeClasses.isEmpty()) {
-            allSchemas = List.of();
+            allSchemas = new ArrayList<>();
         } else {
             allSchemas = SchemaRestClient.getSchemas(getSchemaType(), null, anyTypeClasses.toArray(new String[] {}));
         }
@@ -236,7 +236,7 @@ public abstract class AbstractAttrs<S extends SchemaTO> extends WizardStep imple
         }
     }
 
-    public class Schemas extends Panel {
+    public static class Schemas extends Panel {
 
         private static final long serialVersionUID = -2447602429647965090L;
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/StatusPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/StatusPanel.java
@@ -216,7 +216,7 @@ public class StatusPanel extends Panel {
         return null;
     }
 
-    class RemoteAnyPanel extends RemoteObjectPanel {
+    static class RemoteAnyPanel extends RemoteObjectPanel {
 
         private static final long serialVersionUID = 4303365227411467563L;
 

--- a/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/init/ClassPathScanImplementationLookup.java
+++ b/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/init/ClassPathScanImplementationLookup.java
@@ -22,6 +22,8 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.syncope.client.enduser.annotations.ExtPage;
 import org.apache.syncope.client.enduser.annotations.Resource;
@@ -80,7 +82,8 @@ public class ClassPathScanImplementationLookup {
 
         for (BeanDefinition bd : scanner.findCandidateComponents(getBasePackage())) {
             try {
-                Class<?> clazz = ClassUtils.resolveClassName(bd.getBeanClassName(), ClassUtils.getDefaultClassLoader());
+                Class<?> clazz = ClassUtils.resolveClassName(Objects.requireNonNull(bd.getBeanClassName()),
+                    ClassUtils.getDefaultClassLoader());
                 boolean isAbstractClazz = Modifier.isAbstract(clazz.getModifiers());
                 if (!isAbstractClazz) {
                     if (BaseExtPage.class.isAssignableFrom(clazz)) {

--- a/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/pages/SelfConfirmPasswordReset.java
+++ b/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/pages/SelfConfirmPasswordReset.java
@@ -69,7 +69,7 @@ public class SelfConfirmPasswordReset extends BaseEnduserWebPage {
     public SelfConfirmPasswordReset(final PageParameters parameters) {
         super(parameters);
 
-        if (parameters == null || parameters.get("token").isEmpty()) {
+        if (parameters != null || parameters.get("token").isEmpty()) {
             LOG.debug("No token parameter found in the request url");
             parameters.add("errorMessage", getString("self.confirm.pwd.reset.error.empty"));
             setResponsePage(getApplication().getHomePage(), parameters);

--- a/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/rest/AnyTypeRestClient.java
+++ b/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/rest/AnyTypeRestClient.java
@@ -19,7 +19,6 @@
 package org.apache.syncope.client.enduser.rest;
 
 import java.io.Serializable;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import org.apache.commons.lang3.ObjectUtils;
@@ -52,7 +51,7 @@ public class AnyTypeRestClient extends BaseRestClient {
 
         try {
             types = getService(AnyTypeService.class).list();
-            Collections.sort(types, new AnyTypeComparator());
+            types.sort(new AnyTypeComparator());
         } catch (SyncopeClientException e) {
             LOG.error("While reading all any types", e);
         }
@@ -62,7 +61,7 @@ public class AnyTypeRestClient extends BaseRestClient {
 
     public static List<String> list() {
         List<String> types = getSyncopeService().platform().getAnyTypes();
-        Collections.sort(types, new AnyTypeKeyComparator());
+        types.sort(new AnyTypeKeyComparator());
         return types;
     }
 

--- a/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/wizards/any/AbstractAttrs.java
+++ b/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/wizards/any/AbstractAttrs.java
@@ -167,7 +167,7 @@ public abstract class AbstractAttrs<S extends SchemaTO> extends WizardStep imple
     private void setSchemas(final List<String> anyTypeClasses, final String groupName, final Map<String, S> scs) {
         final List<S> allSchemas;
         if (anyTypeClasses.isEmpty()) {
-            allSchemas = List.of();
+            allSchemas = new ArrayList<>();
         } else {
             allSchemas = SchemaRestClient.getSchemas(getSchemaType(), null, anyTypeClasses.toArray(new String[] {}));
         }
@@ -253,7 +253,7 @@ public abstract class AbstractAttrs<S extends SchemaTO> extends WizardStep imple
         }
     }
 
-    public class Schemas extends Panel {
+    public static class Schemas extends Panel {
 
         private static final long serialVersionUID = -2447602429647965090L;
 

--- a/common/idrepo/lib/src/main/java/org/apache/syncope/common/lib/info/PlatformInfo.java
+++ b/common/idrepo/lib/src/main/java/org/apache/syncope/common/lib/info/PlatformInfo.java
@@ -39,7 +39,7 @@ public class PlatformInfo implements Serializable {
 
     @XmlRootElement(name = "provisioningInfo")
     @XmlType
-    public class ProvisioningInfo implements Serializable {
+    public static class ProvisioningInfo implements Serializable {
 
         private static final long serialVersionUID = 533340357732839568L;
 
@@ -116,7 +116,7 @@ public class PlatformInfo implements Serializable {
 
     @XmlRootElement(name = "workflowInfo")
     @XmlType
-    public class WorkflowInfo implements Serializable {
+    public static class WorkflowInfo implements Serializable {
 
         private static final long serialVersionUID = 6736937721099195324L;
 
@@ -153,7 +153,7 @@ public class PlatformInfo implements Serializable {
 
     @XmlRootElement(name = "persistenceInfo")
     @XmlType
-    public class PersistenceInfo implements Serializable {
+    public static class PersistenceInfo implements Serializable {
 
         private static final long serialVersionUID = 2902980556801069487L;
 

--- a/common/idrepo/lib/src/main/java/org/apache/syncope/common/lib/search/GroupFiqlSearchConditionBuilder.java
+++ b/common/idrepo/lib/src/main/java/org/apache/syncope/common/lib/search/GroupFiqlSearchConditionBuilder.java
@@ -58,7 +58,7 @@ public class GroupFiqlSearchConditionBuilder extends AbstractFiqlSearchCondition
                 withoutMembers(member, moreMembers);
     }
 
-    protected class Builder extends AbstractFiqlSearchConditionBuilder.Builder
+    protected static class Builder extends AbstractFiqlSearchConditionBuilder.Builder
             implements GroupProperty, CompleteCondition {
 
         public Builder(final Map<String, String> properties) {

--- a/core/idrepo/logic/src/main/java/org/apache/syncope/core/logic/init/ClassPathScanImplementationLookup.java
+++ b/core/idrepo/logic/src/main/java/org/apache/syncope/core/logic/init/ClassPathScanImplementationLookup.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.syncope.common.lib.policy.AccountRuleConf;
 import org.apache.syncope.common.lib.policy.PasswordRuleConf;
@@ -130,7 +131,7 @@ public class ClassPathScanImplementationLookup implements ImplementationLookup {
         scanner.findCandidateComponents(getBasePackage()).forEach(bd -> {
             try {
                 Class<?> clazz = ClassUtils.resolveClassName(
-                        bd.getBeanClassName(), ClassUtils.getDefaultClassLoader());
+                    Objects.requireNonNull(bd.getBeanClassName()), ClassUtils.getDefaultClassLoader());
                 boolean isAbstractClazz = Modifier.isAbstract(clazz.getModifiers());
 
                 if (JWTSSOProvider.class.isAssignableFrom(clazz) && !isAbstractClazz) {

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/JavaDocUtils.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/JavaDocUtils.java
@@ -22,6 +22,8 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.core.env.Environment;
 import org.springframework.util.ClassUtils;
@@ -52,7 +54,7 @@ public final class JavaDocUtils {
         String[] result = null;
 
         if (env.containsProperty("javadocPaths")) {
-            result = env.getProperty("javadocPaths").split(",");
+            result = Objects.requireNonNull(env.getProperty("javadocPaths")).split(",");
         }
 
         return result;

--- a/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/dao/search/SearchCond.java
+++ b/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/dao/search/SearchCond.java
@@ -275,7 +275,7 @@ public class SearchCond extends AbstractSearchCond {
         String anyTypeName = null;
 
         if (type == null) {
-            return anyTypeName;
+            return null;
         }
 
         switch (type) {
@@ -363,7 +363,7 @@ public class SearchCond extends AbstractSearchCond {
         boolean isValid = false;
 
         if (type == null) {
-            return isValid;
+            return false;
         }
 
         switch (type) {

--- a/core/persistence-jpa-json/src/main/java/org/apache/syncope/core/persistence/jpa/dao/AbstractJPAJSONAnyDAO.java
+++ b/core/persistence-jpa-json/src/main/java/org/apache/syncope/core/persistence/jpa/dao/AbstractJPAJSONAnyDAO.java
@@ -20,7 +20,6 @@ package org.apache.syncope.core.persistence.jpa.dao;
 
 import java.io.StringReader;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -220,12 +219,12 @@ abstract class AbstractJPAJSONAnyDAO extends AbstractDAO<AbstractEntity> impleme
         }
 
         // Sort literals in order to process later literals included into others
-        Collections.sort(literals, (l1, l2) -> {
+        literals.sort((l1, l2) -> {
             if (l1 == null && l2 == null) {
                 return 0;
             } else if (l1 != null && l2 == null) {
                 return -1;
-            } else if (l1 == null && l2 != null) {
+            } else if (l1 == null) {
                 return 1;
             } else if (l1.length() == l2.length()) {
                 return 0;

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/DomainConfFactory.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/DomainConfFactory.java
@@ -23,6 +23,7 @@ import com.zaxxer.hikari.HikariDataSource;
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.persistence.EntityManagerFactory;
 import javax.sql.DataSource;
@@ -136,7 +137,8 @@ public class DomainConfFactory implements DomainRegistry, EnvironmentAware {
         if (env.containsProperty("openjpaMetaDataFactory")) {
             emf.addPropertyValue("jpaPropertyMap", Map.of(
                     "openjpa.MetaDataFactory",
-                    env.getProperty("openjpaMetaDataFactory").replace("##orm##", domain.getOrm())));
+                    Objects.requireNonNull(env.getProperty("openjpaMetaDataFactory"))
+                        .replace("##orm##", domain.getOrm())));
         }
         registerBeanDefinition(domain.getKey() + "EntityManagerFactory", emf.getBeanDefinition());
         ApplicationContextProvider.getBeanFactory().getBean(domain.getKey() + "EntityManagerFactory");

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/MasterDomain.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/MasterDomain.java
@@ -23,6 +23,7 @@ import com.zaxxer.hikari.HikariDataSource;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;
+import java.util.Objects;
 
 import javax.sql.DataSource;
 import org.apache.syncope.core.persistence.jpa.spring.CommonEntityManagerFactoryConf;
@@ -156,7 +157,7 @@ public class MasterDomain implements EnvironmentAware {
         if (env.containsProperty("openjpaMetaDataFactory")) {
             masterEntityManagerFactory.setJpaPropertyMap(Map.of(
                     "openjpa.MetaDataFactory",
-                    env.getProperty("openjpaMetaDataFactory").replace("##orm##", orm)));
+                    Objects.requireNonNull(env.getProperty("openjpaMetaDataFactory")).replace("##orm##", orm)));
         }
 
         return masterEntityManagerFactory;
@@ -165,7 +166,7 @@ public class MasterDomain implements EnvironmentAware {
     @Bean("MasterTransactionManager")
     @Qualifier("Master")
     public PlatformTransactionManager transactionManager() {
-        return new JpaTransactionManager(masterEntityManagerFactory().getObject());
+        return new JpaTransactionManager(Objects.requireNonNull(masterEntityManagerFactory().getObject()));
     }
 
     @Bean("MasterProperties")

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/content/ContentLoaderHandler.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/content/ContentLoaderHandler.java
@@ -22,6 +22,8 @@ import java.sql.Types;
 import java.text.ParseException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+
 import javax.sql.DataSource;
 import javax.xml.bind.DatatypeConverter;
 import org.apache.syncope.core.provisioning.api.utils.FormatUtils;
@@ -65,7 +67,7 @@ public class ContentLoaderHandler extends DefaultHandler {
 
         Object[] parameters = new Object[attrs.getLength()];
         for (int i = 0; i < attrs.getLength(); i++) {
-            Integer colType = colTypes.get(attrs.getQName(i).toUpperCase());
+            Integer colType = Objects.requireNonNull(colTypes).get(attrs.getQName(i).toUpperCase());
             if (colType == null) {
                 LOG.warn("No column type found for {}", attrs.getQName(i).toUpperCase());
                 colType = Types.VARCHAR;

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/AbstractAnyDAO.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/AbstractAnyDAO.java
@@ -21,7 +21,6 @@ package org.apache.syncope.core.persistence.jpa.dao;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -294,12 +293,12 @@ public abstract class AbstractAnyDAO<A extends Any<?>> extends AbstractDAO<A> im
         }
 
         // Sort literals in order to process later literals included into others
-        Collections.sort(literals, (l1, l2) -> {
+        literals.sort((l1, l2) -> {
             if (l1 == null && l2 == null) {
                 return 0;
             } else if (l1 != null && l2 == null) {
                 return -1;
-            } else if (l1 == null && l2 != null) {
+            } else if (l1 == null) {
                 return 1;
             } else if (l1.length() == l2.length()) {
                 return 0;

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/spring/MultiJarAwarePersistenceUnitPostProcessor.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/spring/MultiJarAwarePersistenceUnitPostProcessor.java
@@ -27,6 +27,8 @@ import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.orm.jpa.persistenceunit.MutablePersistenceUnitInfo;
 import org.springframework.orm.jpa.persistenceunit.PersistenceUnitPostProcessor;
 
+import java.util.Objects;
+
 /**
  * Allows having JPA entities spread in several JAR files; this is needed in order to support the Syncope extensions.
  */
@@ -41,7 +43,7 @@ public class MultiJarAwarePersistenceUnitPostProcessor implements PersistenceUni
 
         scanner.findCandidateComponents(AbstractEntity.class.getPackage().getName()).forEach(bd -> {
             LOG.debug("Adding JPA entity {}", bd.getBeanClassName());
-            pui.addManagedClassName(bd.getBeanClassName());
+            pui.addManagedClassName(Objects.requireNonNull(bd.getBeanClassName()));
         });
     }
 }

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/validation/entity/SchemaKeyValidator.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/validation/entity/SchemaKeyValidator.java
@@ -25,6 +25,8 @@ import org.apache.syncope.core.persistence.api.entity.PlainSchema;
 import org.apache.syncope.core.persistence.api.entity.VirSchema;
 import org.apache.syncope.core.persistence.jpa.entity.JPAAnyUtils;
 
+import java.util.Objects;
+
 public class SchemaKeyValidator extends AbstractValidator<SchemaKeyCheck, Object> {
 
     @Override
@@ -38,7 +40,7 @@ public class SchemaKeyValidator extends AbstractValidator<SchemaKeyCheck, Object
             key = ((VirSchema) object).getKey();
         }
 
-        boolean isValid = KEY_PATTERN.matcher(key).matches();
+        boolean isValid = KEY_PATTERN.matcher(Objects.requireNonNull(key)).matches();
         if (!isValid) {
             context.disableDefaultConstraintViolation();
             context.buildConstraintViolationWithTemplate(

--- a/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/serialization/SyncTokenDeserializer.java
+++ b/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/serialization/SyncTokenDeserializer.java
@@ -25,6 +25,8 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.util.Base64;
+import java.util.Objects;
+
 import org.identityconnectors.framework.common.objects.SyncToken;
 
 class SyncTokenDeserializer extends JsonDeserializer<SyncToken> {
@@ -60,7 +62,7 @@ class SyncTokenDeserializer extends JsonDeserializer<SyncToken> {
             }
         }
 
-        return new SyncToken(value);
+        return new SyncToken(Objects.requireNonNull(value));
     }
 
 }

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/ConnIdBundleManagerImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/ConnIdBundleManagerImpl.java
@@ -137,7 +137,7 @@ public class ConnIdBundleManagerImpl implements ConnIdBundleManager {
         String[] params = StringUtils.isBlank(location.getQuery()) ? null : location.getQuery().split("&");
         if (params != null && params.length > 0) {
             final String[] trustAllCerts = params[0].split("=");
-            if (trustAllCerts != null && trustAllCerts.length > 1
+            if (trustAllCerts.length > 1
                     && "trustAllCerts".equalsIgnoreCase(trustAllCerts[0])
                     && "true".equalsIgnoreCase(trustAllCerts[1])) {
 

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/MappingManagerImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/MappingManagerImpl.java
@@ -666,7 +666,7 @@ public class MappingManagerImpl implements MappingManager {
     public Optional<String> getConnObjectKeyValue(final Realm realm, final OrgUnit orgUnit) {
         OrgUnitItem orgUnitItem = orgUnit.getConnObjectKeyItem().get();
 
-        return Optional.ofNullable(Optional.ofNullable(orgUnitItem)
+        return Optional.ofNullable(Optional.of(orgUnitItem)
             .map(unitItem -> getIntValue(realm, unitItem)).orElse(null));
     }
 

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/jexl/SyncopeJexlFunctions.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/jexl/SyncopeJexlFunctions.java
@@ -57,7 +57,7 @@ public class SyncopeJexlFunctions {
      */
     public static String fullPath2Dn(final String fullPath, final String attr, final String prefix) {
         String[] fullPathSplitted = fullPath.split("/");
-        if (fullPathSplitted == null || fullPathSplitted.length <= 1) {
+        if (fullPathSplitted.length <= 1) {
             return StringUtils.EMPTY;
         }
 

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/notification/DefaultNotificationManager.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/notification/DefaultNotificationManager.java
@@ -382,7 +382,7 @@ public class DefaultNotificationManager implements NotificationManager {
             intAttrName = intAttrNameParser.parse(recipientAttrName, AnyTypeKind.USER);
         } catch (ParseException e) {
             LOG.error("Invalid intAttrName '{}' specified as recipient, ignoring", recipientAttrName, e);
-            return email;
+            return null;
         }
 
         if ("username".equals(intAttrName.getField())) {

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/propagation/PriorityPropagationTaskExecutor.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/propagation/PriorityPropagationTaskExecutor.java
@@ -21,7 +21,6 @@ package org.apache.syncope.core.provisioning.java.propagation;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -105,7 +104,7 @@ public class PriorityPropagationTaskExecutor extends AbstractPropagationTaskExec
             }
         });
 
-        Collections.sort(prioritizedTasks, new PriorityComparator(taskToResource));
+        prioritizedTasks.sort(new PriorityComparator(taskToResource));
         LOG.debug("Propagation tasks sorted by priority, for serial execution: {}", prioritizedTasks);
 
         Collection<PropagationTaskInfo> concurrentTasks = taskInfos.stream().

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/LDAPPasswordPullActions.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/LDAPPasswordPullActions.java
@@ -89,10 +89,7 @@ public class LDAPPasswordPullActions implements PullActions {
     private void parseEncodedPassword(final String password) {
         if (password != null && password.startsWith("{")) {
             int closingBracketIndex = password.indexOf('}');
-            String digest = password.substring(1, password.indexOf('}'));
-            if (digest != null) {
-                digest = digest.toUpperCase();
-            }
+            String digest = password.substring(1, password.indexOf('}')).toUpperCase();
             try {
                 encodedPassword = password.substring(closingBracketIndex + 1);
                 cipher = CipherAlgorithm.valueOf(digest);

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/SinglePullJobDelegate.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/SinglePullJobDelegate.java
@@ -164,7 +164,7 @@ public class SinglePullJobDelegate extends PullJobDelegate implements SyncopeSin
             // execute filtered pull
             connector.filteredReconciliation(
                     provision.getObjectClass(),
-                    new AccountReconciliationFilterBuilder(connObjectKey, connObjectValue),
+                new AccountReconciliationFilterBuilder(connObjectKey, connObjectValue),
                     handler,
                     options);
 
@@ -190,7 +190,7 @@ public class SinglePullJobDelegate extends PullJobDelegate implements SyncopeSin
         }
     }
 
-    class AccountReconciliationFilterBuilder implements ReconFilterBuilder {
+    static class AccountReconciliationFilterBuilder implements ReconFilterBuilder {
 
         private final String key;
 

--- a/ext/camel/client-console/src/main/java/org/apache/syncope/client/console/panels/CamelRoutesDirectoryPanel.java
+++ b/ext/camel/client-console/src/main/java/org/apache/syncope/client/console/panels/CamelRoutesDirectoryPanel.java
@@ -21,7 +21,6 @@ package org.apache.syncope.client.console.panels;
 import de.agilecoders.wicket.core.markup.html.bootstrap.dialog.Modal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.syncope.client.ui.commons.DirectoryDataProvider;
@@ -144,7 +143,7 @@ public class CamelRoutesDirectoryPanel extends DirectoryPanel<
         return panel;
     }
 
-    protected final class CamelRoutesProvider extends DirectoryDataProvider<CamelRouteTO> {
+    protected static final class CamelRoutesProvider extends DirectoryDataProvider<CamelRouteTO> {
 
         private static final long serialVersionUID = -185944053385660794L;
 
@@ -161,7 +160,7 @@ public class CamelRoutesDirectoryPanel extends DirectoryPanel<
         @Override
         public Iterator<CamelRouteTO> iterator(final long first, final long count) {
             List<CamelRouteTO> list = CamelRoutesRestClient.list(anyTypeKind);
-            Collections.sort(list, comparator);
+            list.sort(comparator);
             return list.subList((int) first, (int) first + (int) count).iterator();
         }
 

--- a/ext/camel/logic/src/main/java/org/apache/syncope/core/logic/CamelRouteLogic.java
+++ b/ext/camel/logic/src/main/java/org/apache/syncope/core/logic/CamelRouteLogic.java
@@ -132,9 +132,8 @@ public class CamelRouteLogic extends AbstractTransactionalLogic<CamelRouteTO> {
                 return meanRate;
             }).forEachOrdered(meanRate -> metrics.getResponseMeanRates().add(meanRate));
 
-            Collections.sort(metrics.getResponseMeanRates(),
-                    (o1, o2) -> Collections.reverseOrder(Comparator.<Double>naturalOrder()).
-                            compare(o1.getValue(), o2.getValue()));
+            metrics.getResponseMeanRates().sort((o1, o2) -> Collections.reverseOrder(Comparator.<Double>naturalOrder()).
+                compare(o1.getValue(), o2.getValue()));
         }
 
         return metrics;

--- a/ext/elasticsearch/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/ElasticsearchAnySearchDAO.java
+++ b/ext/elasticsearch/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/ElasticsearchAnySearchDAO.java
@@ -23,6 +23,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -211,7 +212,8 @@ public class ElasticsearchAnySearchDAO extends AbstractAnySearchDAO {
 
         return ArrayUtils.isEmpty(esResult)
                 ? List.of()
-                : buildResult(Stream.of(esResult).map(SearchHit::getId).collect(Collectors.toList()), kind);
+                : buildResult(Stream.of(Objects.requireNonNull(esResult))
+                    .map(SearchHit::getId).collect(Collectors.toList()), kind);
     }
 
     private QueryBuilder getQueryBuilder(final SearchCond cond, final AnyTypeKind kind) {

--- a/ext/flowable/client-console/src/main/java/org/apache/syncope/client/console/panels/BpmnProcessDirectoryPanel.java
+++ b/ext/flowable/client-console/src/main/java/org/apache/syncope/client/console/panels/BpmnProcessDirectoryPanel.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -302,7 +301,7 @@ public class BpmnProcessDirectoryPanel extends DirectoryPanel<
         }
     }
 
-    protected class BpmProcessDataProvider extends DirectoryDataProvider<BpmnProcess> {
+    protected static class BpmProcessDataProvider extends DirectoryDataProvider<BpmnProcess> {
 
         private static final long serialVersionUID = 1764153405387687592L;
 
@@ -317,7 +316,7 @@ public class BpmnProcessDirectoryPanel extends DirectoryPanel<
         @Override
         public Iterator<BpmnProcess> iterator(final long first, final long count) {
             List<BpmnProcess> result = BpmnProcessRestClient.getDefinitions();
-            Collections.sort(result, comparator);
+            result.sort(comparator);
             return result.subList((int) first, (int) first + (int) count).iterator();
         }
 

--- a/ext/flowable/client-enduser/src/main/java/org/apache/syncope/client/enduser/pages/Flowable.java
+++ b/ext/flowable/client-enduser/src/main/java/org/apache/syncope/client/enduser/pages/Flowable.java
@@ -224,7 +224,7 @@ public class Flowable extends BaseExtPage {
         }
     }
 
-    public class URDataProvider implements IDataProvider<UserRequest> {
+    public static class URDataProvider implements IDataProvider<UserRequest> {
 
         private static final long serialVersionUID = 1169386589403139714L;
 

--- a/ext/flowable/flowable-bpmn/src/main/java/org/apache/syncope/core/flowable/impl/FlowableRuntimeUtils.java
+++ b/ext/flowable/flowable-bpmn/src/main/java/org/apache/syncope/core/flowable/impl/FlowableRuntimeUtils.java
@@ -103,7 +103,7 @@ public final class FlowableRuntimeUtils {
 
     public static Pair<String, String> splitProcBusinessKey(final String procBusinessKey) {
         String[] split = procBusinessKey.split(":");
-        if (split == null || split.length != 2) {
+        if (split.length != 2) {
             throw new WorkflowException(new IllegalArgumentException("Unexpected business key: " + procBusinessKey));
         }
 

--- a/ext/flowable/flowable-bpmn/src/main/java/org/apache/syncope/core/flowable/impl/FlowableUserRequestHandler.java
+++ b/ext/flowable/flowable-bpmn/src/main/java/org/apache/syncope/core/flowable/impl/FlowableUserRequestHandler.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -208,7 +209,7 @@ public class FlowableUserRequestHandler implements UserRequestHandler {
         }
 
         engine.getRuntimeService().updateBusinessKey(
-                procInst.getProcessInstanceId(),
+                Objects.requireNonNull(procInst).getProcessInstanceId(),
                 FlowableRuntimeUtils.getProcBusinessKey(bpmnProcess, user.getKey()));
 
         return getUserRequest(engine.getRuntimeService().createProcessInstanceQuery().

--- a/ext/flowable/flowable-bpmn/src/main/java/org/apache/syncope/core/flowable/impl/FlowableUserWorkflowAdapter.java
+++ b/ext/flowable/flowable-bpmn/src/main/java/org/apache/syncope/core/flowable/impl/FlowableUserWorkflowAdapter.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -101,7 +102,7 @@ public class FlowableUserWorkflowAdapter extends AbstractUserWorkflowAdapter imp
         }
 
         engine.getRuntimeService().removeVariable(
-                procInst.getProcessInstanceId(), FlowableRuntimeUtils.WF_EXECUTOR);
+                Objects.requireNonNull(procInst).getProcessInstanceId(), FlowableRuntimeUtils.WF_EXECUTOR);
         engine.getRuntimeService().removeVariable(
                 procInst.getProcessInstanceId(), FlowableRuntimeUtils.USER_CR);
         engine.getRuntimeService().removeVariable(

--- a/ext/flowable/flowable-bpmn/src/main/java/org/apache/syncope/core/flowable/support/DomainProcessEngineFactoryBean.java
+++ b/ext/flowable/flowable-bpmn/src/main/java/org/apache/syncope/core/flowable/support/DomainProcessEngineFactoryBean.java
@@ -21,6 +21,8 @@ package org.apache.syncope.core.flowable.support;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+
 import javax.sql.DataSource;
 import org.apache.syncope.core.persistence.api.DomainHolder;
 import org.apache.syncope.core.persistence.api.SyncopeCoreLoader;
@@ -95,7 +97,7 @@ public class DomainProcessEngineFactoryBean
     @Override
     public void load(final String domain, final DataSource datasource) {
         try {
-            getObject().getEngines().put(domain, build(domain, datasource));
+            Objects.requireNonNull(getObject()).getEngines().put(domain, build(domain, datasource));
         } catch (Exception e) {
             LOG.error("Could not setup Flowable for {}", domain, e);
         }

--- a/ext/oidcclient/client-console/src/main/java/org/apache/syncope/client/console/panels/OIDCProvidersDirectoryPanel.java
+++ b/ext/oidcclient/client-console/src/main/java/org/apache/syncope/client/console/panels/OIDCProvidersDirectoryPanel.java
@@ -22,7 +22,6 @@ import de.agilecoders.wicket.core.markup.html.bootstrap.dialog.Modal;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
@@ -258,7 +257,7 @@ public class OIDCProvidersDirectoryPanel extends DirectoryPanel<
         }
     }
 
-    protected final class OIDCProvidersProvider extends DirectoryDataProvider<OIDCProviderTO> {
+    protected static final class OIDCProvidersProvider extends DirectoryDataProvider<OIDCProviderTO> {
 
         private static final long serialVersionUID = -2865055116864423761L;
 
@@ -274,7 +273,7 @@ public class OIDCProvidersDirectoryPanel extends DirectoryPanel<
         @Override
         public Iterator<OIDCProviderTO> iterator(final long first, final long count) {
             List<OIDCProviderTO> list = OIDCProviderRestClient.list();
-            Collections.sort(list, comparator);
+            list.sort(comparator);
             return list.subList((int) first, (int) first + (int) count).iterator();
         }
 

--- a/ext/oidcclient/client-console/src/main/java/org/apache/syncope/client/console/wizards/OIDCProviderWizardBuilder.java
+++ b/ext/oidcclient/client-console/src/main/java/org/apache/syncope/client/console/wizards/OIDCProviderWizardBuilder.java
@@ -185,7 +185,7 @@ public class OIDCProviderWizardBuilder extends AjaxWizardBuilder<OIDCProviderTO>
         }
     }
 
-    public class OPContinue extends WizardStep {
+    public static class OPContinue extends WizardStep {
 
         private static final long serialVersionUID = -7087008312629522790L;
 

--- a/ext/saml2sp/client-console/src/main/java/org/apache/syncope/client/console/panels/SAML2IdPsDirectoryPanel.java
+++ b/ext/saml2sp/client-console/src/main/java/org/apache/syncope/client/console/panels/SAML2IdPsDirectoryPanel.java
@@ -23,7 +23,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
@@ -309,7 +308,7 @@ public class SAML2IdPsDirectoryPanel extends DirectoryPanel<
         }
     }
 
-    protected final class SAML2IdPsProvider extends DirectoryDataProvider<SAML2IdPTO> {
+    protected static final class SAML2IdPsProvider extends DirectoryDataProvider<SAML2IdPTO> {
 
         private static final long serialVersionUID = -185944053385660794L;
 
@@ -325,7 +324,7 @@ public class SAML2IdPsDirectoryPanel extends DirectoryPanel<
         @Override
         public Iterator<SAML2IdPTO> iterator(final long first, final long count) {
             List<SAML2IdPTO> list = SAML2IdPsRestClient.list();
-            Collections.sort(list, comparator);
+            list.sort(comparator);
             return list.subList((int) first, (int) first + (int) count).iterator();
         }
 

--- a/ext/saml2sp/logic/src/main/java/org/apache/syncope/core/logic/saml2/SAML2IdPEntity.java
+++ b/ext/saml2sp/logic/src/main/java/org/apache/syncope/core/logic/saml2/SAML2IdPEntity.java
@@ -31,6 +31,8 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+
 import org.apache.syncope.common.lib.to.ItemTO;
 import org.apache.syncope.common.lib.to.SAML2IdPTO;
 import org.apache.syncope.common.lib.to.UserTO;
@@ -95,7 +97,7 @@ public class SAML2IdPEntity {
             for (X509Data x509Data : key.getKeyInfo().getX509Datas()) {
                 for (org.opensaml.xmlsec.signature.X509Certificate cert : x509Data.getX509Certificates()) {
                     try (ByteArrayInputStream bais = new ByteArrayInputStream(
-                            Base64.getMimeDecoder().decode(cert.getValue()))) {
+                            Base64.getMimeDecoder().decode(Objects.requireNonNull(cert.getValue())))) {
                         chain.add(X509Certificate.class.cast(cf.generateCertificate(bais)));
                     }
                 }

--- a/ext/saml2sp/logic/src/main/java/org/apache/syncope/core/logic/saml2/SAML2ReaderWriter.java
+++ b/ext/saml2sp/logic/src/main/java/org/apache/syncope/core/logic/saml2/SAML2ReaderWriter.java
@@ -105,10 +105,8 @@ public class SAML2ReaderWriter {
         if (loader.getSignatureAlgorithm() != null) {
             SignatureAlgorithm loadedSignatureAlgorithm =
                     SignatureAlgorithm.valueOf(loader.getSignatureAlgorithm());
-            if (loadedSignatureAlgorithm != null) {
-                sigAlgo = loadedSignatureAlgorithm.getAlgorithm();
-                jceSigAlgo = JCEMapper.translateURItoJCEID(sigAlgo);
-            }
+            sigAlgo = loadedSignatureAlgorithm.getAlgorithm();
+            jceSigAlgo = JCEMapper.translateURItoJCEID(sigAlgo);
             if (jceSigAlgo == null) {
                 LOG.warn("Signature algorithm {} is not valid. Using default algorithm instead.",
                         loader.getSignatureAlgorithm());

--- a/fit/build-tools/src/main/java/org/apache/syncope/fit/buildtools/ConnectorServerStartStopListener.java
+++ b/fit/build-tools/src/main/java/org/apache/syncope/fit/buildtools/ConnectorServerStartStopListener.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import javax.servlet.annotation.WebListener;
@@ -68,7 +70,8 @@ public class ConnectorServerStartStopListener implements ServletContextListener 
         ConnectorServer server = ConnectorServer.newInstance();
         WebApplicationContext ctx = WebApplicationContextUtils.getWebApplicationContext(sce.getServletContext());
         try {
-            server.setPort(ctx.getEnvironment().getProperty("testconnectorserver.port", Integer.class));
+            server.setPort(Objects.requireNonNull(ctx).getEnvironment()
+                .getProperty("testconnectorserver.port", Integer.class));
 
             server.setBundleURLs(getBundleURLs(ctx));
 

--- a/fit/build-tools/src/main/java/org/apache/syncope/fit/buildtools/H2StartStopListener.java
+++ b/fit/build-tools/src/main/java/org/apache/syncope/fit/buildtools/H2StartStopListener.java
@@ -20,6 +20,8 @@ package org.apache.syncope.fit.buildtools;
 
 import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
+import java.util.Objects;
+
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
@@ -51,7 +53,7 @@ public class H2StartStopListener implements ServletContextListener {
         try {
             Server h2TestDb = new Server();
             h2TestDb.runTool("-ifNotExists", "-tcp", "-tcpDaemon", "-web", "-webDaemon",
-                    "-webPort", ctx.getEnvironment().getProperty("testdb.webport"));
+                    "-webPort", Objects.requireNonNull(ctx).getEnvironment().getProperty("testdb.webport"));
 
             context.setAttribute(H2_TESTDB, h2TestDb);
         } catch (SQLException e) {

--- a/sra/src/main/java/org/apache/syncope/sra/SyncopeSRAApplication.java
+++ b/sra/src/main/java/org/apache/syncope/sra/SyncopeSRAApplication.java
@@ -39,6 +39,8 @@ import org.springframework.security.web.server.util.matcher.PathPatternParserSer
 import org.springframework.web.util.pattern.PathPatternParser;
 import reactor.core.publisher.Flux;
 
+import java.util.Objects;
+
 @PropertySource("classpath:sra.properties")
 @PropertySource(value = "file:${conf.directory}/sra.properties", ignoreResourceNotFound = true)
 @EnableWebFluxSecurity
@@ -75,7 +77,7 @@ public class SyncopeSRAApplication implements EnvironmentAware {
     @Bean
     public MapReactiveUserDetailsService userDetailsService() {
         UserDetails user = User.builder().
-                username(env.getProperty("anonymousUser")).
+                username(Objects.requireNonNull(env.getProperty("anonymousUser"))).
                 password("{noop}" + env.getProperty("anonymousKey")).
                 roles(IdRepoEntitlement.ANONYMOUS).
                 build();


### PR DESCRIPTION
This pull request is a semi-large cleanup effort to protect against the following issues:

- Immutable object modification as part of sort operations.
- Null check clean up where the condition is always true/false
- Protect against NPEs where objects may be calculated as `null`
- Switch sort ops to use factory methods such as `List.sort()` instead of `Collections.sort()`

All FITs should pass, as they did locally. 