### PR TITLE
Enabling YAML-based IT run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,13 +81,13 @@ jobs:
       script: mvn -f core/persistence-jpa-json/pom.xml -P mysql -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Dsass.skip=true
       ######################################################
     - stage: fit
-      name: "Integration Tests: Apache Tomcat / H2 / JSON Content-Type"
+      name: "Integration Tests: Tomcat / H2 / JSON Content-Type"
       script: mvn -f fit/core-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
       #- stage: fit
-      #name: "Integration Tests: Apache Tomcat / H2 / XML Content-Type"
+      #name: "Integration Tests: Tomcat / H2 / XML Content-Type"
       #script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/xml -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Integration Tests: Apache Tomcat / H2 / YAML Content-Type"
+      name: "Integration Tests: Tomcat / H2 / YAML Content-Type"
       script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/yaml -Dit.test=org.apache.syncope.fit.core.*ITCase -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
       name: "Integration Tests: Wildfly / H2 / JSON Content-Type"
@@ -96,25 +96,25 @@ jobs:
       #name: "Integration Tests: Payara / H2 / JSON Content-Type"
       #script: mvn -f fit/core-reference/pom.xml -P payara-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Integration Tests: Apache Tomcat / PostgreSQL / JSON Content-Type"
+      name: "Integration Tests: Tomcat / PostgreSQL / JSON Content-Type"
       script: mvn -f fit/core-reference/pom.xml -P postgres-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Integration Tests: Apache Tomcat / PostgreSQL (JSONB) / JSON Content-Type"
+      name: "Integration Tests: Tomcat / PostgreSQL (JSONB) / JSON Content-Type"
       script: mvn -f fit/core-reference/pom.xml -P pgjsonb-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Integration Tests: Apache Tomcat / MySQL / JSON Content-Type"
+      name: "Integration Tests: Tomcat / MySQL / JSON Content-Type"
       script: mvn -f fit/core-reference/pom.xml -P mysql-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Integration Tests: Apache Tomcat / MySQL (JSON) / JSON Content-Type"
+      name: "Integration Tests: Tomcat / MySQL (JSON) / JSON Content-Type"
       script: mvn -f fit/core-reference/pom.xml -P myjson-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Integration Tests: Apache Tomcat / MariaDB / JSON Content-Type"
+      name: "Integration Tests: Tomcat / MariaDB / JSON Content-Type"
       script: mvn -f fit/core-reference/pom.xml -P mariadb-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Integration Tests: Apache Tomcat / H2 / JSON Content-Type + Elasticsearch"
+      name: "Integration Tests: Tomcat / H2 / JSON Content-Type + Elasticsearch"
       script: mvn -f fit/core-reference/pom.xml -P elasticsearch-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Integration Tests: Apache Tomcat / H2 / JSON Content-Type + Zookeeper"
+      name: "Integration Tests: Tomcat / H2 / JSON Content-Type + Zookeeper"
       script: mvn -f fit/core-reference/pom.xml -P zookeeper-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
       after_failure:
        - cat fit/core-reference/target/log/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -81,40 +81,40 @@ jobs:
       script: mvn -f core/persistence-jpa-json/pom.xml -P mysql -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Dsass.skip=true
       ######################################################
     - stage: fit
-      name: "Full Integration Tests: Apache Tomcat / H2 / JSON Content-Type"
+      name: "Integration Tests: Apache Tomcat / H2 / JSON Content-Type"
       script: mvn -f fit/core-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
       #- stage: fit
-      #name: "Full Integration Tests: Apache Tomcat / H2 / XML Content-Type"
+      #name: "Integration Tests: Apache Tomcat / H2 / XML Content-Type"
       #script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/xml -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Full Integration Tests: Apache Tomcat / H2 / YAML Content-Type"
+      name: "Integration Tests: Apache Tomcat / H2 / YAML Content-Type"
       script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/yaml -Dit.test=org.apache.syncope.fit.core.*ITCase -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Full Integration Tests: Wildfly / H2 / JSON Content-Type"
+      name: "Integration Tests: Wildfly / H2 / JSON Content-Type"
       script: mvn -f fit/core-reference/pom.xml -P wildfly-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
       #- stage: fit
-      #name: "Full Integration Tests: Payara / H2 / JSON Content-Type"
+      #name: "Integration Tests: Payara / H2 / JSON Content-Type"
       #script: mvn -f fit/core-reference/pom.xml -P payara-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Full Integration Tests: Apache Tomcat / PostgreSQL / JSON Content-Type"
+      name: "Integration Tests: Apache Tomcat / PostgreSQL / JSON Content-Type"
       script: mvn -f fit/core-reference/pom.xml -P postgres-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Full Integration Tests: Apache Tomcat / PostgreSQL (JSONB) / JSON Content-Type"
+      name: "Integration Tests: Apache Tomcat / PostgreSQL (JSONB) / JSON Content-Type"
       script: mvn -f fit/core-reference/pom.xml -P pgjsonb-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Full Integration Tests: Apache Tomcat / MySQL / JSON Content-Type"
+      name: "Integration Tests: Apache Tomcat / MySQL / JSON Content-Type"
       script: mvn -f fit/core-reference/pom.xml -P mysql-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Full Integration Tests: Apache Tomcat / MySQL (JSON) / JSON Content-Type"
+      name: "Integration Tests: Apache Tomcat / MySQL (JSON) / JSON Content-Type"
       script: mvn -f fit/core-reference/pom.xml -P myjson-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Full Integration Tests: Apache Tomcat / MariaDB / JSON Content-Type"
+      name: "Integration Tests: Apache Tomcat / MariaDB / JSON Content-Type"
       script: mvn -f fit/core-reference/pom.xml -P mariadb-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Full Integration Tests: Apache Tomcat / H2 / JSON Content-Type + Elasticsearch"
+      name: "Integration Tests: Apache Tomcat / H2 / JSON Content-Type + Elasticsearch"
       script: mvn -f fit/core-reference/pom.xml -P elasticsearch-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Full Integration Tests: Apache Tomcat / H2 / JSON Content-Type + Zookeeper"
+      name: "Integration Tests: Apache Tomcat / H2 / JSON Content-Type + Zookeeper"
       script: mvn -f fit/core-reference/pom.xml -P zookeeper-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
       after_failure:
        - cat fit/core-reference/target/log/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ jobs:
       #- stage: fit
       #name: "Full Integration Tests: Apache Tomcat / H2 / XML Content-Type"
       #script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/xml -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
-      #- stage: fit
+    - stage: fit
       name: "Full Integration Tests: Apache Tomcat / H2 / YAML Content-Type"
       script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/yaml -Dit.test=org.apache.syncope.fit.core.*ITCase -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,8 +87,8 @@ jobs:
       #name: "Full Integration Tests: Apache Tomcat / H2 / XML Content-Type"
       #script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/xml -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
       #- stage: fit
-      #name: "Full Integration Tests: Apache Tomcat / H2 / YAML Content-Type"
-      #script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/yaml -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+      name: "Full Integration Tests: Apache Tomcat / H2 / YAML Content-Type"
+      script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/yaml -Dit.test=org.apache.syncope.fit.core.*ITCase -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
       name: "Full Integration Tests: Wildfly / H2 / JSON Content-Type"
       script: mvn -f fit/core-reference/pom.xml -P wildfly-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true


### PR DESCRIPTION
After fixing [SYNCOPE-1564](https://issues.apache.org/jira/browse/SYNCOPE-1564) we are ready to add YAML-based integration tests to the collection run by Travis CI.