### PR TITLE
Updating Tika

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -445,7 +445,7 @@ under the License.
     <commons-text.version>1.8</commons-text.version>
     <commons-logging.version>1.1.3</commons-logging.version>
     
-    <tika.version>1.21</tika.version>
+    <tika.version>1.23</tika.version>
 
     <joda.version>2.10.5</joda.version>
 


### PR DESCRIPTION
This is to fix the CVE: tika-core-1.21.jar (pkg:maven/org.apache.tika/tika-core@1.21, cpe:2.3:a:apache:tika:1.21:*:*:*:*:*:*:*) : CVE-2019-10088, CVE-2019-10093, CVE-2019-10094

Please cherry-pick to 2.1 + 2.0