### PR TITLE
NOJIRA: Fix typo in destination field

### DIFF
--- a/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/entity/task/PullTask.java
+++ b/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/entity/task/PullTask.java
@@ -35,7 +35,7 @@ public interface PullTask extends ProvisioningTask {
 
     void setReconFilterBuilder(Implementation reconFilterBuilder);
 
-    Realm getDestinatioRealm();
+    Realm getDestinationRealm();
 
     void setDestinationRealm(Realm destinationRealm);
 

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/entity/task/JPAPullTask.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/entity/task/JPAPullTask.java
@@ -100,7 +100,7 @@ public class JPAPullTask extends AbstractProvisioningTask implements PullTask {
     }
 
     @Override
-    public Realm getDestinatioRealm() {
+    public Realm getDestinationRealm() {
         return destinationRealm;
     }
 

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/TaskDataBinderImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/TaskDataBinderImpl.java
@@ -412,7 +412,7 @@ public class TaskDataBinderImpl implements TaskDataBinder {
 
                 fill(pullTaskTO, pullTask);
 
-                pullTaskTO.setDestinationRealm(pullTask.getDestinatioRealm().getFullPath());
+                pullTaskTO.setDestinationRealm(pullTask.getDestinationRealm().getFullPath());
                 pullTaskTO.setMatchingRule(pullTask.getMatchingRule() == null
                         ? MatchingRule.UPDATE : pullTask.getMatchingRule());
                 pullTaskTO.setUnmatchingRule(pullTask.getUnmatchingRule() == null

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/propagation/PriorityPropagationTaskExecutor.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/propagation/PriorityPropagationTaskExecutor.java
@@ -69,7 +69,7 @@ public class PriorityPropagationTaskExecutor extends AbstractPropagationTaskExec
      */
     protected static PropagationTaskCallable newPropagationTaskCallable(
         final PropagationTaskInfo taskInfo, final PropagationReporter reporter) {
-
+        
         PropagationTaskCallable callable = (PropagationTaskCallable) ApplicationContextProvider.getBeanFactory().
                 createBean(DefaultPropagationTaskCallable.class, AbstractBeanDefinition.AUTOWIRE_BY_TYPE, false);
         callable.setTaskInfo(taskInfo);

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/DefaultRealmPullResultHandler.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/DefaultRealmPullResultHandler.java
@@ -138,7 +138,7 @@ public class DefaultRealmPullResultHandler
         RealmTO realmTO = connObjectUtils.getRealmTO(delta.getObject(), profile.getTask(), orgUnit);
         if (realmTO.getFullPath() == null) {
             if (realmTO.getParent() == null) {
-                realmTO.setParent(profile.getTask().getDestinatioRealm().getFullPath());
+                realmTO.setParent(profile.getTask().getDestinationRealm().getFullPath());
             }
 
             realmTO.setFullPath(realmTO.getParent() + '/' + realmTO.getName());
@@ -177,7 +177,7 @@ public class DefaultRealmPullResultHandler
         RealmTO realmTO = connObjectUtils.getRealmTO(delta.getObject(), profile.getTask(), orgUnit);
         if (realmTO.getFullPath() == null) {
             if (realmTO.getParent() == null) {
-                realmTO.setParent(profile.getTask().getDestinatioRealm().getFullPath());
+                realmTO.setParent(profile.getTask().getDestinationRealm().getFullPath());
             }
 
             realmTO.setFullPath(realmTO.getParent() + '/' + realmTO.getName());
@@ -232,7 +232,7 @@ public class DefaultRealmPullResultHandler
         Result resultStatus;
 
         try {
-            Realm realm = realmDAO.save(binder.create(profile.getTask().getDestinatioRealm(), realmTO));
+            Realm realm = realmDAO.save(binder.create(profile.getTask().getDestinationRealm(), realmTO));
 
             PropagationByResource<String> propByRes = new PropagationByResource<>();
             propByRes.addAll(ResourceOperation.CREATE, realm.getResourceKeys());
@@ -244,7 +244,7 @@ public class DefaultRealmPullResultHandler
             RealmTO actual = binder.getRealmTO(realm, true);
 
             result.setKey(actual.getKey());
-            result.setName(profile.getTask().getDestinatioRealm().getFullPath() + '/' + actual.getName());
+            result.setName(profile.getTask().getDestinationRealm().getFullPath() + '/' + actual.getName());
 
             output = actual;
             resultStatus = Result.SUCCESS;

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/utils/ConnObjectUtils.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/utils/ConnObjectUtils.java
@@ -309,7 +309,7 @@ public class ConnObjectUtils {
         anyTO.setType(provision.getAnyType().getKey());
 
         // 1. fill with data from connector object
-        anyTO.setRealm(pullTask.getDestinatioRealm().getFullPath());
+        anyTO.setRealm(pullTask.getDestinationRealm().getFullPath());
         MappingUtils.getPullItems(provision.getMapping().getItems()).forEach(
                 item -> mappingManager.setIntValues(item, obj.getAttributeByName(item.getExtAttrName()), anyTO));
 


### PR DESCRIPTION
This pull request fixes a typo in `getDestinatioRealm` where it should be `getDestinationRealm` (missing `n`).