### PR TITLE
NOJIRA - Switch Travis CI to AMD64 Bionic Distro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ dist: bionic
 arch: arm64
 jdk:
   - openjdk11
+before_install:
+- sudo apt-get -yq install maven
 cache:
   bundler: false
   cargo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
   include:
     - stage: build
       name: "Build"
-      script: mvn -U --quiet -T 1C -P skipTests,all
+      script: travis_wait 55 mvn -U --quiet -T 1C -P skipTests,all
       #######################################################
     - stage: validate
       name: "Checkstyle, Legal Files, Modernizer and Release Audit Tool (RAT) Analysis"
@@ -72,7 +72,7 @@ jobs:
       ######################################################
     - stage: fit
       name: "Full Integration Tests: Apache Tomcat / H2 / JSON Content-Type"
-      script: mvn -f fit/core-reference/pom.xml verify --quiet -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+      script: travis_wait 55 mvn -f fit/core-reference/pom.xml verify --quiet -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
       after_failure:
        - cat fit/core-reference/target/log/*
        - cat fit/core-reference/target/failsafe-reports/org.apache.syncope.fit.*-output.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@
 
 language: java
 os: linux
-dist: trusty
+dist: bionic
+arch: arm64
 jdk:
   - openjdk11
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
   - jaxrsContentType=application/json
   - TestCommand="mvn -U -T 1C clean test -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Dsass.skip=true"
 before_install:
-- wget https://github.com/sormuras/bach/raw/master/install-jdk.sh && chmod +x install-jdk.sh
+- wget https://github.com/sormuras/bach/raw/master/install-jdk.sh -O ~/install-jdk.sh && chmod +x ~/install-jdk.sh
 install: true
 notifications:
   email:
@@ -60,14 +60,14 @@ jobs:
     - stage: test
       name: "Unit Tests via JDK 14"
       script: 
-      - ./install-jdk.sh --target "/home/travis/openjdk14" --workspace "/home/travis/.cache/install-jdk" --feature "14" --license "GPL" --cacerts
+      - ~/install-jdk.sh --target "/home/travis/openjdk14" --workspace "/home/travis/.cache/install-jdk" --feature "14" --license "GPL" --cacerts
       - export JAVA_HOME=~/openjdk14
       - export PATH="$JAVA_HOME/bin:$PATH"
       - eval $TestCommand
     - stage: test
       name: "Unit Tests via JDK 15"
       script: 
-      - ./install-jdk.sh --target "/home/travis/openjdk15" --workspace "/home/travis/.cache/install-jdk" --feature "15" --license "GPL" --cacerts
+      - ~/install-jdk.sh --target "/home/travis/openjdk15" --workspace "/home/travis/.cache/install-jdk" --feature "15" --license "GPL" --cacerts
       - export JAVA_HOME=~/openjdk15
       - export PATH="$JAVA_HOME/bin:$PATH"
       - eval $TestCommand

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ jobs:
   include:
     - stage: build
       name: "Build"
-      script: travis_wait 55 mvn -U --quiet -T 1C -P skipTests,all
+      script: mvn -U --quiet -T 1C -P skipTests,all
       #######################################################
     - stage: validate
       name: "Checkstyle, Legal Files, Modernizer and Release Audit Tool (RAT) Analysis"
@@ -72,7 +72,7 @@ jobs:
       ######################################################
     - stage: fit
       name: "Full Integration Tests: Apache Tomcat / H2 / JSON Content-Type"
-      script: travis_wait 55 mvn -f fit/core-reference/pom.xml verify --quiet -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+      script: mvn -f fit/core-reference/pom.xml verify --quiet -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
       after_failure:
        - cat fit/core-reference/target/log/*
        - cat fit/core-reference/target/failsafe-reports/org.apache.syncope.fit.*-output.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ env:
   - DBMS=H2
   - jaxrsContentType=application/json
   - TestCommand="mvn -U -T 1C clean test -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Dsass.skip=true"
+before_install:
+- wget https://github.com/sormuras/bach/raw/master/install-jdk.sh && chmod +x install-jdk.sh
 install: true
 notifications:
   email:
@@ -58,14 +60,14 @@ jobs:
     - stage: test
       name: "Unit Tests via JDK 14"
       script: 
-      - ~/bin/install-jdk.sh --target "/home/travis/openjdk14" --workspace "/home/travis/.cache/install-jdk" --feature "14" --license "GPL" --cacerts
+      - ./install-jdk.sh --target "/home/travis/openjdk14" --workspace "/home/travis/.cache/install-jdk" --feature "14" --license "GPL" --cacerts
       - export JAVA_HOME=~/openjdk14
       - export PATH="$JAVA_HOME/bin:$PATH"
       - eval $TestCommand
     - stage: test
       name: "Unit Tests via JDK 15"
       script: 
-      - ~/bin/install-jdk.sh --target "/home/travis/openjdk15" --workspace "/home/travis/.cache/install-jdk" --feature "15" --license "GPL" --cacerts
+      - ./install-jdk.sh --target "/home/travis/openjdk15" --workspace "/home/travis/.cache/install-jdk" --feature "15" --license "GPL" --cacerts
       - export JAVA_HOME=~/openjdk15
       - export PATH="$JAVA_HOME/bin:$PATH"
       - eval $TestCommand

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,9 @@
 language: java
 os: linux
 dist: bionic
-arch: arm64
+arch: amd64
 jdk:
   - openjdk11
-before_install:
-- sudo apt-get -yq install maven
 cache:
   bundler: false
   cargo: false

--- a/pom.xml
+++ b/pom.xml
@@ -2530,7 +2530,6 @@ under the License.
             <exclude>**/*.json</exclude>
             <exclude>**/banner.txt</exclude>
             <exclude>**/target/**</exclude>
-            <exclude>**/install-jdk.sh</exclude>
           </excludes>
         </configuration>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -2530,6 +2530,7 @@ under the License.
             <exclude>**/*.json</exclude>
             <exclude>**/banner.txt</exclude>
             <exclude>**/target/**</exclude>
+            <exclude>**/install-jdk.sh</exclude>
           </excludes>
         </configuration>
         <executions>


### PR DESCRIPTION
The Travis CI trusty image is deprecated. This change switches the distro to Bionic which builds against Ubuntu 18.

PS. I also experimented with arm-based builds which are super fast to startup (less than 10 seconds) but they are not as packed as others (No maven, Java installed, etc) and the cache seems somewhat suspicious with those. Bionic should do fine for now.