### PR TITLE
SYNCOPE-1511: Provide Audit APIs

### DIFF
--- a/common/lib/src/main/java/org/apache/syncope/common/lib/to/AuditEntryTO.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/to/AuditEntryTO.java
@@ -52,6 +52,8 @@ public class AuditEntryTO extends BaseBean implements EntityTO  {
 
     private String key;
 
+    private String loggerName;
+
     public Date getDate() {
         return date;
     }
@@ -118,6 +120,14 @@ public class AuditEntryTO extends BaseBean implements EntityTO  {
 
     public void setWho(final String who) {
         this.who = who;
+    }
+
+    public String getLoggerName() {
+        return loggerName;
+    }
+
+    public void setLoggerName(final String loggerName) {
+        this.loggerName = loggerName;
     }
 
     @Override

--- a/common/lib/src/main/java/org/apache/syncope/common/lib/to/AuditEntryTO.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/to/AuditEntryTO.java
@@ -29,7 +29,7 @@ import java.util.List;
 
 @XmlRootElement(name = "audit")
 @XmlType
-public class AuditTO extends BaseBean implements EntityTO {
+public class AuditEntryTO extends BaseBean implements EntityTO  {
     private static final long serialVersionUID = 1215115961911228005L;
 
     private final List<String> inputs = new ArrayList<>();

--- a/common/lib/src/main/java/org/apache/syncope/common/lib/to/AuditTO.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/to/AuditTO.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.syncope.common.lib.to;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+@XmlRootElement(name = "audit")
+@XmlType
+public class AuditTO implements Serializable {
+    private static final long serialVersionUID = 1215115961911228005L;
+
+    private final List<String> inputs = new ArrayList<>();
+
+    private String who;
+
+    private String subCategory;
+
+    private String event;
+
+    private String result;
+
+    private String before;
+
+    private String output;
+
+    private Date date;
+
+    private String throwable;
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(final Date date) {
+        this.date = date;
+    }
+
+    public String getThrowable() {
+        return throwable;
+    }
+
+    public void setThrowable(final String throwable) {
+        this.throwable = throwable;
+    }
+
+    public String getOutput() {
+        return output;
+    }
+
+    public void setOutput(final String output) {
+        this.output = output;
+    }
+
+    public String getBefore() {
+        return before;
+    }
+
+    public void setBefore(final String before) {
+        this.before = before;
+    }
+
+    public List<String> getInputs() {
+        return inputs;
+    }
+
+    public String getSubCategory() {
+        return subCategory;
+    }
+
+    public void setSubCategory(final String subCategory) {
+        this.subCategory = subCategory;
+    }
+
+    public String getEvent() {
+        return event;
+    }
+
+    public void setEvent(final String event) {
+        this.event = event;
+    }
+
+    public String getResult() {
+        return result;
+    }
+
+    public void setResult(final String result) {
+        this.result = result;
+    }
+
+    public String getWho() {
+        return who;
+    }
+
+    public void setWho(final String who) {
+        this.who = who;
+    }
+}

--- a/common/lib/src/main/java/org/apache/syncope/common/lib/to/AuditTO.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/to/AuditTO.java
@@ -18,17 +18,18 @@
  */
 package org.apache.syncope.common.lib.to;
 
+import org.apache.syncope.common.lib.BaseBean;
+
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
 @XmlRootElement(name = "audit")
 @XmlType
-public class AuditTO implements Serializable {
+public class AuditTO extends BaseBean implements EntityTO {
     private static final long serialVersionUID = 1215115961911228005L;
 
     private final List<String> inputs = new ArrayList<>();
@@ -48,6 +49,8 @@ public class AuditTO implements Serializable {
     private Date date;
 
     private String throwable;
+
+    private String key;
 
     public Date getDate() {
         return date;
@@ -115,5 +118,15 @@ public class AuditTO implements Serializable {
 
     public void setWho(final String who) {
         this.who = who;
+    }
+
+    @Override
+    public String getKey() {
+        return this.key;
+    }
+
+    @Override
+    public void setKey(final String key) {
+        this.key = key;
     }
 }

--- a/common/lib/src/main/java/org/apache/syncope/common/lib/types/StandardEntitlement.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/types/StandardEntitlement.java
@@ -110,6 +110,8 @@ public final class StandardEntitlement {
 
     public static final String SCHEMA_DELETE = "SCHEMA_DELETE";
 
+    public static final String AUDIT_SEARCH = "AUDIT_SEARCH";
+
     public static final String USER_SEARCH = "USER_SEARCH";
 
     public static final String USER_CREATE = "USER_CREATE";

--- a/common/rest-api/src/main/java/org/apache/syncope/common/rest/api/beans/AuditQuery.java
+++ b/common/rest-api/src/main/java/org/apache/syncope/common/rest/api/beans/AuditQuery.java
@@ -16,13 +16,36 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.syncope.core.persistence.api.dao;
+package org.apache.syncope.common.rest.api.beans;
 
-import org.apache.syncope.core.persistence.api.dao.search.OrderByClause;
-import org.apache.syncope.core.persistence.api.entity.AuditEntry;
+import javax.ws.rs.QueryParam;
 
-import java.util.List;
+public class AuditQuery extends AbstractQuery {
 
-public interface AuditDAO<T extends AuditEntry> {
-    List<AuditEntry> findByEntityKey(String key, int page, int size, List<OrderByClause> orderByClauses);
+    private static final long serialVersionUID = -2863334226169614417L;
+
+    private String key;
+
+    public String getKey() {
+        return key;
+    }
+
+    @QueryParam("key")
+    public void setKey(final String key) {
+        this.key = key;
+    }
+
+    public static class Builder extends AbstractQuery.Builder<AuditQuery, Builder> {
+
+        public Builder key(final String keyword) {
+            getInstance().setKey(keyword);
+            return this;
+        }
+
+        @Override
+        protected AuditQuery newInstance() {
+            return new AuditQuery();
+        }
+    }
+
 }

--- a/common/rest-api/src/main/java/org/apache/syncope/common/rest/api/service/AuditService.java
+++ b/common/rest-api/src/main/java/org/apache/syncope/common/rest/api/service/AuditService.java
@@ -21,7 +21,7 @@ package org.apache.syncope.common.rest.api.service;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import org.apache.syncope.common.lib.to.AuditTO;
+import org.apache.syncope.common.lib.to.AuditEntryTO;
 import org.apache.syncope.common.lib.to.PagedResult;
 import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.common.rest.api.beans.AnyQuery;
@@ -49,5 +49,5 @@ public interface AuditService {
      */
     @GET
     @Produces({MediaType.APPLICATION_JSON, RESTHeaders.APPLICATION_YAML, MediaType.APPLICATION_XML})
-    PagedResult<AuditTO> search(AnyQuery anyQuery);
+    PagedResult<AuditEntryTO> search(AnyQuery anyQuery);
 }

--- a/common/rest-api/src/main/java/org/apache/syncope/common/rest/api/service/AuditService.java
+++ b/common/rest-api/src/main/java/org/apache/syncope/common/rest/api/service/AuditService.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.syncope.common.rest.api.service;
+
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.apache.syncope.common.lib.to.AuditTO;
+import org.apache.syncope.common.rest.api.RESTHeaders;
+
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
+import java.util.List;
+
+/**
+ * REST operations for audit events.
+ */
+@Tag(name = "Audits")
+@SecurityRequirements({
+    @SecurityRequirement(name = "BasicAuthentication"),
+    @SecurityRequirement(name = "Bearer")})
+@Path("audits")
+public interface AuditService {
+
+    /**
+     * Returns a list of all audit events.
+     *
+     * @return list of all audit events.
+     */
+    @ApiResponses(
+        @ApiResponse(responseCode = "200", description =
+            "List of all audit events recorded and found in Syncope.",
+            headers = @Header(name = HttpHeaders.ETAG)))
+    @GET
+    @Produces({MediaType.APPLICATION_JSON, RESTHeaders.APPLICATION_YAML, MediaType.APPLICATION_XML})
+    List<AuditTO> list();
+
+    /**
+     * Returns audit record with matching key.
+     *
+     * @param key audit key to be read
+     * @return audit record with matching key
+     */
+    @GET
+    @Path("{key}")
+    @Produces({MediaType.APPLICATION_JSON, RESTHeaders.APPLICATION_YAML, MediaType.APPLICATION_XML})
+    AuditTO read(@NotNull @PathParam("key") String key);
+}

--- a/common/rest-api/src/main/java/org/apache/syncope/common/rest/api/service/AuditService.java
+++ b/common/rest-api/src/main/java/org/apache/syncope/common/rest/api/service/AuditService.java
@@ -18,24 +18,18 @@
  */
 package org.apache.syncope.common.rest.api.service;
 
-import io.swagger.v3.oas.annotations.headers.Header;
-import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.syncope.common.lib.to.AuditTO;
+import org.apache.syncope.common.lib.to.PagedResult;
 import org.apache.syncope.common.rest.api.RESTHeaders;
+import org.apache.syncope.common.rest.api.beans.AnyQuery;
 
-import javax.validation.constraints.NotNull;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
-
-import java.util.List;
 
 /**
  * REST operations for audit events.
@@ -48,26 +42,12 @@ import java.util.List;
 public interface AuditService {
 
     /**
-     * Returns a list of all audit events.
+     * Returns a paged list of audit objects matching the given query.
      *
-     * @return list of all audit events.
-     */
-    @ApiResponses(
-        @ApiResponse(responseCode = "200", description =
-            "List of all audit events recorded and found in Syncope.",
-            headers = @Header(name = HttpHeaders.ETAG)))
-    @GET
-    @Produces({MediaType.APPLICATION_JSON, RESTHeaders.APPLICATION_YAML, MediaType.APPLICATION_XML})
-    List<AuditTO> list();
-
-    /**
-     * Returns audit record with matching key.
-     *
-     * @param key audit key to be read
-     * @return audit record with matching key
+     * @param anyQuery query conditions
+     * @return paged list of objects matching the given query
      */
     @GET
-    @Path("{key}")
     @Produces({MediaType.APPLICATION_JSON, RESTHeaders.APPLICATION_YAML, MediaType.APPLICATION_XML})
-    AuditTO read(@NotNull @PathParam("key") String key);
+    PagedResult<AuditTO> search(AnyQuery anyQuery);
 }

--- a/common/rest-api/src/main/java/org/apache/syncope/common/rest/api/service/AuditService.java
+++ b/common/rest-api/src/main/java/org/apache/syncope/common/rest/api/service/AuditService.java
@@ -24,8 +24,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.apache.syncope.common.lib.to.AuditEntryTO;
 import org.apache.syncope.common.lib.to.PagedResult;
 import org.apache.syncope.common.rest.api.RESTHeaders;
-import org.apache.syncope.common.rest.api.beans.AnyQuery;
+import org.apache.syncope.common.rest.api.beans.AuditQuery;
 
+import javax.ws.rs.BeanParam;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -44,10 +45,10 @@ public interface AuditService {
     /**
      * Returns a paged list of audit objects matching the given query.
      *
-     * @param anyQuery query conditions
+     * @param auditQuery query conditions
      * @return paged list of objects matching the given query
      */
     @GET
     @Produces({MediaType.APPLICATION_JSON, RESTHeaders.APPLICATION_YAML, MediaType.APPLICATION_XML})
-    PagedResult<AuditEntryTO> search(AnyQuery anyQuery);
+    PagedResult<AuditEntryTO> search(@BeanParam AuditQuery auditQuery);
 }

--- a/core/logic/src/main/java/org/apache/syncope/core/logic/AuditLogic.java
+++ b/core/logic/src/main/java/org/apache/syncope/core/logic/AuditLogic.java
@@ -33,12 +33,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Component
 public class AuditLogic extends AbstractTransactionalLogic<AuditTO> {
     private static final Logger LOG = LoggerFactory.getLogger(AuditLogic.class);
 

--- a/core/logic/src/main/java/org/apache/syncope/core/logic/AuditLogic.java
+++ b/core/logic/src/main/java/org/apache/syncope/core/logic/AuditLogic.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.syncope.core.logic;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.syncope.common.lib.to.AuditTO;
+import org.apache.syncope.common.lib.types.StandardEntitlement;
+import org.apache.syncope.core.persistence.api.dao.AuditDAO;
+import org.apache.syncope.core.persistence.api.dao.search.OrderByClause;
+import org.apache.syncope.core.persistence.api.dao.search.SearchCond;
+import org.apache.syncope.core.persistence.api.entity.AuditEntry;
+import org.apache.syncope.core.provisioning.api.data.AuditDataBinder;
+import org.apache.syncope.core.provisioning.api.utils.RealmUtils;
+import org.apache.syncope.core.spring.security.AuthContextUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class AuditLogic extends AbstractTransactionalLogic<AuditTO> {
+    private static final Logger LOG = LoggerFactory.getLogger(AuditLogic.class);
+
+    @Autowired
+    private AuditDataBinder binder;
+
+    @Autowired
+    private AuditDAO auditDAO;
+
+    @Override
+    protected AuditTO resolveReference(final Method method, final Object... args) throws UnresolvedReferenceException {
+        String who = null;
+
+        if (ArrayUtils.isNotEmpty(args)) {
+            for (int i = 0; who == null && i < args.length; i++) {
+                if (args[i] instanceof String) {
+                    who = (String) args[i];
+                } else if (args[i] instanceof AuditTO) {
+                    who = ((AuditTO) args[i]).getWho();
+                }
+            }
+        }
+
+        if (who != null) {
+            try {
+                return binder.getAuditTO(auditDAO.findByUsername(who));
+            } catch (final Throwable throwable) {
+                LOG.debug("Unresolved reference", throwable);
+                throw new UnresolvedReferenceException(throwable);
+            }
+        }
+
+        throw new UnresolvedReferenceException();
+    }
+
+    @PreAuthorize("hasRole('" + StandardEntitlement.AUDIT_SEARCH + "')")
+    @Transactional(readOnly = true)
+    public Pair<Integer, List<AuditTO>> search(
+        final SearchCond searchCond,
+        final int page, final int size, final List<OrderByClause> orderBy,
+        final String realm,
+        final boolean details) {
+
+        SearchCond effectiveSearchCond = searchCond == null ? auditDAO.getAllMatchingCond() : searchCond;
+        int count = auditDAO.count(RealmUtils.getEffective(
+            AuthContextUtils.getAuthorizations().get(StandardEntitlement.AUDIT_SEARCH), realm), effectiveSearchCond);
+
+        List<AuditEntry> matching = auditDAO.search(RealmUtils.getEffective(
+            AuthContextUtils.getAuthorizations().get(StandardEntitlement.AUDIT_SEARCH), realm),
+            effectiveSearchCond, page, size, orderBy);
+        List<AuditTO> result = matching.stream().
+            map(binder::getAuditTO).
+            collect(Collectors.toList());
+
+        return Pair.of(count, result);
+    }
+}

--- a/core/logic/src/main/java/org/apache/syncope/core/logic/AuditLogic.java
+++ b/core/logic/src/main/java/org/apache/syncope/core/logic/AuditLogic.java
@@ -56,10 +56,11 @@ public class AuditLogic extends AbstractTransactionalLogic<AuditEntryTO> {
         final int size,
         final List<OrderByClause> orderByClauses) {
 
+        Integer count = auditDAO.count(key);
         List<AuditEntry> matching = auditDAO.findByEntityKey(key, page, size, orderByClauses);
         List<AuditEntryTO> results = matching.stream().
             map(audit -> binder.returnAuditTO(binder.getAuditTO(audit))).
             collect(Collectors.toList());
-        return Pair.of(results.size(), results);
+        return Pair.of(count, results);
     }
 }

--- a/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/dao/AuditDAO.java
+++ b/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/dao/AuditDAO.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.syncope.core.persistence.api.dao;
+
+import org.apache.syncope.core.persistence.api.dao.search.OrderByClause;
+import org.apache.syncope.core.persistence.api.dao.search.SearchCond;
+import org.apache.syncope.core.persistence.api.entity.AuditEntry;
+
+import java.util.List;
+import java.util.Set;
+
+public interface AuditDAO<T extends AuditEntry> {
+    AuditEntry findByUsername(String who);
+
+    SearchCond getAllMatchingCond();
+
+    int count(Set<String> adminRealms, SearchCond cond);
+
+    List<AuditEntry> search(Set<String> effective, SearchCond effectiveSearchCond,
+                            int page, int size, List<OrderByClause> orderBy);
+}

--- a/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/dao/AuditDAO.java
+++ b/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/dao/AuditDAO.java
@@ -25,4 +25,6 @@ import java.util.List;
 
 public interface AuditDAO<T extends AuditEntry> {
     List<AuditEntry> findByEntityKey(String key, int page, int size, List<OrderByClause> orderByClauses);
+
+    Integer count(String key);
 }

--- a/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/entity/AuditEntry.java
+++ b/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/entity/AuditEntry.java
@@ -1,0 +1,18 @@
+package org.apache.syncope.core.persistence.api.entity;
+
+import org.apache.syncope.common.lib.types.AuditLoggerName;
+
+import java.io.Serializable;
+
+public interface AuditEntry extends Serializable {
+
+    String getWho();
+
+    AuditLoggerName getLogger();
+
+    Object getBefore();
+
+    Object getOutput();
+
+    Object[] getInput();
+}

--- a/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/entity/AuditEntry.java
+++ b/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/entity/AuditEntry.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.syncope.core.persistence.api.entity;
 
 import org.apache.syncope.common.lib.types.AuditLoggerName;

--- a/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/entity/AuditEntry.java
+++ b/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/entity/AuditEntry.java
@@ -21,6 +21,7 @@ package org.apache.syncope.core.persistence.api.entity;
 import org.apache.syncope.common.lib.types.AuditLoggerName;
 
 import java.io.Serializable;
+import java.util.Date;
 
 public interface AuditEntry extends Serializable {
 
@@ -33,4 +34,10 @@ public interface AuditEntry extends Serializable {
     Object getOutput();
 
     Object[] getInput();
+
+    String getThrowable();
+
+    Date getDate();
+
+    String getKey();
 }

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/JPAAuditDAO.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/JPAAuditDAO.java
@@ -39,7 +39,7 @@ public class JPAAuditDAO implements AuditDAO<AuditEntry> {
     private static final Logger LOG = LoggerFactory.getLogger(JPAAuditDAO.class);
 
     @Override
-    public AuditEntry findByUsername(final String who) {
+    public AuditEntry findByEntityKey(final String key) {
         return null;
     }
 

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/JPAAuditDAO.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/JPAAuditDAO.java
@@ -1,6 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.syncope.core.persistence.jpa.dao;
 
-import org.apache.syncope.common.lib.types.AnyTypeKind;
 import org.apache.syncope.core.persistence.api.dao.AuditDAO;
 import org.apache.syncope.core.persistence.api.dao.search.AnyCond;
 import org.apache.syncope.core.persistence.api.dao.search.AttributeCond;

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/JPAAuditDAO.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/JPAAuditDAO.java
@@ -1,0 +1,50 @@
+package org.apache.syncope.core.persistence.jpa.dao;
+
+import org.apache.syncope.common.lib.types.AnyTypeKind;
+import org.apache.syncope.core.persistence.api.dao.AuditDAO;
+import org.apache.syncope.core.persistence.api.dao.search.AnyCond;
+import org.apache.syncope.core.persistence.api.dao.search.AttributeCond;
+import org.apache.syncope.core.persistence.api.dao.search.OrderByClause;
+import org.apache.syncope.core.persistence.api.dao.search.SearchCond;
+import org.apache.syncope.core.persistence.api.entity.AuditEntry;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Set;
+
+@Transactional(rollbackFor = Throwable.class)
+@Repository
+public class JPAAuditDAO implements AuditDAO<AuditEntry> {
+    private static final Logger LOG = LoggerFactory.getLogger(JPAAuditDAO.class);
+
+    @Override
+    public AuditEntry findByUsername(final String who) {
+        return null;
+    }
+
+    @Override
+    public SearchCond getAllMatchingCond() {
+        AnyCond idCond = new AnyCond(AttributeCond.Type.ISNOTNULL);
+        idCond.setSchema("logger");
+        return SearchCond.getLeafCond(idCond);
+    }
+
+    @Override
+    public int count(final Set<String> adminRealms, final SearchCond cond) {
+        LOG.debug("Search condition:\n{}", cond);
+        if (cond == null || !cond.isValid()) {
+            LOG.error("Invalid search condition:\n{}", cond);
+            return 0;
+        }
+        return 0;
+    }
+
+    @Override
+    public List<AuditEntry> search(final Set<String> effective, final SearchCond effectiveSearchCond,
+                                   final int page, final int size, final List<OrderByClause> orderBy) {
+        return null;
+    }
+}

--- a/core/persistence-jpa/src/test/resources/domains/MasterContent.xml
+++ b/core/persistence-jpa/src/test/resources/domains/MasterContent.xml
@@ -2558,4 +2558,45 @@ $$ }&#10;
   <SyncopeLogger logName="syncope.audit.[LOGIC]:[SyncopeLogic]:[]:[isSelfRegAllowed]:[SUCCESS]" logLevel="DEBUG" logType="AUDIT"/>
   
   <SecurityQuestion id="887028ea-66fc-41e7-b397-620d7ea6dfbb" content="What's your mother's maiden name?"/>
+
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[assign]:[FAILURE]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[assign]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[confirmPasswordReset]:[FAILURE]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[confirmPasswordReset]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[create]:[FAILURE]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[create]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[delete]:[FAILURE]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[delete]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[deprovision]:[FAILURE]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[deprovision]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[link]:[FAILURE]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[link]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[mustChangePassword]:[FAILURE]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[mustChangePassword]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[provision]:[FAILURE]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[provision]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[read]:[FAILURE]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[read]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[requestPasswordReset]:[FAILURE]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[requestPasswordReset]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[search]:[FAILURE]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[search]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[selfCreate]:[FAILURE]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[selfCreate]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[selfDelete]:[FAILURE]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[selfDelete]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[selfRead]:[FAILURE]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[selfRead]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[selfStatus]:[FAILURE]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[selfStatus]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[selfUpdate]:[FAILURE]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[selfUpdate]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[status]:[FAILURE]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[status]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[unassign]:[FAILURE]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[unassign]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[unlink]:[FAILURE]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[unlink]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[update]:[FAILURE]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[update]:[SUCCESS]" LOGLEVEL="DEBUG"/>
 </dataset>

--- a/core/persistence-jpa/src/test/resources/domains/MasterContent.xml
+++ b/core/persistence-jpa/src/test/resources/domains/MasterContent.xml
@@ -2602,4 +2602,19 @@ $$ }&#10;
   <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[unlink]:[SUCCESS]" LOGLEVEL="DEBUG"/>
   <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[update]:[FAILURE]" LOGLEVEL="DEBUG"/>
   <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[UserLogic]:[]:[update]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[GroupLogic]:[]:[assign]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[GroupLogic]:[]:[create]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[GroupLogic]:[]:[delete]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[GroupLogic]:[]:[deprovision]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[GroupLogic]:[]:[link]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[GroupLogic]:[]:[own]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[GroupLogic]:[]:[provisionMembers]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[GroupLogic]:[]:[provision]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[GroupLogic]:[]:[read]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[GroupLogic]:[]:[search]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[GroupLogic]:[]:[unassign]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[GroupLogic]:[]:[unlink]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[GroupLogic]:[]:[update]:[SUCCESS]" LOGLEVEL="DEBUG"/>
+  <SYNCOPELOGGER LOGTYPE="AUDIT" LOGNAME="syncope.audit.[LOGIC]:[SyncopeLogic]:[]:[isSelfRegAllowed]:[SUCCESS]" LOGLEVEL="DEBUG"/>
 </dataset>

--- a/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/AuditEntryImpl.java
+++ b/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/AuditEntryImpl.java
@@ -27,6 +27,8 @@ import org.apache.syncope.common.lib.to.UserTO;
 import org.apache.syncope.common.lib.types.AuditLoggerName;
 import org.apache.syncope.core.persistence.api.entity.AuditEntry;
 
+import java.util.Date;
+
 public class AuditEntryImpl implements AuditEntry {
 
     private static final long serialVersionUID = -2299082316063743582L;
@@ -43,6 +45,12 @@ public class AuditEntryImpl implements AuditEntry {
 
     private final Object[] input;
 
+    private String throwable;
+
+    private Date date;
+
+    private String key;
+    
     @JsonCreator
     public AuditEntryImpl(
         @JsonProperty("who") final String who,
@@ -111,6 +119,33 @@ public class AuditEntryImpl implements AuditEntry {
         return input;
     }
 
+    @Override
+    public String getThrowable() {
+        return throwable;
+    }
+
+    public void setThrowable(final String throwable) {
+        this.throwable = throwable;
+    }
+
+    @Override
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(final Date date) {
+        this.date = date;
+    }
+
+    @Override
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(final String key) {
+        this.key = key;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -126,7 +161,28 @@ public class AuditEntryImpl implements AuditEntry {
 
         private Object[] input;
 
+        private String throwable;
+
+        private Date date;
+
+        private String key;
+
         private Builder() {
+        }
+
+        public Builder date(final Date date) {
+            this.date = date;
+            return this;
+        }
+
+        public Builder throwable(final String throwable) {
+            this.throwable = throwable;
+            return this;
+        }
+
+        public Builder key(final String key) {
+            this.key = key;
+            return this;
         }
 
         public Builder who(final String who) {
@@ -155,7 +211,11 @@ public class AuditEntryImpl implements AuditEntry {
         }
 
         public AuditEntryImpl build() {
-            return new AuditEntryImpl(who, logger, before, output, input);
+            AuditEntryImpl entry = new AuditEntryImpl(who, logger, before, output, input);
+            entry.setDate(date);
+            entry.setThrowable(throwable);
+            entry.setKey(key);
+            return entry;
         }
     }
 }

--- a/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/AuditEntryImpl.java
+++ b/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/AuditEntryImpl.java
@@ -110,4 +110,52 @@ public class AuditEntryImpl implements AuditEntry {
     public Object[] getInput() {
         return input;
     }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String who;
+
+        private AuditLoggerName logger;
+
+        private Object before;
+
+        private Object output;
+
+        private Object[] input;
+
+        private Builder() {
+        }
+
+        public Builder who(final String who) {
+            this.who = who;
+            return this;
+        }
+
+        public Builder logger(final AuditLoggerName logger) {
+            this.logger = logger;
+            return this;
+        }
+
+        public Builder before(final Object before) {
+            this.before = before;
+            return this;
+        }
+
+        public Builder output(final Object output) {
+            this.output = output;
+            return this;
+        }
+
+        public Builder input(final Object[] input) {
+            this.input = input;
+            return this;
+        }
+
+        public AuditEntryImpl build() {
+            return new AuditEntryImpl(who, logger, before, output, input);
+        }
+    }
 }

--- a/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/AuditEntryImpl.java
+++ b/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/AuditEntryImpl.java
@@ -16,18 +16,18 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.syncope.core.provisioning.java;
+package org.apache.syncope.core.provisioning.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.io.Serializable;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.SerializationUtils;
 import org.apache.syncope.common.lib.patch.UserPatch;
 import org.apache.syncope.common.lib.to.UserTO;
 import org.apache.syncope.common.lib.types.AuditLoggerName;
+import org.apache.syncope.core.persistence.api.entity.AuditEntry;
 
-public class AuditEntry implements Serializable {
+public class AuditEntryImpl implements AuditEntry {
 
     private static final long serialVersionUID = -2299082316063743582L;
 
@@ -44,12 +44,12 @@ public class AuditEntry implements Serializable {
     private final Object[] input;
 
     @JsonCreator
-    public AuditEntry(
-            @JsonProperty("who") final String who,
-            @JsonProperty("logger") final AuditLoggerName logger,
-            @JsonProperty("before") final Object before,
-            @JsonProperty("output") final Object output,
-            @JsonProperty("input") final Object[] input) {
+    public AuditEntryImpl(
+        @JsonProperty("who") final String who,
+        @JsonProperty("logger") final AuditLoggerName logger,
+        @JsonProperty("before") final Object before,
+        @JsonProperty("output") final Object output,
+        @JsonProperty("input") final Object[] input) {
 
         super();
 
@@ -65,7 +65,7 @@ public class AuditEntry implements Serializable {
         }
     }
 
-    private Object maskSensitive(final Object object) {
+    private static Object maskSensitive(final Object object) {
         Object masked;
 
         if (object instanceof UserTO) {
@@ -86,22 +86,27 @@ public class AuditEntry implements Serializable {
         return masked;
     }
 
+    @Override
     public String getWho() {
         return who;
     }
 
+    @Override
     public AuditLoggerName getLogger() {
         return logger;
     }
 
+    @Override
     public Object getBefore() {
         return before;
     }
 
+    @Override
     public Object getOutput() {
         return output;
     }
 
+    @Override
     public Object[] getInput() {
         return input;
     }

--- a/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/data/AuditDataBinder.java
+++ b/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/data/AuditDataBinder.java
@@ -22,10 +22,7 @@ import org.apache.syncope.common.lib.to.AuditEntryTO;
 import org.apache.syncope.core.persistence.api.entity.AuditEntry;
 
 public interface AuditDataBinder {
-
-    AuditEntry create(AuditEntryTO applicationTO);
-
-    AuditEntryTO getAuditTO(AuditEntry application, boolean details);
+    AuditEntryTO getAuditTO(AuditEntry application);
 
     AuditEntryTO returnAuditTO(AuditEntryTO user);
 }

--- a/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/data/AuditDataBinder.java
+++ b/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/data/AuditDataBinder.java
@@ -25,7 +25,7 @@ public interface AuditDataBinder {
 
     AuditEntry create(AuditEntryTO applicationTO);
 
-    AuditEntryTO getAuditTO(AuditEntry application);
+    AuditEntryTO getAuditTO(AuditEntry application, boolean details);
 
-    AuditEntryTO returnAuditTO(AuditEntryTO user, boolean details);
+    AuditEntryTO returnAuditTO(AuditEntryTO user);
 }

--- a/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/data/AuditDataBinder.java
+++ b/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/data/AuditDataBinder.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.syncope.core.provisioning.api.data;
+
+import org.apache.syncope.common.lib.to.AuditTO;
+import org.apache.syncope.core.persistence.api.entity.AuditEntry;
+
+public interface AuditDataBinder {
+
+    AuditEntry create(AuditTO applicationTO);
+
+    AuditTO getAuditTO(AuditEntry application);
+}

--- a/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/data/AuditDataBinder.java
+++ b/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/data/AuditDataBinder.java
@@ -18,12 +18,14 @@
  */
 package org.apache.syncope.core.provisioning.api.data;
 
-import org.apache.syncope.common.lib.to.AuditTO;
+import org.apache.syncope.common.lib.to.AuditEntryTO;
 import org.apache.syncope.core.persistence.api.entity.AuditEntry;
 
 public interface AuditDataBinder {
 
-    AuditEntry create(AuditTO applicationTO);
+    AuditEntry create(AuditEntryTO applicationTO);
 
-    AuditTO getAuditTO(AuditEntry application);
+    AuditEntryTO getAuditTO(AuditEntry application);
+
+    AuditEntryTO returnAuditTO(AuditEntryTO user, boolean details);
 }

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/DefaultAuditManager.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/DefaultAuditManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.syncope.core.provisioning.java;
 
+import org.apache.syncope.core.persistence.api.entity.AuditEntry;
 import org.apache.syncope.core.provisioning.api.AuditEntryImpl;
 import org.apache.syncope.core.provisioning.api.AuditManager;
 import org.apache.syncope.common.lib.types.AuditElements;
@@ -48,12 +49,10 @@ public class DefaultAuditManager implements AuditManager {
             final String subcategory,
             final String event) {
 
-        AuditEntryImpl auditEntry = new AuditEntryImpl(
-                who,
-                new AuditLoggerName(type, category, subcategory, event, Result.SUCCESS),
-                null,
-                null,
-                null);
+        AuditEntry auditEntry = AuditEntryImpl.builder()
+            .who(who)
+            .logger(new AuditLoggerName(type, category, subcategory, event, Result.SUCCESS))
+            .build();
         org.apache.syncope.core.persistence.api.entity.Logger syncopeLogger =
                 loggerDAO.find(auditEntry.getLogger().toLoggerName());
         boolean auditRequested = syncopeLogger != null && syncopeLogger.getLevel() == LoggerLevel.DEBUG;
@@ -62,12 +61,10 @@ public class DefaultAuditManager implements AuditManager {
             return true;
         }
 
-        auditEntry = new AuditEntryImpl(
-                who,
-                new AuditLoggerName(type, category, subcategory, event, Result.FAILURE),
-                null,
-                null,
-                null);
+        auditEntry = AuditEntryImpl.builder()
+            .who(who)
+            .logger(new AuditLoggerName(type, category, subcategory, event, Result.FAILURE))
+            .build();
         syncopeLogger = loggerDAO.find(auditEntry.getLogger().toLoggerName());
         auditRequested = syncopeLogger != null && syncopeLogger.getLevel() == LoggerLevel.DEBUG;
 
@@ -107,13 +104,14 @@ public class DefaultAuditManager implements AuditManager {
             throwable = (Throwable) output;
         }
 
-        AuditEntryImpl auditEntry = new AuditEntryImpl(
-                who,
-                new AuditLoggerName(type, category, subcategory, event, condition),
-                before,
-                throwable == null ? output : throwable.getMessage(),
-                input);
-
+        AuditEntry auditEntry = AuditEntryImpl.builder()
+            .who(who)
+            .logger(new AuditLoggerName(type, category, subcategory, event, condition))
+            .before(before)
+            .output(throwable == null ? output : throwable.getMessage())
+            .input(input)
+            .build();
+        
         org.apache.syncope.core.persistence.api.entity.Logger syncopeLogger =
                 loggerDAO.find(auditEntry.getLogger().toLoggerName());
         if (syncopeLogger != null && syncopeLogger.getLevel() == LoggerLevel.DEBUG) {

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/DefaultAuditManager.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/DefaultAuditManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.syncope.core.provisioning.java;
 
+import org.apache.syncope.core.provisioning.api.AuditEntryImpl;
 import org.apache.syncope.core.provisioning.api.AuditManager;
 import org.apache.syncope.common.lib.types.AuditElements;
 import org.apache.syncope.common.lib.types.AuditElements.Result;
@@ -47,7 +48,7 @@ public class DefaultAuditManager implements AuditManager {
             final String subcategory,
             final String event) {
 
-        AuditEntry auditEntry = new AuditEntry(
+        AuditEntryImpl auditEntry = new AuditEntryImpl(
                 who,
                 new AuditLoggerName(type, category, subcategory, event, Result.SUCCESS),
                 null,
@@ -61,7 +62,7 @@ public class DefaultAuditManager implements AuditManager {
             return true;
         }
 
-        auditEntry = new AuditEntry(
+        auditEntry = new AuditEntryImpl(
                 who,
                 new AuditLoggerName(type, category, subcategory, event, Result.FAILURE),
                 null,
@@ -106,7 +107,7 @@ public class DefaultAuditManager implements AuditManager {
             throwable = (Throwable) output;
         }
 
-        AuditEntry auditEntry = new AuditEntry(
+        AuditEntryImpl auditEntry = new AuditEntryImpl(
                 who,
                 new AuditLoggerName(type, category, subcategory, event, condition),
                 before,

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/AuditDataBinderImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/AuditDataBinderImpl.java
@@ -1,0 +1,19 @@
+package org.apache.syncope.core.provisioning.java.data;
+
+import org.apache.syncope.common.lib.to.AuditTO;
+import org.apache.syncope.core.persistence.api.entity.AuditEntry;
+import org.apache.syncope.core.provisioning.api.data.AuditDataBinder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuditDataBinderImpl implements AuditDataBinder {
+    @Override
+    public AuditEntry create(final AuditTO applicationTO) {
+        return null;
+    }
+
+    @Override
+    public AuditTO getAuditTO(final AuditEntry application) {
+        return null;
+    }
+}

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/AuditDataBinderImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/AuditDataBinderImpl.java
@@ -1,6 +1,5 @@
 package org.apache.syncope.core.provisioning.java.data;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.syncope.common.lib.to.AuditEntryTO;
@@ -23,12 +22,10 @@ public class AuditDataBinderImpl implements AuditDataBinder {
         auditTO.setThrowable(auditEntry.getThrowable());
         auditTO.setLoggerName(auditEntry.getLogger().toLoggerName());
 
-        if (StringUtils.isNotBlank(auditEntry.getLogger().getSubcategory())) {
-            auditTO.setSubCategory(auditEntry.getLogger().getSubcategory());
-        }
-        if (StringUtils.isNotBlank(auditEntry.getLogger().getEvent())) {
-            auditTO.setEvent(auditEntry.getLogger().getEvent());
-        }
+
+        auditTO.setSubCategory(auditEntry.getLogger().getSubcategory());
+        auditTO.setEvent(auditEntry.getLogger().getEvent());
+
         if (auditEntry.getLogger().getResult() != null) {
             auditTO.setResult(auditEntry.getLogger().getResult().name());
         }
@@ -54,7 +51,7 @@ public class AuditDataBinderImpl implements AuditDataBinder {
     }
 
     @Override
-    public AuditEntryTO returnAuditTO(final AuditEntryTO user) {
-        return user;
+    public AuditEntryTO returnAuditTO(final AuditEntryTO auditEntryTO) {
+        return auditEntryTO;
     }
 }

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/AuditDataBinderImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/AuditDataBinderImpl.java
@@ -1,24 +1,60 @@
 package org.apache.syncope.core.provisioning.java.data;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.syncope.common.lib.to.AuditEntryTO;
 import org.apache.syncope.core.persistence.api.entity.AuditEntry;
 import org.apache.syncope.core.provisioning.api.data.AuditDataBinder;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 @Component
 public class AuditDataBinderImpl implements AuditDataBinder {
-    @Override
-    public AuditEntry create(final AuditEntryTO applicationTO) {
-        return null;
-    }
 
     @Override
-    public AuditEntryTO getAuditTO(final AuditEntry application, final boolean details) {
-        return null;
+    public AuditEntryTO getAuditTO(final AuditEntry auditEntry) {
+        AuditEntryTO auditTO = new AuditEntryTO();
+        auditTO.setKey(auditEntry.getKey());
+        auditTO.setWho(auditEntry.getWho());
+        auditTO.setDate(auditEntry.getDate());
+        auditTO.setThrowable(auditEntry.getThrowable());
+        auditTO.setLoggerName(auditEntry.getLogger().toLoggerName());
+
+        if (StringUtils.isNotBlank(auditEntry.getLogger().getSubcategory())) {
+            auditTO.setSubCategory(auditEntry.getLogger().getSubcategory());
+        }
+        if (StringUtils.isNotBlank(auditEntry.getLogger().getEvent())) {
+            auditTO.setEvent(auditEntry.getLogger().getEvent());
+        }
+        if (auditEntry.getLogger().getResult() != null) {
+            auditTO.setResult(auditEntry.getLogger().getResult().name());
+        }
+
+        if (auditEntry.getBefore() != null) {
+            String before = ToStringBuilder.reflectionToString(
+                auditEntry.getBefore(), ToStringStyle.JSON_STYLE);
+            auditTO.setBefore(before);
+        }
+
+        if (auditEntry.getInput() != null) {
+            auditTO.getInputs().addAll(Arrays.stream(auditEntry.getInput())
+                .map(input -> ToStringBuilder.reflectionToString(input, ToStringStyle.JSON_STYLE))
+                .collect(Collectors.toList()));
+        }
+
+        if (auditEntry.getOutput() != null) {
+            auditTO.setOutput(ToStringBuilder.reflectionToString(
+                auditEntry.getOutput(), ToStringStyle.JSON_STYLE));
+        }
+        
+        return auditTO;
     }
 
     @Override
     public AuditEntryTO returnAuditTO(final AuditEntryTO user) {
-        return null;
+        return user;
     }
 }

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/AuditDataBinderImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/AuditDataBinderImpl.java
@@ -1,6 +1,6 @@
 package org.apache.syncope.core.provisioning.java.data;
 
-import org.apache.syncope.common.lib.to.AuditTO;
+import org.apache.syncope.common.lib.to.AuditEntryTO;
 import org.apache.syncope.core.persistence.api.entity.AuditEntry;
 import org.apache.syncope.core.provisioning.api.data.AuditDataBinder;
 import org.springframework.stereotype.Component;
@@ -8,12 +8,17 @@ import org.springframework.stereotype.Component;
 @Component
 public class AuditDataBinderImpl implements AuditDataBinder {
     @Override
-    public AuditEntry create(final AuditTO applicationTO) {
+    public AuditEntry create(final AuditEntryTO applicationTO) {
         return null;
     }
 
     @Override
-    public AuditTO getAuditTO(final AuditEntry application) {
+    public AuditEntryTO getAuditTO(final AuditEntry application) {
+        return null;
+    }
+
+    @Override
+    public AuditEntryTO returnAuditTO(final AuditEntryTO user, final boolean details) {
         return null;
     }
 }

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/AuditDataBinderImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/AuditDataBinderImpl.java
@@ -13,12 +13,12 @@ public class AuditDataBinderImpl implements AuditDataBinder {
     }
 
     @Override
-    public AuditEntryTO getAuditTO(final AuditEntry application) {
+    public AuditEntryTO getAuditTO(final AuditEntry application, final boolean details) {
         return null;
     }
 
     @Override
-    public AuditEntryTO returnAuditTO(final AuditEntryTO user, final boolean details) {
+    public AuditEntryTO returnAuditTO(final AuditEntryTO user) {
         return null;
     }
 }

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/job/report/AuditReportlet.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/job/report/AuditReportlet.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.syncope.common.lib.report.AuditReportletConf;
 import org.apache.syncope.common.lib.report.ReportletConf;
+import org.apache.syncope.core.persistence.api.entity.AuditEntry;
 import org.apache.syncope.core.provisioning.api.AuditEntryImpl;
 import org.apache.syncope.core.spring.security.AuthContextUtils;
 import org.apache.syncope.core.provisioning.api.serialization.POJOHelper;
@@ -59,7 +60,7 @@ public class AuditReportlet extends AbstractReportlet {
         handler.startElement("", "", "events", null);
         AttributesImpl atts = new AttributesImpl();
         for (Map<String, Object> row : rows) {
-            AuditEntryImpl auditEntry = POJOHelper.deserialize(row.get("MESSAGE").toString(), AuditEntryImpl.class);
+            AuditEntry auditEntry = POJOHelper.deserialize(row.get("MESSAGE").toString(), AuditEntryImpl.class);
 
             atts.clear();
             if (StringUtils.isNotBlank(auditEntry.getWho())) {

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/job/report/AuditReportlet.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/job/report/AuditReportlet.java
@@ -27,7 +27,7 @@ import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.syncope.common.lib.report.AuditReportletConf;
 import org.apache.syncope.common.lib.report.ReportletConf;
-import org.apache.syncope.core.provisioning.java.AuditEntry;
+import org.apache.syncope.core.provisioning.api.AuditEntryImpl;
 import org.apache.syncope.core.spring.security.AuthContextUtils;
 import org.apache.syncope.core.provisioning.api.serialization.POJOHelper;
 import org.apache.syncope.core.persistence.api.DomainsHolder;
@@ -59,7 +59,7 @@ public class AuditReportlet extends AbstractReportlet {
         handler.startElement("", "", "events", null);
         AttributesImpl atts = new AttributesImpl();
         for (Map<String, Object> row : rows) {
-            AuditEntry auditEntry = POJOHelper.deserialize(row.get("MESSAGE").toString(), AuditEntry.class);
+            AuditEntryImpl auditEntry = POJOHelper.deserialize(row.get("MESSAGE").toString(), AuditEntryImpl.class);
 
             atts.clear();
             if (StringUtils.isNotBlank(auditEntry.getWho())) {

--- a/core/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AbstractAnyService.java
+++ b/core/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AbstractAnyService.java
@@ -56,8 +56,8 @@ import org.apache.syncope.core.provisioning.api.serialization.POJOHelper;
 import org.apache.syncope.core.spring.security.SecureRandomUtils;
 
 public abstract class AbstractAnyService<TO extends AnyTO, P extends AnyPatch>
-        extends AbstractServiceImpl
-        implements AnyService<TO> {
+    extends AbstractServiceImpl
+    implements AnyService<TO> {
 
     protected abstract AnyDAO<?> getAnyDAO();
 
@@ -122,20 +122,20 @@ public abstract class AbstractAnyService<TO extends AnyTO, P extends AnyPatch>
 
         // if an assignable query is provided in the FIQL string, start anyway from root realm
         boolean isAssignableCond = StringUtils.isBlank(anyQuery.getFiql())
-                ? false
-                : -1 != anyQuery.getFiql().indexOf(SpecialAttr.ASSIGNABLE.toString());
+            ? false
+            : -1 != anyQuery.getFiql().indexOf(SpecialAttr.ASSIGNABLE.toString());
 
         SearchCond searchCond = StringUtils.isBlank(anyQuery.getFiql())
-                ? null
-                : getSearchCond(anyQuery.getFiql(), realm);
-                
+            ? null
+            : getSearchCond(anyQuery.getFiql(), realm);
+
         Pair<Integer, List<TO>> result = getAnyLogic().search(
-                searchCond,
-                anyQuery.getPage(),
-                anyQuery.getSize(),
-                getOrderByClauses(anyQuery.getOrderBy()),
-                isAssignableCond ? SyncopeConstants.ROOT_REALM : realm,
-                anyQuery.getDetails());
+            searchCond,
+            anyQuery.getPage(),
+            anyQuery.getSize(),
+            getOrderByClauses(anyQuery.getOrderBy()),
+            isAssignableCond ? SyncopeConstants.ROOT_REALM : realm,
+            anyQuery.getDetails());
 
         return buildPagedResult(result.getRight(), anyQuery.getPage(), anyQuery.getSize(), result.getLeft());
     }
@@ -159,7 +159,7 @@ public abstract class AbstractAnyService<TO extends AnyTO, P extends AnyPatch>
     }
 
     private void addUpdateOrReplaceAttr(
-            final String key, final SchemaType schemaType, final AttrTO attrTO, final PatchOperation operation) {
+        final String key, final SchemaType schemaType, final AttrTO attrTO, final PatchOperation operation) {
 
         if (attrTO.getSchema() == null) {
             throw new NotFoundException("Must specify schema");
@@ -193,10 +193,10 @@ public abstract class AbstractAnyService<TO extends AnyTO, P extends AnyPatch>
     @Override
     public void delete(final String key, final SchemaType schemaType, final String schema) {
         addUpdateOrReplaceAttr(
-                getActualKey(getAnyDAO(), key),
-                schemaType,
-                new AttrTO.Builder().schema(schema).build(),
-                PatchOperation.DELETE);
+            getActualKey(getAnyDAO(), key),
+            schemaType,
+            new AttrTO.Builder().schema(schema).build(),
+            PatchOperation.DELETE);
     }
 
     @Override
@@ -242,13 +242,13 @@ public abstract class AbstractAnyService<TO extends AnyTO, P extends AnyPatch>
                 item.getHeaders().put(RESTHeaders.RESOURCE_KEY, Arrays.asList(resource));
 
                 item.setStatus(updated.getEntity().getResources().contains(resource)
-                        ? Response.Status.BAD_REQUEST.getStatusCode()
-                        : Response.Status.OK.getStatusCode());
+                    ? Response.Status.BAD_REQUEST.getStatusCode()
+                    : Response.Status.OK.getStatusCode());
 
                 if (getPreference() == Preference.RETURN_NO_CONTENT) {
                     item.getHeaders().put(
-                            RESTHeaders.PREFERENCE_APPLIED,
-                            Arrays.asList(Preference.RETURN_NO_CONTENT.toString()));
+                        RESTHeaders.PREFERENCE_APPLIED,
+                        Arrays.asList(Preference.RETURN_NO_CONTENT.toString()));
                 } else {
                     item.setContent(POJOHelper.serialize(updated.getEntity()));
                 }
@@ -257,34 +257,34 @@ public abstract class AbstractAnyService<TO extends AnyTO, P extends AnyPatch>
             }).collect(Collectors.toList());
         } else {
             batchResponseItems = updated.getPropagationStatuses().stream().
-                    map(status -> {
-                        BatchResponseItem item = new BatchResponseItem();
+                map(status -> {
+                    BatchResponseItem item = new BatchResponseItem();
 
-                        item.getHeaders().put(RESTHeaders.RESOURCE_KEY, Arrays.asList(status.getResource()));
+                    item.getHeaders().put(RESTHeaders.RESOURCE_KEY, Arrays.asList(status.getResource()));
 
-                        item.setStatus(status.getStatus().getHttpStatus());
+                    item.setStatus(status.getStatus().getHttpStatus());
 
-                        if (status.getFailureReason() != null) {
-                            item.getHeaders().put(RESTHeaders.ERROR_INFO, Arrays.asList(status.getFailureReason()));
-                        }
+                    if (status.getFailureReason() != null) {
+                        item.getHeaders().put(RESTHeaders.ERROR_INFO, Arrays.asList(status.getFailureReason()));
+                    }
 
-                        if (getPreference() == Preference.RETURN_NO_CONTENT) {
-                            item.getHeaders().put(
-                                    RESTHeaders.PREFERENCE_APPLIED,
-                                    Arrays.asList(Preference.RETURN_NO_CONTENT.toString()));
-                        } else {
-                            item.setContent(POJOHelper.serialize(updated.getEntity()));
-                        }
+                    if (getPreference() == Preference.RETURN_NO_CONTENT) {
+                        item.getHeaders().put(
+                            RESTHeaders.PREFERENCE_APPLIED,
+                            Arrays.asList(Preference.RETURN_NO_CONTENT.toString()));
+                    } else {
+                        item.setContent(POJOHelper.serialize(updated.getEntity()));
+                    }
 
-                        return item;
-                    }).collect(Collectors.toList());
+                    return item;
+                }).collect(Collectors.toList());
         }
 
         String boundary = "deassociate_" + SecureRandomUtils.generateRandomUUID().toString();
         return Response.ok(BatchPayloadGenerator.generate(
-                batchResponseItems, SyncopeConstants.DOUBLE_DASH + boundary)).
-                type(RESTHeaders.multipartMixedWith(boundary)).
-                build();
+            batchResponseItems, SyncopeConstants.DOUBLE_DASH + boundary)).
+            type(RESTHeaders.multipartMixedWith(boundary)).
+            build();
     }
 
     @Override
@@ -297,26 +297,26 @@ public abstract class AbstractAnyService<TO extends AnyTO, P extends AnyPatch>
             case LINK:
                 updated = new ProvisioningResult<>();
                 updated.setEntity(getAnyLogic().link(
-                        patch.getKey(),
-                        patch.getResources()));
+                    patch.getKey(),
+                    patch.getResources()));
                 break;
 
             case ASSIGN:
                 updated = getAnyLogic().assign(
-                        patch.getKey(),
-                        patch.getResources(),
-                        patch.getValue() != null,
-                        patch.getValue(),
-                        isNullPriorityAsync());
+                    patch.getKey(),
+                    patch.getResources(),
+                    patch.getValue() != null,
+                    patch.getValue(),
+                    isNullPriorityAsync());
                 break;
 
             case PROVISION:
                 updated = getAnyLogic().provision(
-                        patch.getKey(),
-                        patch.getResources(),
-                        patch.getValue() != null,
-                        patch.getValue(),
-                        isNullPriorityAsync());
+                    patch.getKey(),
+                    patch.getResources(),
+                    patch.getValue() != null,
+                    patch.getValue(),
+                    isNullPriorityAsync());
                 break;
 
             default:
@@ -331,13 +331,13 @@ public abstract class AbstractAnyService<TO extends AnyTO, P extends AnyPatch>
                 item.getHeaders().put(RESTHeaders.RESOURCE_KEY, Arrays.asList(resource));
 
                 item.setStatus(updated.getEntity().getResources().contains(resource)
-                        ? Response.Status.OK.getStatusCode()
-                        : Response.Status.BAD_REQUEST.getStatusCode());
+                    ? Response.Status.OK.getStatusCode()
+                    : Response.Status.BAD_REQUEST.getStatusCode());
 
                 if (getPreference() == Preference.RETURN_NO_CONTENT) {
                     item.getHeaders().put(
-                            RESTHeaders.PREFERENCE_APPLIED,
-                            Arrays.asList(Preference.RETURN_NO_CONTENT.toString()));
+                        RESTHeaders.PREFERENCE_APPLIED,
+                        Arrays.asList(Preference.RETURN_NO_CONTENT.toString()));
                 } else {
                     item.setContent(POJOHelper.serialize(updated.getEntity()));
                 }
@@ -346,33 +346,33 @@ public abstract class AbstractAnyService<TO extends AnyTO, P extends AnyPatch>
             }).collect(Collectors.toList());
         } else {
             batchResponseItems = updated.getPropagationStatuses().stream().
-                    map(status -> {
-                        BatchResponseItem item = new BatchResponseItem();
+                map(status -> {
+                    BatchResponseItem item = new BatchResponseItem();
 
-                        item.getHeaders().put(RESTHeaders.RESOURCE_KEY, Arrays.asList(status.getResource()));
+                    item.getHeaders().put(RESTHeaders.RESOURCE_KEY, Arrays.asList(status.getResource()));
 
-                        item.setStatus(status.getStatus().getHttpStatus());
+                    item.setStatus(status.getStatus().getHttpStatus());
 
-                        if (status.getFailureReason() != null) {
-                            item.getHeaders().put(RESTHeaders.ERROR_INFO, Arrays.asList(status.getFailureReason()));
-                        }
+                    if (status.getFailureReason() != null) {
+                        item.getHeaders().put(RESTHeaders.ERROR_INFO, Arrays.asList(status.getFailureReason()));
+                    }
 
-                        if (getPreference() == Preference.RETURN_NO_CONTENT) {
-                            item.getHeaders().put(
-                                    RESTHeaders.PREFERENCE_APPLIED,
-                                    Arrays.asList(Preference.RETURN_NO_CONTENT.toString()));
-                        } else {
-                            item.setContent(POJOHelper.serialize(updated.getEntity()));
-                        }
+                    if (getPreference() == Preference.RETURN_NO_CONTENT) {
+                        item.getHeaders().put(
+                            RESTHeaders.PREFERENCE_APPLIED,
+                            Arrays.asList(Preference.RETURN_NO_CONTENT.toString()));
+                    } else {
+                        item.setContent(POJOHelper.serialize(updated.getEntity()));
+                    }
 
-                        return item;
-                    }).collect(Collectors.toList());
+                    return item;
+                }).collect(Collectors.toList());
         }
 
         String boundary = "associate_" + SecureRandomUtils.generateRandomUUID().toString();
         return Response.ok(BatchPayloadGenerator.generate(
-                batchResponseItems, SyncopeConstants.DOUBLE_DASH + boundary)).
-                type(RESTHeaders.multipartMixedWith(boundary)).
-                build();
+            batchResponseItems, SyncopeConstants.DOUBLE_DASH + boundary)).
+            type(RESTHeaders.multipartMixedWith(boundary)).
+            build();
     }
 }

--- a/core/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AbstractAnyService.java
+++ b/core/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AbstractAnyService.java
@@ -128,7 +128,7 @@ public abstract class AbstractAnyService<TO extends AnyTO, P extends AnyPatch>
         SearchCond searchCond = StringUtils.isBlank(anyQuery.getFiql())
                 ? null
                 : getSearchCond(anyQuery.getFiql(), realm);
-
+                
         Pair<Integer, List<TO>> result = getAnyLogic().search(
                 searchCond,
                 anyQuery.getPage(),

--- a/core/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AuditServiceImpl.java
+++ b/core/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AuditServiceImpl.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.syncope.common.lib.SyncopeConstants;
 import org.apache.syncope.common.lib.search.SpecialAttr;
-import org.apache.syncope.common.lib.to.AuditTO;
+import org.apache.syncope.common.lib.to.AuditEntryTO;
 import org.apache.syncope.common.lib.to.PagedResult;
 import org.apache.syncope.common.rest.api.beans.AnyQuery;
 import org.apache.syncope.common.rest.api.service.AuditService;
@@ -39,7 +39,7 @@ public class AuditServiceImpl extends AbstractServiceImpl implements AuditServic
     private AuditLogic logic;
 
     @Override
-    public PagedResult<AuditTO> search(final AnyQuery anyQuery) {
+    public PagedResult<AuditEntryTO> search(final AnyQuery anyQuery) {
         String realm = StringUtils.prependIfMissing(anyQuery.getRealm(), SyncopeConstants.ROOT_REALM);
 
         boolean isAssignableCond = !StringUtils.isBlank(anyQuery.getFiql())
@@ -49,7 +49,7 @@ public class AuditServiceImpl extends AbstractServiceImpl implements AuditServic
             ? null
             : getSearchCond(anyQuery.getFiql(), realm);
 
-        Pair<Integer, List<AuditTO>> result = this.logic.search(
+        Pair<Integer, List<AuditEntryTO>> result = this.logic.search(
             searchCond,
             anyQuery.getPage(),
             anyQuery.getSize(),

--- a/core/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AuditServiceImpl.java
+++ b/core/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AuditServiceImpl.java
@@ -19,102 +19,46 @@
 package org.apache.syncope.core.rest.cxf.service;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.syncope.common.lib.SyncopeConstants;
+import org.apache.syncope.common.lib.search.SpecialAttr;
 import org.apache.syncope.common.lib.to.AuditTO;
+import org.apache.syncope.common.lib.to.PagedResult;
+import org.apache.syncope.common.rest.api.beans.AnyQuery;
 import org.apache.syncope.common.rest.api.service.AuditService;
-import org.apache.syncope.core.persistence.api.DomainsHolder;
-import org.apache.syncope.core.provisioning.api.serialization.POJOHelper;
-import org.apache.syncope.core.provisioning.java.AuditEntry;
-import org.apache.syncope.core.spring.security.AuthContextUtils;
+import org.apache.syncope.core.logic.AuditLogic;
+import org.apache.syncope.core.persistence.api.dao.search.SearchCond;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.jdbc.core.RowMapper;
-import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.stereotype.Service;
 
-import javax.sql.DataSource;
-
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Timestamp;
-import java.util.Arrays;
-import java.util.Date;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 public class AuditServiceImpl extends AbstractServiceImpl implements AuditService {
-    private static final String SQL_TABLE = "SYNCOPEAUDIT";
-
-    private static final String SQL_SELECT = "SELECT * FROM SYNCOPEAUDIT %s ORDER BY EVENT_DATE DESC";
-
     @Autowired
-    private DomainsHolder domainsHolder;
+    private AuditLogic logic;
 
     @Override
-    public List<AuditTO> list() {
-        return getJdbcTemplate().
-            query(String.format(SQL_SELECT, StringUtils.EMPTY), new AuditTORowMapper());
+    public PagedResult<AuditTO> search(final AnyQuery anyQuery) {
+        String realm = StringUtils.prependIfMissing(anyQuery.getRealm(), SyncopeConstants.ROOT_REALM);
+
+        boolean isAssignableCond = !StringUtils.isBlank(anyQuery.getFiql())
+            && anyQuery.getFiql().contains(SpecialAttr.ASSIGNABLE.toString());
+
+        SearchCond searchCond = StringUtils.isBlank(anyQuery.getFiql())
+            ? null
+            : getSearchCond(anyQuery.getFiql(), realm);
+
+        Pair<Integer, List<AuditTO>> result = this.logic.search(
+            searchCond,
+            anyQuery.getPage(),
+            anyQuery.getSize(),
+            getOrderByClauses(anyQuery.getOrderBy()),
+            isAssignableCond ? SyncopeConstants.ROOT_REALM : realm,
+            anyQuery.getDetails());
+
+        return buildPagedResult(result.getRight(), anyQuery.getPage(), anyQuery.getSize(), result.getLeft());
     }
 
-    @Override
-    public AuditTO read(final String logger) {
-        return getJdbcTemplate().
-            queryForObject(String.format(SQL_SELECT, "WHERE LOGGER=:logger"),
-                new MapSqlParameterSource("logger", logger),
-                new AuditTORowMapper());
-    }
 
-    private NamedParameterJdbcTemplate getJdbcTemplate() {
-        DataSource datasource = domainsHolder.getDomains().get(AuthContextUtils.getDomain());
-        if (datasource == null) {
-            throw new IllegalArgumentException("Could not get to DataSource");
-        }
-        return new NamedParameterJdbcTemplate(datasource);
-    }
-
-    private static class AuditTORowMapper implements RowMapper<AuditTO> {
-        @Override
-        public AuditTO mapRow(final ResultSet resultSet, final int i) throws SQLException {
-            AuditEntry auditEntry = POJOHelper.deserialize(resultSet.getString("MESSAGE"), AuditEntry.class);
-            AuditTO auditTO = new AuditTO();
-            auditTO.setWho(auditEntry.getWho());
-
-            if (StringUtils.isNotBlank(auditEntry.getLogger().getSubcategory())) {
-                auditTO.setSubCategory(auditEntry.getLogger().getSubcategory());
-            }
-            if (StringUtils.isNotBlank(auditEntry.getLogger().getEvent())) {
-                auditTO.setEvent(auditEntry.getLogger().getEvent());
-            }
-            if (auditEntry.getLogger().getResult() != null) {
-                auditTO.setResult(auditEntry.getLogger().getResult().name());
-            }
-
-            if (auditEntry.getBefore() != null) {
-                String before = ToStringBuilder.reflectionToString(
-                    auditEntry.getBefore(), ToStringStyle.JSON_STYLE);
-                auditTO.setBefore(before);
-            }
-
-            if (auditEntry.getInput() != null) {
-                auditTO.getInputs().addAll(Arrays.stream(auditEntry.getInput())
-                    .map(input -> ToStringBuilder.reflectionToString(input, ToStringStyle.JSON_STYLE))
-                    .collect(Collectors.toList()));
-            }
-
-            if (auditEntry.getOutput() != null) {
-                auditTO.setOutput(ToStringBuilder.reflectionToString(
-                    auditEntry.getOutput(), ToStringStyle.JSON_STYLE));
-            }
-
-            String throwable = resultSet.getString("THROWABLE");
-            auditTO.setThrowable(throwable);
-
-            Timestamp date = resultSet.getTimestamp("EVENT_DATE");
-            auditTO.setDate(new Date(date.getTime()));
-
-            return auditTO;
-        }
-    }
 }

--- a/core/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AuditServiceImpl.java
+++ b/core/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AuditServiceImpl.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.syncope.core.rest.cxf.service;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.apache.syncope.common.lib.to.AuditTO;
+import org.apache.syncope.common.rest.api.service.AuditService;
+import org.apache.syncope.core.persistence.api.DomainsHolder;
+import org.apache.syncope.core.provisioning.api.serialization.POJOHelper;
+import org.apache.syncope.core.provisioning.java.AuditEntry;
+import org.apache.syncope.core.spring.security.AuthContextUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import javax.sql.DataSource;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class AuditServiceImpl extends AbstractServiceImpl implements AuditService {
+    private static final String SQL_TABLE = "SYNCOPEAUDIT";
+
+    private static final String SQL_SELECT = "SELECT * FROM SYNCOPEAUDIT %s ORDER BY EVENT_DATE DESC";
+
+    @Autowired
+    private DomainsHolder domainsHolder;
+
+    @Override
+    public List<AuditTO> list() {
+        return getJdbcTemplate().
+            query(String.format(SQL_SELECT, StringUtils.EMPTY), new AuditTORowMapper());
+    }
+
+    @Override
+    public AuditTO read(final String logger) {
+        return getJdbcTemplate().
+            queryForObject(String.format(SQL_SELECT, "WHERE LOGGER=:logger"),
+                new MapSqlParameterSource("logger", logger),
+                new AuditTORowMapper());
+    }
+
+    private NamedParameterJdbcTemplate getJdbcTemplate() {
+        DataSource datasource = domainsHolder.getDomains().get(AuthContextUtils.getDomain());
+        if (datasource == null) {
+            throw new IllegalArgumentException("Could not get to DataSource");
+        }
+        return new NamedParameterJdbcTemplate(datasource);
+    }
+
+    private static class AuditTORowMapper implements RowMapper<AuditTO> {
+        @Override
+        public AuditTO mapRow(final ResultSet resultSet, final int i) throws SQLException {
+            AuditEntry auditEntry = POJOHelper.deserialize(resultSet.getString("MESSAGE"), AuditEntry.class);
+            AuditTO auditTO = new AuditTO();
+            auditTO.setWho(auditEntry.getWho());
+
+            if (StringUtils.isNotBlank(auditEntry.getLogger().getSubcategory())) {
+                auditTO.setSubCategory(auditEntry.getLogger().getSubcategory());
+            }
+            if (StringUtils.isNotBlank(auditEntry.getLogger().getEvent())) {
+                auditTO.setEvent(auditEntry.getLogger().getEvent());
+            }
+            if (auditEntry.getLogger().getResult() != null) {
+                auditTO.setResult(auditEntry.getLogger().getResult().name());
+            }
+
+            if (auditEntry.getBefore() != null) {
+                String before = ToStringBuilder.reflectionToString(
+                    auditEntry.getBefore(), ToStringStyle.JSON_STYLE);
+                auditTO.setBefore(before);
+            }
+
+            if (auditEntry.getInput() != null) {
+                auditTO.getInputs().addAll(Arrays.stream(auditEntry.getInput())
+                    .map(input -> ToStringBuilder.reflectionToString(input, ToStringStyle.JSON_STYLE))
+                    .collect(Collectors.toList()));
+            }
+
+            if (auditEntry.getOutput() != null) {
+                auditTO.setOutput(ToStringBuilder.reflectionToString(
+                    auditEntry.getOutput(), ToStringStyle.JSON_STYLE));
+            }
+
+            String throwable = resultSet.getString("THROWABLE");
+            auditTO.setThrowable(throwable);
+
+            Timestamp date = resultSet.getTimestamp("EVENT_DATE");
+            auditTO.setDate(new Date(date.getTime()));
+
+            return auditTO;
+        }
+    }
+}

--- a/core/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AuditServiceImpl.java
+++ b/core/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AuditServiceImpl.java
@@ -18,16 +18,12 @@
  */
 package org.apache.syncope.core.rest.cxf.service;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
-import org.apache.syncope.common.lib.SyncopeConstants;
-import org.apache.syncope.common.lib.search.SpecialAttr;
 import org.apache.syncope.common.lib.to.AuditEntryTO;
 import org.apache.syncope.common.lib.to.PagedResult;
-import org.apache.syncope.common.rest.api.beans.AnyQuery;
+import org.apache.syncope.common.rest.api.beans.AuditQuery;
 import org.apache.syncope.common.rest.api.service.AuditService;
 import org.apache.syncope.core.logic.AuditLogic;
-import org.apache.syncope.core.persistence.api.dao.search.SearchCond;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -39,26 +35,14 @@ public class AuditServiceImpl extends AbstractServiceImpl implements AuditServic
     private AuditLogic logic;
 
     @Override
-    public PagedResult<AuditEntryTO> search(final AnyQuery anyQuery) {
-        String realm = StringUtils.prependIfMissing(anyQuery.getRealm(), SyncopeConstants.ROOT_REALM);
-
-        boolean isAssignableCond = !StringUtils.isBlank(anyQuery.getFiql())
-            && anyQuery.getFiql().contains(SpecialAttr.ASSIGNABLE.toString());
-
-        SearchCond searchCond = StringUtils.isBlank(anyQuery.getFiql())
-            ? null
-            : getSearchCond(anyQuery.getFiql(), realm);
-
-        Pair<Integer, List<AuditEntryTO>> result = this.logic.search(
-            searchCond,
-            anyQuery.getPage(),
-            anyQuery.getSize(),
-            getOrderByClauses(anyQuery.getOrderBy()),
-            isAssignableCond ? SyncopeConstants.ROOT_REALM : realm,
-            anyQuery.getDetails());
-
-        return buildPagedResult(result.getRight(), anyQuery.getPage(), anyQuery.getSize(), result.getLeft());
+    public PagedResult<AuditEntryTO> search(final AuditQuery auditQuery) {
+        Pair<Integer, List<AuditEntryTO>> result = logic.search(
+            auditQuery.getKey(),
+            auditQuery.getPage(),
+            auditQuery.getSize(),
+            getOrderByClauses(auditQuery.getOrderBy())
+            );
+        return buildPagedResult(result.getRight(), auditQuery.getPage(), auditQuery.getSize(), result.getLeft());
     }
-
 
 }

--- a/fit/core-reference/pom.xml
+++ b/fit/core-reference/pom.xml
@@ -338,7 +338,7 @@ under the License.
             <deployable>
               <location>${project.build.directory}/${project.build.finalName}</location>
               <pingURL>http://localhost:${cargo.servlet.port}/syncope/cacheStats.jsp</pingURL>
-              <pingTimeout>60000</pingTimeout>
+              <pingTimeout>180000</pingTimeout>
               <properties>
                 <context>syncope</context>
               </properties>

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/AbstractITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/AbstractITCase.java
@@ -77,6 +77,7 @@ import org.apache.syncope.common.rest.api.service.AnyObjectService;
 import org.apache.syncope.common.rest.api.service.AnyTypeClassService;
 import org.apache.syncope.common.rest.api.service.AnyTypeService;
 import org.apache.syncope.common.rest.api.service.ApplicationService;
+import org.apache.syncope.common.rest.api.service.AuditService;
 import org.apache.syncope.common.rest.api.service.CamelRouteService;
 import org.apache.syncope.common.rest.api.service.ConfigurationService;
 import org.apache.syncope.common.rest.api.service.ConnectorHistoryService;
@@ -281,6 +282,8 @@ public abstract class AbstractITCase {
 
     protected static SCIMConfService scimConfService;
 
+    protected static AuditService auditService;
+
     @BeforeAll
     public static void securitySetup() {
         try (InputStream propStream = Encryptor.class.getResourceAsStream("/security.properties")) {
@@ -353,6 +356,7 @@ public abstract class AbstractITCase {
         oidcClientService = adminClient.getService(OIDCClientService.class);
         oidcProviderService = adminClient.getService(OIDCProviderService.class);
         scimConfService = adminClient.getService(SCIMConfService.class);
+        auditService = adminClient.getService(AuditService.class);
     }
 
     protected static String getUUIDString() {

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AuditITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AuditITCase.java
@@ -18,15 +18,59 @@
  */
 package org.apache.syncope.fit.core;
 
+import org.apache.syncope.common.lib.SyncopeConstants;
+import org.apache.syncope.common.lib.search.UserFiqlSearchConditionBuilder;
+import org.apache.syncope.common.lib.to.PagedResult;
+import org.apache.syncope.common.lib.to.ProvisioningResult;
+import org.apache.syncope.common.lib.to.UserTO;
+import org.apache.syncope.common.rest.api.beans.AnyQuery;
 import org.apache.syncope.fit.AbstractITCase;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assumptions.*;
 
 public class AuditITCase extends AbstractITCase {
 
+    public static UserTO getSampleUserTO(final String email) {
+        UserTO userTO = new UserTO();
+        userTO.setRealm(SyncopeConstants.ROOT_REALM);
+        userTO.setPassword("password123");
+        userTO.setUsername(email);
+        userTO.getPlainAttrs().add(attrTO("email", email));
+        return userTO;
+    }
+
+    @BeforeEach
+    public void setup() {
+        /**
+         * Execute operations to activate audits.
+         */
+        PagedResult<UserTO> matching = userService.search(
+            new AnyQuery.Builder().realm(SyncopeConstants.ROOT_REALM)
+                .fiql(new UserFiqlSearchConditionBuilder()
+                    .is("username").equalTo("example@syncope.org").query())
+                .size(1)
+                .page(1)
+                .details(false)
+                .build());
+        assertNotNull(matching);
+        if (matching.getSize() > 0) {
+            UserTO userTO = matching.getResult().get(0);
+            userService.delete(userTO.getKey());
+        }
+
+        UserTO userTO = getSampleUserTO("example@syncope.org");
+        userTO.getResources().add(RESOURCE_NAME_TESTDB);
+        ProvisioningResult<UserTO> result = createUser(userTO);
+        assertNotNull(result);
+        userTO = result.getEntity();
+        userTO = userService.read(userTO.getKey());
+        userService.delete(userTO.getKey());
+    }
+
     @Test
     public void list() {
-        assumeTrue(auditService.list().isEmpty());
     }
 }

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AuditITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AuditITCase.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.syncope.fit.core;
+
+import org.apache.syncope.fit.AbstractITCase;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assumptions.*;
+
+public class AuditITCase extends AbstractITCase {
+
+    @Test
+    public void list() {
+        assumeTrue(auditService.list().isEmpty());
+    }
+}

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AuditITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AuditITCase.java
@@ -38,6 +38,10 @@ public class AuditITCase extends AbstractITCase {
         userTO.setRealm(SyncopeConstants.ROOT_REALM);
         userTO.setPassword("password123");
         userTO.setUsername(email);
+        userTO.getPlainAttrs().add(attrTO("fullname", "Apache Syncope"));
+        userTO.getPlainAttrs().add(attrTO("firstname", "Apache"));
+        userTO.getPlainAttrs().add(attrTO("surname", "Syncope"));
+        userTO.getPlainAttrs().add(attrTO("userId", email));
         userTO.getPlainAttrs().add(attrTO("email", email));
         return userTO;
     }


### PR DESCRIPTION
This pull request demonstrates the basic outline of introduced components and the design, modeled and inspired by existing functionality/components in Syncope. This is still very much a WIP and will be updated continuously.

A brief outline of the changes are:

1. AuditService as the main REST API interface, presenting search ops
2. AuditLogic in charge of executing search ops, etc.
3. AuditDAO and AuditDataBinder, in charge of handling the JPA layer and data bindings.
4. AuditTO, AuditEntry and AuditEntryImpl as carrier/transfer objects between the data layer, core and APIs.