### PR TITLE
Replace JSTL with Apache Standard Taglibs

### DIFF
--- a/ext/oidcclient/agent/pom.xml
+++ b/ext/oidcclient/agent/pom.xml
@@ -47,8 +47,8 @@ under the License.
       <artifactId>javax.servlet.jsp-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>jstl</artifactId>
+      <groupId>org.apache.taglibs</groupId>
+      <artifactId>taglibs-standard-impl</artifactId>
       <scope>provided</scope>
     </dependency>
     

--- a/ext/saml2sp/agent/pom.xml
+++ b/ext/saml2sp/agent/pom.xml
@@ -47,8 +47,8 @@ under the License.
       <artifactId>javax.servlet.jsp-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>jstl</artifactId>
+      <groupId>org.apache.taglibs</groupId>
+      <artifactId>taglibs-standard-impl</artifactId>
       <scope>provided</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -602,9 +602,9 @@ under the License.
         <scope>provided</scope>
       </dependency>
       <dependency>
-        <groupId>javax.servlet</groupId>
-        <artifactId>jstl</artifactId>
-        <version>1.2</version>
+        <groupId>org.apache.taglibs</groupId>
+        <artifactId>taglibs-standard-impl</artifactId>
+        <version>1.2.5</version>
       </dependency>
       
       <!-- CXF -->

--- a/standalone/LICENSE
+++ b/standalone/LICENSE
@@ -928,8 +928,8 @@ This is licensed under the CDDL 1.0, see above.
 
 ==
 
-For JSP Standard Tag Library (https://jstl.java.net/):
-This is licensed under the CDDL 1.0, see above.
+For Apache Standard Taglib (http://tomcat.apache.org/taglibs/standard/):
+This is licensed under the AL 2.0, see above.
 
 ==
 


### PR DESCRIPTION
The JSTL dependency is not needed and comes with a CVE as it ships with an old version of Apache TagLibs.