### PR TITLE
Check for presence of value before using an Optional

### DIFF
--- a/client/console/src/main/java/org/apache/syncope/client/console/wizards/any/AbstractAttrs.java
+++ b/client/console/src/main/java/org/apache/syncope/client/console/wizards/any/AbstractAttrs.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.syncope.client.console.rest.GroupRestClient;
@@ -32,14 +33,18 @@ import org.apache.syncope.common.lib.to.SchemaTO;
 import org.apache.syncope.common.lib.to.EntityTO;
 import org.apache.syncope.common.lib.to.GroupTO;
 import org.apache.syncope.common.lib.to.MembershipTO;
+import org.apache.syncope.common.lib.to.TypeExtensionTO;
 import org.apache.wicket.WicketRuntimeException;
 import org.apache.wicket.core.util.lang.PropertyResolver;
 import org.apache.wicket.markup.head.IHeaderResponse;
 import org.apache.wicket.markup.head.OnDomReadyHeaderItem;
 import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.util.ListModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class AbstractAttrs<S extends SchemaTO> extends AbstractAttrsWizardStep<S> {
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractAttrs.class);
 
     private static final long serialVersionUID = -5387344116983102292L;
 
@@ -103,7 +108,12 @@ public abstract class AbstractAttrs<S extends SchemaTO> extends AbstractAttrsWiz
     private List<String> getMembershipAuxClasses(final MembershipTO membershipTO, final String anyType) {
         try {
             final GroupTO groupTO = groupRestClient.read(membershipTO.getGroupKey());
-            return groupTO.getTypeExtension(anyType).get().getAuxClasses();
+            Optional<TypeExtensionTO> typeExtension = groupTO.getTypeExtension(anyType);
+            if (!typeExtension.isPresent()) {
+                LOG.trace("Unable to locate type extension for " + anyType);
+                return Collections.emptyList();
+            }
+            return typeExtension.get().getAuxClasses();
         } catch (Exception e) {
             return Collections.emptyList();
         }

--- a/core/logic/src/main/java/org/apache/syncope/core/logic/ReconciliationLogic.java
+++ b/core/logic/src/main/java/org/apache/syncope/core/logic/ReconciliationLogic.java
@@ -353,6 +353,10 @@ public class ReconciliationLogic extends AbstractTransactionalLogic<EntityTO> {
             throw new NotFoundException("Realm " + pullTask.getDestinationRealm());
         }
 
+        if (!provision.getMapping().getConnObjectKeyItem().isPresent()) {
+            throw new NotFoundException("ConnObjectKey cannot be determines for mapping " + provision.getMapping().getKey());
+        }
+
         SyncopeClientException sce = SyncopeClientException.build(ClientExceptionType.Reconciliation);
         try {
             List<ProvisioningReport> results = singlePullExecutor.pull(

--- a/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/PlainAttrTest.java
+++ b/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/PlainAttrTest.java
@@ -25,14 +25,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Random;
 import javax.validation.ValidationException;
-import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
+
 import org.apache.syncope.common.lib.SyncopeConstants;
 import org.apache.syncope.common.lib.types.AnyTypeKind;
 import org.apache.syncope.common.lib.types.AttrSchemaType;

--- a/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/SecurityQuestionTest.java
+++ b/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/SecurityQuestionTest.java
@@ -23,7 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.List;
-import java.util.UUID;
+
 import org.apache.syncope.core.persistence.api.dao.SecurityQuestionDAO;
 import org.apache.syncope.core.persistence.api.entity.user.SecurityQuestion;
 import org.apache.syncope.core.persistence.jpa.AbstractTest;

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/MappingManagerImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/MappingManagerImpl.java
@@ -852,7 +852,12 @@ public class MappingManagerImpl implements MappingManager {
     @Transactional(readOnly = true)
     @Override
     public Optional<String> getConnObjectKeyValue(final Any<?> any, final Provision provision) {
-        MappingItem mapItem = provision.getMapping().getConnObjectKeyItem().get();
+        Optional<? extends MappingItem> connObjectKeyItem = provision.getMapping().getConnObjectKeyItem();
+        if (!connObjectKeyItem.isPresent()) {
+             LOG.error("Unable to locate conn object key item for " + provision.getMapping().getKey());
+             return Optional.empty();
+        }
+        MappingItem mapItem = connObjectKeyItem.get();
         Pair<AttrSchemaType, List<PlainAttrValue>> intValues;
         try {
             intValues = getIntValues(provision,
@@ -874,9 +879,14 @@ public class MappingManagerImpl implements MappingManager {
     @Transactional(readOnly = true)
     @Override
     public Optional<String> getConnObjectKeyValue(final Realm realm, final OrgUnit orgUnit) {
-        OrgUnitItem orgUnitItem = orgUnit.getConnObjectKeyItem().get();
-
-        return Optional.ofNullable(orgUnitItem == null ? null : getIntValue(realm, orgUnitItem));
+        Optional<? extends OrgUnitItem> connObjectKeyItem = orgUnit.getConnObjectKeyItem();
+        if (!connObjectKeyItem.isPresent()) {
+            LOG.error("Unable to locate conn object key item for " + orgUnit.getKey());
+            return Optional.empty();
+        }
+        
+        OrgUnitItem orgUnitItem = connObjectKeyItem.get();
+        return Optional.ofNullable(getIntValue(realm, orgUnitItem));
     }
 
     @Transactional(readOnly = true)

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/UserDataBinderImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/UserDataBinderImpl.java
@@ -51,6 +51,7 @@ import org.apache.syncope.core.persistence.api.dao.AccessTokenDAO;
 import org.apache.syncope.core.persistence.api.dao.ConfDAO;
 import org.apache.syncope.core.persistence.api.dao.SecurityQuestionDAO;
 import org.apache.syncope.core.persistence.api.entity.group.Group;
+import org.apache.syncope.core.persistence.api.entity.resource.Provision;
 import org.apache.syncope.core.persistence.api.entity.user.SecurityQuestion;
 import org.apache.syncope.core.persistence.api.entity.user.User;
 import org.apache.syncope.core.provisioning.api.PropagationByResource;
@@ -414,8 +415,10 @@ public class UserDataBinderImpl extends AbstractAnyDataBinder implements UserDat
                     ResourceOperation.UPDATE,
                     anyUtils.getAllResources(toBeUpdated).stream().
                             filter(resource -> resource.getProvision(toBeUpdated.getType()).isPresent()).
-                            filter(resource -> mappingManager.hasMustChangePassword(
-                            resource.getProvision(toBeUpdated.getType()).get())).
+                            filter(resource -> {
+                                Provision provision = resource.getProvision(toBeUpdated.getType()).orElse(null);
+                                return provision != null && mappingManager.hasMustChangePassword(provision);
+                            }).
                             map(Entity::getKey).
                             collect(Collectors.toSet()));
         }

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/UserDataBinderImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/UserDataBinderImpl.java
@@ -51,7 +51,6 @@ import org.apache.syncope.core.persistence.api.dao.AccessTokenDAO;
 import org.apache.syncope.core.persistence.api.dao.ConfDAO;
 import org.apache.syncope.core.persistence.api.dao.SecurityQuestionDAO;
 import org.apache.syncope.core.persistence.api.entity.group.Group;
-import org.apache.syncope.core.persistence.api.entity.resource.Provision;
 import org.apache.syncope.core.persistence.api.entity.user.SecurityQuestion;
 import org.apache.syncope.core.persistence.api.entity.user.User;
 import org.apache.syncope.core.provisioning.api.PropagationByResource;
@@ -415,10 +414,8 @@ public class UserDataBinderImpl extends AbstractAnyDataBinder implements UserDat
                     ResourceOperation.UPDATE,
                     anyUtils.getAllResources(toBeUpdated).stream().
                             filter(resource -> resource.getProvision(toBeUpdated.getType()).isPresent()).
-                            filter(resource -> {
-                                Provision provision = resource.getProvision(toBeUpdated.getType()).orElse(null);
-                                return provision != null && mappingManager.hasMustChangePassword(provision);
-                            }).
+                            filter(resource -> mappingManager.hasMustChangePassword(
+                            resource.getProvision(toBeUpdated.getType()).get())).
                             map(Entity::getKey).
                             collect(Collectors.toSet()));
         }

--- a/core/spring/src/main/java/org/apache/syncope/core/spring/security/AuthDataAccessor.java
+++ b/core/spring/src/main/java/org/apache/syncope/core/spring/security/AuthDataAccessor.java
@@ -29,6 +29,8 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Resource;
+import javax.security.auth.login.AccountNotFoundException;
+
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.syncope.common.lib.SyncopeConstants;
@@ -38,6 +40,8 @@ import org.apache.syncope.common.lib.types.StandardEntitlement;
 import org.apache.syncope.core.persistence.api.ImplementationLookup;
 import org.apache.syncope.core.persistence.api.dao.AccessTokenDAO;
 import org.apache.syncope.core.persistence.api.dao.AnySearchDAO;
+import org.apache.syncope.core.persistence.api.entity.AnyType;
+import org.apache.syncope.core.persistence.api.entity.resource.Provision;
 import org.apache.syncope.core.provisioning.api.utils.RealmUtils;
 import org.apache.syncope.core.persistence.api.dao.AnyTypeDAO;
 import org.apache.syncope.core.persistence.api.dao.ConfDAO;
@@ -249,8 +253,16 @@ public class AuthDataAccessor {
             ExternalResource resource = itor.next();
             String connObjectKey = null;
             try {
-                connObjectKey = mappingManager.getConnObjectKeyValue(
-                        user, resource.getProvision(anyTypeDAO.findUser()).get()).get();
+                AnyType userType = anyTypeDAO.findUser();
+                Optional<? extends Provision> provision = resource.getProvision(userType);
+                if (!provision.isPresent()) {
+                    throw new AccountNotFoundException("Unable to locate provision for user type " + userType.getKey());
+                }
+                Optional<String> connObjectKeyValue = mappingManager.getConnObjectKeyValue(user, provision.get());
+                if (!connObjectKeyValue.isPresent()) {
+                    throw new AccountNotFoundException("Unable to locate conn object key value for " + userType.getKey());
+                }
+                connObjectKey = connObjectKeyValue.get();
                 Uid uid = connFactory.getConnector(resource).authenticate(connObjectKey, password, null);
                 if (uid != null) {
                     authenticated = true;

--- a/ext/saml2sp/logic/src/main/java/org/apache/syncope/core/logic/saml2/SAML2UserManager.java
+++ b/ext/saml2sp/logic/src/main/java/org/apache/syncope/core/logic/saml2/SAML2UserManager.java
@@ -89,7 +89,10 @@ public class SAML2UserManager {
             LOG.warn("Invalid IdP: {}", idpKey);
             return Collections.emptyList();
         }
-
+        if (!idp.getConnObjectKeyItem().isPresent()) {
+            LOG.warn("Unable to determine conn object key item for  IdP: {}", idpKey);
+            return Collections.emptyList();
+        }
         return inboundMatcher.matchByConnObjectKeyValue(
                 idp.getConnObjectKeyItem().get(), connObjectKeyValue, AnyTypeKind.USER, false, null).stream().
                 filter(match -> match.getAny() != null).

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/PushTaskITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/PushTaskITCase.java
@@ -43,7 +43,6 @@ import org.apache.syncope.common.lib.to.MappingTO;
 import org.apache.syncope.common.lib.to.NotificationTO;
 import org.apache.syncope.common.lib.to.NotificationTaskTO;
 import org.apache.syncope.common.lib.to.PlainSchemaTO;
-import org.apache.syncope.common.lib.to.PropagationTaskTO;
 import org.apache.syncope.common.lib.to.ProvisionTO;
 import org.apache.syncope.common.lib.to.ReconStatus;
 import org.apache.syncope.common.lib.to.ResourceTO;


### PR DESCRIPTION
This pull request:

- Removes a number of unused imports from Syncope
- Primarily makes sure, in certain areas, that Optional objects are checked to actually contain a value before a value can be retrieved. I specifically ran into an example of this, as a result of bad (manual) mapping configuration in the MasterContent.xml file, where no mapping was tagged with a `conn-object-key=1`. I decided to add a bit more safety to protect and defect against the dark arts...of dealing with optionals! :)