### PR TITLE
[SYNCOPE-1519]: use hasAttrs instead of findAttrs in SchemaDataBinder…

### DIFF
--- a/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/dao/PlainSchemaDAO.java
+++ b/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/dao/PlainSchemaDAO.java
@@ -27,5 +27,7 @@ public interface PlainSchemaDAO extends SchemaDAO<PlainSchema> {
 
     <T extends PlainAttr<?>> List<T> findAttrs(PlainSchema schema, Class<T> reference);
 
+    <T extends PlainAttr<?>> boolean hasAttrs(PlainSchema schema, Class<T> reference);
+
     List<PlainSchema> findByValidator(Implementation validator);
 }

--- a/core/persistence-jpa-json/src/main/java/org/apache/syncope/core/persistence/jpa/dao/JPAJSONPlainSchemaDAO.java
+++ b/core/persistence-jpa-json/src/main/java/org/apache/syncope/core/persistence/jpa/dao/JPAJSONPlainSchemaDAO.java
@@ -32,6 +32,12 @@ public class JPAJSONPlainSchemaDAO extends JPAPlainSchemaDAO {
     }
 
     @Override
+    public <T extends PlainAttr<?>> boolean hasAttrs(final PlainSchema schema, final Class<T> plainAttrTable) {
+        // not possible
+        return false;
+    }
+
+    @Override
     protected void deleteAttrs(final PlainSchema schema) {
         // nothing to do
     }

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/JPAPlainSchemaDAO.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/JPAPlainSchemaDAO.java
@@ -20,6 +20,7 @@ package org.apache.syncope.core.persistence.jpa.dao;
 
 import java.util.Collection;
 import java.util.List;
+import javax.persistence.Query;
 import javax.persistence.TypedQuery;
 import org.apache.syncope.common.lib.types.AnyTypeKind;
 import org.apache.syncope.core.persistence.api.dao.ExternalResourceDAO;
@@ -32,6 +33,9 @@ import org.apache.syncope.core.persistence.api.entity.Implementation;
 import org.apache.syncope.core.persistence.api.entity.PlainAttr;
 import org.apache.syncope.core.persistence.api.entity.PlainSchema;
 import org.apache.syncope.core.persistence.jpa.entity.JPAPlainSchema;
+import org.apache.syncope.core.persistence.jpa.entity.anyobject.JPAAPlainAttr;
+import org.apache.syncope.core.persistence.jpa.entity.group.JPAGPlainAttr;
+import org.apache.syncope.core.persistence.jpa.entity.user.JPAUPlainAttr;
 import org.springframework.beans.factory.annotation.Autowired;
 
 public class JPAPlainSchemaDAO extends AbstractDAO<PlainSchema> implements PlainSchemaDAO {
@@ -102,6 +106,18 @@ public class JPAPlainSchemaDAO extends AbstractDAO<PlainSchema> implements Plain
     }
 
     @Override
+    public <T extends PlainAttr<?>> boolean hasAttrs(final PlainSchema schema, final Class<T> reference) {
+        String plainAttrTable = getPlainAttrTable(reference);
+        Query query = entityManager()
+                .createNativeQuery("SELECT COUNT(" + plainAttrTable + ".id) FROM " + JPAPlainSchema.TABLE
+                        + " JOIN " + plainAttrTable + " ON " + JPAPlainSchema.TABLE + ".id = " + plainAttrTable
+                        + ".schema_id WHERE " + JPAPlainSchema.TABLE + ".id = ?1");
+        query.setParameter(1, schema.getKey());
+
+        return (long) query.getSingleResult() > 0;
+    }
+
+    @Override
     public PlainSchema save(final PlainSchema schema) {
         return entityManager().merge(schema);
     }
@@ -134,5 +150,18 @@ public class JPAPlainSchemaDAO extends AbstractDAO<PlainSchema> implements Plain
         }
 
         entityManager().remove(schema);
+    }
+
+    private <T extends PlainAttr<?>> String getPlainAttrTable(final Class<T> plainAttrClass) {
+        if (plainAttrClass.equals(JPAGPlainAttr.class)) {
+            return JPAGPlainAttr.TABLE;
+        }
+        if (plainAttrClass.equals(JPAAPlainAttr.class)) {
+            return JPAAPlainAttr.TABLE;
+        }
+        if (plainAttrClass.equals(JPAUPlainAttr.class)) {
+            return JPAUPlainAttr.TABLE;
+        }
+        return JPAUPlainAttr.TABLE;
     }
 }

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/SchemaDataBinderImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/SchemaDataBinderImpl.java
@@ -177,7 +177,7 @@ public class SchemaDataBinderImpl implements SchemaDataBinder {
         boolean hasAttrs = false;
         for (AnyTypeKind anyTypeKind : AnyTypeKind.values()) {
             AnyUtils anyUtils = anyUtilsFactory.getInstance(anyTypeKind);
-            hasAttrs |= plainSchemaDAO.findAttrs(schema, anyUtils.plainAttrClass()).isEmpty();
+            hasAttrs |= plainSchemaDAO.hasAttrs(schema, anyUtils.plainAttrClass());
         }
 
         if (hasAttrs) {


### PR DESCRIPTION
use org.apache.syncope.core.persistence.api.dao.PlainSchemaDAO#hasAttrs instead of org.apache.syncope.core.persistence.api.dao.PlainSchemaDAO#findAttrs in SchemaDataBinderImpl.java