### PR TITLE
[SYNCOPE-1533] added equals and hashCode methods for TOs

### DIFF
--- a/common/lib/src/main/java/org/apache/syncope/common/lib/patch/ResourceDeassociationPatch.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/patch/ResourceDeassociationPatch.java
@@ -27,6 +27,8 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.syncope.common.lib.types.ResourceDeassociationAction;
 
 @XmlRootElement(name = "resourceDeassociationPatch")
@@ -77,4 +79,31 @@ public class ResourceDeassociationPatch implements Serializable {
         return anyKyes;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        ResourceDeassociationPatch that = (ResourceDeassociationPatch) o;
+
+        return new EqualsBuilder().
+                append(key, that.key).
+                append(anyTypeKey, that.anyTypeKey).
+                append(action, that.action).
+                append(anyKyes, that.anyKyes).
+                isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().
+                append(key).
+                append(anyTypeKey).
+                append(action).
+                append(anyKyes).
+                toHashCode();
+    }
 }

--- a/common/lib/src/main/java/org/apache/syncope/common/lib/policy/PasswordPolicyTO.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/policy/PasswordPolicyTO.java
@@ -19,7 +19,6 @@
 package org.apache.syncope.common.lib.policy;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.ArrayList;
 import java.util.List;
 import javax.xml.bind.annotation.XmlElement;
@@ -27,6 +26,9 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 @XmlRootElement(name = "passwordPolicy")
 @XmlType
@@ -71,5 +73,33 @@ public class PasswordPolicyTO extends PolicyTO implements ComposablePolicy {
     @Override
     public List<String> getRules() {
         return rules;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        PasswordPolicyTO that = (PasswordPolicyTO) o;
+
+        return new EqualsBuilder().
+                appendSuper(super.equals(o)).
+                append(allowNullPassword, that.allowNullPassword).
+                append(historyLength, that.historyLength).
+                append(rules, that.rules).
+                isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().
+                appendSuper(super.hashCode()).
+                append(allowNullPassword).
+                append(historyLength).
+                append(rules).
+                toHashCode();
     }
 }

--- a/common/lib/src/main/java/org/apache/syncope/common/lib/policy/PolicyTO.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/policy/PolicyTO.java
@@ -31,6 +31,8 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.syncope.common.lib.to.EntityTO;
 
 @XmlRootElement(name = "policy")
@@ -102,4 +104,33 @@ public abstract class PolicyTO implements EntityTO {
         return usedByRealms;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        PolicyTO policyTO = (PolicyTO) o;
+
+        return new EqualsBuilder().
+                append(discriminator, policyTO.discriminator).
+                append(key, policyTO.key).
+                append(description, policyTO.description).
+                append(usedByResources, policyTO.usedByResources).
+                append(usedByRealms, policyTO.usedByRealms).
+                isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().
+                append(discriminator).
+                append(key).
+                append(description).
+                append(usedByResources).
+                append(usedByRealms).
+                toHashCode();
+    }
 }

--- a/common/lib/src/main/java/org/apache/syncope/common/lib/to/AccessTokenTO.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/to/AccessTokenTO.java
@@ -21,6 +21,8 @@ package org.apache.syncope.common.lib.to;
 import java.util.Date;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.syncope.common.lib.BaseBean;
 
 @XmlRootElement(name = "accessToken")
@@ -73,5 +75,33 @@ public class AccessTokenTO extends BaseBean implements EntityTO {
 
     public void setOwner(final String owner) {
         this.owner = owner;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        AccessTokenTO that = (AccessTokenTO) o;
+
+        return new EqualsBuilder().
+                append(key, that.key).
+                append(body, that.body).
+                append(expiryTime, that.expiryTime).
+                append(owner, that.owner).
+                isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().
+                append(key).
+                append(body).
+                append(expiryTime).
+                append(owner).
+                toHashCode();
     }
 }

--- a/common/lib/src/main/java/org/apache/syncope/common/lib/to/AnyTypeTO.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/to/AnyTypeTO.java
@@ -26,6 +26,8 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.syncope.common.lib.types.AnyTypeKind;
 
 @XmlRootElement(name = "anyType")
@@ -66,4 +68,29 @@ public class AnyTypeTO implements EntityTO {
         return classes;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        AnyTypeTO anyTypeTO = (AnyTypeTO) o;
+
+        return new EqualsBuilder().
+                append(key, anyTypeTO.key).
+                append(kind, anyTypeTO.kind).
+                append(classes, anyTypeTO.classes).
+                isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().
+                append(key).
+                append(kind).
+                append(classes).
+                toHashCode();
+    }
 }

--- a/common/lib/src/main/java/org/apache/syncope/common/lib/to/ConnInstanceTO.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/to/ConnInstanceTO.java
@@ -30,6 +30,8 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.syncope.common.lib.types.ConnConfProperty;
 import org.apache.syncope.common.lib.types.ConnectorCapability;
 
@@ -167,4 +169,45 @@ public class ConnInstanceTO implements EntityTO {
         this.poolConf = poolConf;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        ConnInstanceTO that = (ConnInstanceTO) o;
+
+        return new EqualsBuilder().
+                append(key, that.key).
+                append(adminRealm, that.adminRealm).
+                append(location, that.location).
+                append(connectorName, that.connectorName).
+                append(bundleName, that.bundleName).
+                append(version, that.version).
+                append(conf, that.conf).
+                append(capabilities, that.capabilities).
+                append(displayName, that.displayName).
+                append(connRequestTimeout, that.connRequestTimeout).
+                append(poolConf, that.poolConf).
+                isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().
+                append(key).
+                append(adminRealm).
+                append(location).
+                append(connectorName).
+                append(bundleName).
+                append(version).
+                append(conf).
+                append(capabilities).
+                append(displayName).
+                append(connRequestTimeout).
+                append(poolConf).
+                toHashCode();
+    }
 }

--- a/common/lib/src/main/java/org/apache/syncope/common/lib/to/ConnPoolConfTO.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/to/ConnPoolConfTO.java
@@ -21,6 +21,8 @@ package org.apache.syncope.common.lib.to;
 import java.io.Serializable;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 @XmlRootElement(name = "connPoolConf")
 @XmlType
@@ -78,4 +80,33 @@ public class ConnPoolConfTO implements Serializable {
         this.minEvictableIdleTimeMillis = minEvictableIdleTimeMillis;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        ConnPoolConfTO that = (ConnPoolConfTO) o;
+
+        return new EqualsBuilder().
+                append(maxObjects, that.maxObjects).
+                append(minIdle, that.minIdle).
+                append(maxIdle, that.maxIdle).
+                append(maxWait, that.maxWait).
+                append(minEvictableIdleTimeMillis, that.minEvictableIdleTimeMillis).
+                isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().
+                append(maxObjects).
+                append(minIdle).
+                append(maxIdle).
+                append(maxWait).
+                append(minEvictableIdleTimeMillis).
+                toHashCode();
+    }
 }

--- a/common/lib/src/main/java/org/apache/syncope/common/lib/to/ItemTO.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/to/ItemTO.java
@@ -25,6 +25,8 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.syncope.common.lib.types.MappingPurpose;
 
 @XmlRootElement(name = "item")
@@ -157,5 +159,45 @@ public class ItemTO implements EntityTO {
     @JsonProperty("transformers")
     public List<String> getTransformers() {
         return transformers;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        ItemTO itemTO = (ItemTO) o;
+
+        return new EqualsBuilder().
+                append(connObjectKey, itemTO.connObjectKey).
+                append(password, itemTO.password).
+                append(key, itemTO.key).
+                append(intAttrName, itemTO.intAttrName).
+                append(extAttrName, itemTO.extAttrName).
+                append(mandatoryCondition, itemTO.mandatoryCondition).
+                append(purpose, itemTO.purpose).
+                append(propagationJEXLTransformer, itemTO.propagationJEXLTransformer).
+                append(pullJEXLTransformer, itemTO.pullJEXLTransformer).
+                append(transformers, itemTO.transformers).
+                isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().
+                append(key).
+                append(intAttrName).
+                append(extAttrName).
+                append(connObjectKey).
+                append(password).
+                append(mandatoryCondition).
+                append(purpose).
+                append(propagationJEXLTransformer).
+                append(pullJEXLTransformer).
+                append(transformers).
+                toHashCode();
     }
 }

--- a/common/lib/src/main/java/org/apache/syncope/common/lib/to/MailTemplateTO.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/to/MailTemplateTO.java
@@ -21,6 +21,8 @@ package org.apache.syncope.common.lib.to;
 import javax.ws.rs.PathParam;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 @XmlRootElement(name = "mailTemplate")
 @XmlType
@@ -39,5 +41,27 @@ public class MailTemplateTO implements EntityTO {
     @Override
     public void setKey(final String key) {
         this.key = key;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        MailTemplateTO that = (MailTemplateTO) o;
+
+        return new EqualsBuilder().
+                append(key, that.key).
+                isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().
+                append(key).
+                toHashCode();
     }
 }

--- a/common/lib/src/main/java/org/apache/syncope/common/lib/to/MappingTO.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/to/MappingTO.java
@@ -26,6 +26,8 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 @XmlRootElement(name = "mapping")
 @XmlType
@@ -88,5 +90,31 @@ public class MappingTO implements ItemContainerTO, Serializable {
     @JsonProperty("linkingItems")
     public List<ItemTO> getLinkingItems() {
         return linkingItems;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        MappingTO mappingTO = (MappingTO) o;
+
+        return new EqualsBuilder().
+                append(connObjectLink, mappingTO.connObjectLink).
+                append(items, mappingTO.items).
+                append(linkingItems, mappingTO.linkingItems).
+                isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().
+                append(connObjectLink).
+                append(items).
+                append(linkingItems).
+                toHashCode();
     }
 }

--- a/common/lib/src/main/java/org/apache/syncope/common/lib/to/OrgUnitTO.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/to/OrgUnitTO.java
@@ -25,6 +25,8 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 @XmlRootElement(name = "orgUnit")
 @XmlType
@@ -120,5 +122,37 @@ public class OrgUnitTO implements EntityTO, ItemContainerTO {
 
     public boolean remove(final ItemTO item) {
         return this.items.remove(item);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        OrgUnitTO orgUnitTO = (OrgUnitTO) o;
+
+        return new EqualsBuilder().
+                append(ignoreCaseMatch, orgUnitTO.ignoreCaseMatch).
+                append(key, orgUnitTO.key).
+                append(objectClass, orgUnitTO.objectClass).
+                append(syncToken, orgUnitTO.syncToken).
+                append(connObjectLink, orgUnitTO.connObjectLink).
+                append(items, orgUnitTO.items).
+                isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().
+                append(key).
+                append(objectClass).
+                append(syncToken).
+                append(ignoreCaseMatch).
+                append(connObjectLink).
+                append(items).
+                toHashCode();
     }
 }

--- a/common/lib/src/main/java/org/apache/syncope/common/lib/to/ProvisionTO.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/to/ProvisionTO.java
@@ -25,6 +25,8 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 @XmlRootElement(name = "provision")
 @XmlType
@@ -122,4 +124,41 @@ public class ProvisionTO implements EntityTO {
         return virSchemas;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        ProvisionTO that = (ProvisionTO) o;
+
+        return new EqualsBuilder().
+                append(ignoreCaseMatch, that.ignoreCaseMatch).
+                append(key, that.key).
+                append(anyType, that.anyType).
+                append(objectClass, that.objectClass).
+                append(auxClasses, that.auxClasses).
+                append(syncToken, that.syncToken).
+                append(uidOnCreate, that.uidOnCreate).
+                append(mapping, that.mapping).
+                append(virSchemas, that.virSchemas).
+                isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().
+                append(key).
+                append(anyType).
+                append(objectClass).
+                append(auxClasses).
+                append(syncToken).
+                append(ignoreCaseMatch).
+                append(uidOnCreate).
+                append(mapping).
+                append(virSchemas).
+                toHashCode();
+    }
 }

--- a/common/lib/src/main/java/org/apache/syncope/common/lib/to/RealmTO.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/to/RealmTO.java
@@ -31,6 +31,8 @@ import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.syncope.common.lib.jaxb.XmlGenericMapAdapter;
 
 @XmlRootElement(name = "realm")
@@ -129,4 +131,41 @@ public class RealmTO implements EntityTO, TemplatableTO {
         return resources;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        RealmTO realmTO = (RealmTO) o;
+
+        return new EqualsBuilder().
+                append(key, realmTO.key).
+                append(name, realmTO.name).
+                append(parent, realmTO.parent).
+                append(fullPath, realmTO.fullPath).
+                append(accountPolicy, realmTO.accountPolicy).
+                append(passwordPolicy, realmTO.passwordPolicy).
+                append(actions, realmTO.actions).
+                append(templates, realmTO.templates).
+                append(resources, realmTO.resources).
+                isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().
+                append(key).
+                append(name).
+                append(parent).
+                append(fullPath).
+                append(accountPolicy).
+                append(passwordPolicy).
+                append(actions).
+                append(templates).
+                append(resources).
+                toHashCode();
+    }
 }

--- a/common/lib/src/main/java/org/apache/syncope/common/lib/to/ResourceTO.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/to/ResourceTO.java
@@ -30,6 +30,8 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.syncope.common.lib.types.ConnConfProperty;
 import org.apache.syncope.common.lib.types.ConnectorCapability;
 import org.apache.syncope.common.lib.types.TraceLevel;
@@ -250,5 +252,65 @@ public class ResourceTO implements EntityTO {
     @JsonProperty("propagationActions")
     public List<String> getPropagationActions() {
         return propagationActions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        ResourceTO that = (ResourceTO) o;
+
+        return new EqualsBuilder().
+                append(randomPwdIfNotProvided, that.randomPwdIfNotProvided).
+                append(enforceMandatoryCondition, that.enforceMandatoryCondition).
+                append(overrideCapabilities, that.overrideCapabilities).
+                append(key, that.key).
+                append(connector, that.connector).
+                append(connectorDisplayName, that.connectorDisplayName).
+                append(provisions, that.provisions).
+                append(orgUnit, that.orgUnit).
+                append(propagationPriority, that.propagationPriority).
+                append(createTraceLevel, that.createTraceLevel).
+                append(updateTraceLevel, that.updateTraceLevel).
+                append(deleteTraceLevel, that.deleteTraceLevel).
+                append(provisioningTraceLevel, that.provisioningTraceLevel).
+                append(passwordPolicy, that.passwordPolicy).
+                append(accountPolicy, that.accountPolicy).
+                append(pullPolicy, that.pullPolicy).
+                append(pushPolicy, that.pushPolicy).
+                append(confOverride, that.confOverride).
+                append(capabilitiesOverride, that.capabilitiesOverride).
+                append(propagationActions, that.propagationActions).
+                isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().
+                append(key).
+                append(connector).
+                append(connectorDisplayName).
+                append(provisions).
+                append(orgUnit).
+                append(propagationPriority).
+                append(randomPwdIfNotProvided).
+                append(enforceMandatoryCondition).
+                append(createTraceLevel).
+                append(updateTraceLevel).
+                append(deleteTraceLevel).
+                append(provisioningTraceLevel).
+                append(passwordPolicy).
+                append(accountPolicy).
+                append(pullPolicy).
+                append(pushPolicy).
+                append(confOverride).
+                append(overrideCapabilities).
+                append(capabilitiesOverride).
+                append(propagationActions).
+                toHashCode();
     }
 }

--- a/common/lib/src/main/java/org/apache/syncope/common/lib/to/RoleTO.java
+++ b/common/lib/src/main/java/org/apache/syncope/common/lib/to/RoleTO.java
@@ -28,6 +28,8 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlElementWrapper;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 @XmlRootElement(name = "role")
 @XmlType
@@ -94,4 +96,35 @@ public class RoleTO implements EntityTO {
         return privileges;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        RoleTO roleTO = (RoleTO) o;
+
+        return new EqualsBuilder().
+                append(key, roleTO.key).
+                append(entitlements, roleTO.entitlements).
+                append(realms, roleTO.realms).
+                append(dynRealms, roleTO.dynRealms).
+                append(dynMembershipCond, roleTO.dynMembershipCond).
+                append(privileges, roleTO.privileges).
+                isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().
+                append(key).
+                append(entitlements).
+                append(realms).
+                append(dynRealms).
+                append(dynMembershipCond).
+                append(privileges).
+                toHashCode();
+    }
 }

--- a/common/rest-api/src/main/java/org/apache/syncope/common/rest/api/beans/AbstractQuery.java
+++ b/common/rest-api/src/main/java/org/apache/syncope/common/rest/api/beans/AbstractQuery.java
@@ -24,6 +24,8 @@ import java.io.Serializable;
 import javax.validation.constraints.Min;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.QueryParam;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.syncope.common.rest.api.service.JAXRSService;
 
 public abstract class AbstractQuery implements Serializable {
@@ -107,5 +109,31 @@ public abstract class AbstractQuery implements Serializable {
     @QueryParam(JAXRSService.PARAM_ORDERBY)
     public void setOrderBy(final String orderBy) {
         this.orderBy = orderBy;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        AbstractQuery that = (AbstractQuery) o;
+
+        return new EqualsBuilder().
+                append(page, that.page).
+                append(size, that.size).
+                append(orderBy, that.orderBy).
+                isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().
+                append(page).
+                append(size).
+                append(orderBy).
+                toHashCode();
     }
 }

--- a/common/rest-api/src/main/java/org/apache/syncope/common/rest/api/beans/AnyQuery.java
+++ b/common/rest-api/src/main/java/org/apache/syncope/common/rest/api/beans/AnyQuery.java
@@ -23,6 +23,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.QueryParam;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.syncope.common.lib.SyncopeConstants;
 import org.apache.syncope.common.rest.api.service.JAXRSService;
 
@@ -102,5 +104,33 @@ public class AnyQuery extends AbstractQuery {
     @QueryParam(JAXRSService.PARAM_FIQL)
     public void setFiql(final String fiql) {
         this.fiql = fiql;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        AnyQuery anyQuery = (AnyQuery) o;
+
+        return new EqualsBuilder().
+                appendSuper(super.equals(o)).
+                append(realm, anyQuery.realm).
+                append(details, anyQuery.details).
+                append(fiql, anyQuery.fiql).
+                isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().
+                appendSuper(super.hashCode()).
+                append(realm).
+                append(details).
+                append(fiql).
+                toHashCode();
     }
 }

--- a/common/rest-api/src/main/java/org/apache/syncope/common/rest/api/beans/ExecQuery.java
+++ b/common/rest-api/src/main/java/org/apache/syncope/common/rest/api/beans/ExecQuery.java
@@ -20,6 +20,8 @@ package org.apache.syncope.common.rest.api.beans;
 
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.PathParam;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 public class ExecQuery extends AbstractQuery {
 
@@ -48,5 +50,29 @@ public class ExecQuery extends AbstractQuery {
     @PathParam("key")
     public void setKey(final String key) {
         this.key = key;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        ExecQuery execQuery = (ExecQuery) o;
+
+        return new EqualsBuilder().
+                appendSuper(super.equals(o)).
+                append(key, execQuery.key).
+                isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().
+                appendSuper(super.hashCode()).
+                append(key).
+                toHashCode();
     }
 }

--- a/common/rest-api/src/main/java/org/apache/syncope/common/rest/api/beans/SchemaQuery.java
+++ b/common/rest-api/src/main/java/org/apache/syncope/common/rest/api/beans/SchemaQuery.java
@@ -26,6 +26,8 @@ import java.util.List;
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.syncope.common.lib.types.SchemaType;
 
 public class SchemaQuery implements Serializable {
@@ -108,4 +110,29 @@ public class SchemaQuery implements Serializable {
         this.keyword = keyword;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+
+        if (o == null || getClass() != o.getClass())
+            return false;
+
+        SchemaQuery that = (SchemaQuery) o;
+
+        return new EqualsBuilder().
+                append(type, that.type).
+                append(anyTypeClasses, that.anyTypeClasses).
+                append(keyword, that.keyword).
+                isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder().
+                append(type).
+                append(anyTypeClasses).
+                append(keyword).
+                toHashCode();
+    }
 }


### PR DESCRIPTION
Override equals and hashCode methods to preserve the backward compatibility with 2.0.X