### PR TITLE
SYNCOPE-1556: Manage OIDC JWKS

### DIFF
--- a/common/am/lib/src/main/java/org/apache/syncope/common/lib/to/OIDCJWKSTO.java
+++ b/common/am/lib/src/main/java/org/apache/syncope/common/lib/to/OIDCJWKSTO.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.syncope.common.lib.to;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+public class OIDCJWKSTO implements EntityTO {
+
+    private static final long serialVersionUID = 1285073386484048953L;
+
+    private String key;
+
+    private String json;
+
+    public String getJson() {
+        return json;
+    }
+
+    public void setJson(final String json) {
+        this.json = json;
+    }
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(final String key) {
+        this.key = key;
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder()
+            .appendSuper(super.hashCode())
+            .append(key)
+            .append(json)
+            .toHashCode();
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (obj == this) {
+            return true;
+        }
+        if (obj.getClass() != getClass()) {
+            return false;
+        }
+        OIDCJWKSTO rhs = (OIDCJWKSTO) obj;
+        return new EqualsBuilder()
+            .appendSuper(super.equals(obj))
+            .append(this.key, rhs.key)
+            .append(this.json, rhs.json)
+            .isEquals();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+            .append("key", key)
+            .append("json", json)
+            .toString();
+    }
+
+    public static class Builder {
+
+        private final OIDCJWKSTO instance = new OIDCJWKSTO();
+
+        public OIDCJWKSTO.Builder json(final String json) {
+            instance.setJson(json);
+            return this;
+        }
+
+        public OIDCJWKSTO.Builder key(final String key) {
+            instance.setKey(key);
+            return this;
+        }
+
+        public OIDCJWKSTO build() {
+            return instance;
+        }
+    }
+}

--- a/common/am/lib/src/main/java/org/apache/syncope/common/lib/types/AMEntitlement.java
+++ b/common/am/lib/src/main/java/org/apache/syncope/common/lib/types/AMEntitlement.java
@@ -102,6 +102,8 @@ public final class AMEntitlement {
 
     public static final String OIDC_JWKS_UPDATE = "OIDC_JWKS_UPDATE";
 
+    public static final String OIDC_JWKS_DELETE = "OIDC_JWKS_DELETE";
+
     private static final Set<String> VALUES;
 
     static {

--- a/common/am/lib/src/main/java/org/apache/syncope/common/lib/types/AMEntitlement.java
+++ b/common/am/lib/src/main/java/org/apache/syncope/common/lib/types/AMEntitlement.java
@@ -96,6 +96,12 @@ public final class AMEntitlement {
 
     public static final String GOOGLE_MFA_COUNT_ACCOUNTS = "GOOGLE_MFA_COUNT_ACCOUNTS";
 
+    public static final String OIDC_JWKS_CREATE = "OIDC_JWKS_CREATE";
+
+    public static final String OIDC_JWKS_READ = "OIDC_JWKS_READ";
+
+    public static final String OIDC_JWKS_UPDATE = "OIDC_JWKS_UPDATE";
+
     private static final Set<String> VALUES;
 
     static {

--- a/common/am/rest-api/src/main/java/org/apache/syncope/common/rest/api/service/OIDCJWKSConfService.java
+++ b/common/am/rest-api/src/main/java/org/apache/syncope/common/rest/api/service/OIDCJWKSConfService.java
@@ -27,10 +27,13 @@ import org.apache.syncope.common.rest.api.RESTHeaders;
 
 import javax.validation.constraints.NotNull;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 @Tag(name = "OIDC Json Web Keystore")
 @SecurityRequirements({
@@ -45,4 +48,8 @@ public interface OIDCJWKSConfService extends JAXRSService {
     @Produces({MediaType.APPLICATION_JSON, RESTHeaders.APPLICATION_YAML, MediaType.APPLICATION_XML})
     void update(@NotNull OIDCJWKSTO jwksTO);
 
+    @DELETE
+    @Consumes({ MediaType.APPLICATION_JSON, RESTHeaders.APPLICATION_YAML, MediaType.APPLICATION_XML })
+    @Produces({ MediaType.APPLICATION_JSON, RESTHeaders.APPLICATION_YAML, MediaType.APPLICATION_XML })
+    Response delete();
 }

--- a/common/am/rest-api/src/main/java/org/apache/syncope/common/rest/api/service/OIDCJWKSConfService.java
+++ b/common/am/rest-api/src/main/java/org/apache/syncope/common/rest/api/service/OIDCJWKSConfService.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.syncope.common.rest.api.service;
+
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.apache.syncope.common.lib.to.OIDCJWKSTO;
+import org.apache.syncope.common.rest.api.RESTHeaders;
+
+import javax.validation.constraints.NotNull;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+@Tag(name = "OIDC Json Web Keystore")
+@SecurityRequirements({
+    @SecurityRequirement(name = "BasicAuthentication"),
+    @SecurityRequirement(name = "Bearer")})
+@Path("oidc/jwks")
+public interface OIDCJWKSConfService extends JAXRSService {
+
+    @ApiResponse(responseCode = "204", description = "Operation was successful")
+    @PUT
+    @Consumes({MediaType.APPLICATION_JSON, RESTHeaders.APPLICATION_YAML, MediaType.APPLICATION_XML})
+    @Produces({MediaType.APPLICATION_JSON, RESTHeaders.APPLICATION_YAML, MediaType.APPLICATION_XML})
+    void update(@NotNull OIDCJWKSTO jwksTO);
+
+}

--- a/common/am/rest-api/src/main/java/org/apache/syncope/common/rest/api/service/OIDCJWKSConfService.java
+++ b/common/am/rest-api/src/main/java/org/apache/syncope/common/rest/api/service/OIDCJWKSConfService.java
@@ -30,7 +30,6 @@ import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;

--- a/common/am/rest-api/src/main/java/org/apache/syncope/common/rest/api/service/wa/OIDCJWKSService.java
+++ b/common/am/rest-api/src/main/java/org/apache/syncope/common/rest/api/service/wa/OIDCJWKSService.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.syncope.common.rest.api.service.wa;
+
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.security.SecurityRequirements;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.apache.syncope.common.lib.to.OIDCJWKSTO;
+import org.apache.syncope.common.rest.api.RESTHeaders;
+import org.apache.syncope.common.rest.api.service.JAXRSService;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+@Tag(name = "OIDC Json Web Keystore")
+@SecurityRequirements({
+    @SecurityRequirement(name = "BasicAuthentication"),
+    @SecurityRequirement(name = "Bearer")})
+@Path("wa/oidc/jwks")
+public interface OIDCJWKSService extends JAXRSService {
+
+    @GET
+    @Produces({MediaType.APPLICATION_JSON, RESTHeaders.APPLICATION_YAML, MediaType.APPLICATION_XML})
+    OIDCJWKSTO get();
+
+    @ApiResponses({
+        @ApiResponse(responseCode = "201",
+            description = "JWKS successfully created", headers = {
+            @Header(name = RESTHeaders.RESOURCE_KEY, schema =
+            @Schema(type = "string"),
+                description = "UUID generated for the entity created"),
+            @Header(name = HttpHeaders.LOCATION, schema =
+            @Schema(type = "string"),
+                description = "URL of the entity created")}),
+        @ApiResponse(responseCode = "409",
+            description = "JWKS already exists")})
+    @POST
+    @Consumes({MediaType.APPLICATION_JSON, RESTHeaders.APPLICATION_YAML, MediaType.APPLICATION_XML})
+    @Produces({MediaType.APPLICATION_JSON, RESTHeaders.APPLICATION_YAML, MediaType.APPLICATION_XML})
+    Response set();
+}

--- a/core/am/logic/src/main/java/org/apache/syncope/core/logic/GoogleMfaAuthAccountLogic.java
+++ b/core/am/logic/src/main/java/org/apache/syncope/core/logic/GoogleMfaAuthAccountLogic.java
@@ -38,7 +38,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.lang.reflect.Method;
 import java.util.List;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Component

--- a/core/am/logic/src/main/java/org/apache/syncope/core/logic/GoogleMfaAuthAccountLogic.java
+++ b/core/am/logic/src/main/java/org/apache/syncope/core/logic/GoogleMfaAuthAccountLogic.java
@@ -29,6 +29,7 @@ import org.apache.syncope.core.persistence.api.dao.auth.AuthProfileDAO;
 import org.apache.syncope.core.persistence.api.entity.EntityFactory;
 import org.apache.syncope.core.persistence.api.entity.auth.AuthProfile;
 import org.apache.syncope.core.provisioning.api.data.AuthProfileDataBinder;
+import org.apache.syncope.core.spring.security.SecureRandomUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Component;
@@ -108,7 +109,7 @@ public class GoogleMfaAuthAccountLogic extends AbstractTransactionalLogic<AuthPr
             });
 
         if (acct.getKey() == null) {
-            acct.setKey(UUID.randomUUID().toString());
+            acct.setKey(SecureRandomUtils.generateRandomUUID().toString());
         }
         profile.setGoogleMfaAuthAccount(acct);
         return authProfileDAO.save(profile).getGoogleMfaAuthAccount();

--- a/core/am/logic/src/main/java/org/apache/syncope/core/logic/GoogleMfaAuthTokenLogic.java
+++ b/core/am/logic/src/main/java/org/apache/syncope/core/logic/GoogleMfaAuthTokenLogic.java
@@ -22,7 +22,6 @@ import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
-import java.util.UUID;
 import java.util.function.Predicate;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.syncope.common.lib.to.AuthProfileTO;

--- a/core/am/logic/src/main/java/org/apache/syncope/core/logic/GoogleMfaAuthTokenLogic.java
+++ b/core/am/logic/src/main/java/org/apache/syncope/core/logic/GoogleMfaAuthTokenLogic.java
@@ -34,6 +34,7 @@ import org.apache.syncope.core.persistence.api.dao.auth.AuthProfileDAO;
 import org.apache.syncope.core.persistence.api.entity.EntityFactory;
 import org.apache.syncope.core.persistence.api.entity.auth.AuthProfile;
 import org.apache.syncope.core.provisioning.api.data.AuthProfileDataBinder;
+import org.apache.syncope.core.spring.security.SecureRandomUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Component;
@@ -106,7 +107,7 @@ public class GoogleMfaAuthTokenLogic extends AbstractTransactionalLogic<AuthProf
                 });
 
         if (token.getKey() == null) {
-            token.setKey(UUID.randomUUID().toString());
+            token.setKey(SecureRandomUtils.generateRandomUUID().toString());
         }
         profile.add(token);
         profile = authProfileDAO.save(profile);

--- a/core/am/logic/src/main/java/org/apache/syncope/core/logic/OIDCJWKSLogic.java
+++ b/core/am/logic/src/main/java/org/apache/syncope/core/logic/OIDCJWKSLogic.java
@@ -60,7 +60,7 @@ public class OIDCJWKSLogic extends AbstractTransactionalLogic<OIDCJWKSTO> {
     public OIDCJWKSTO set() {
         OIDCJWKS jwks = dao.get();
         if (jwks == null) {
-            binder.get(dao.save(binder.create()));
+            return binder.get(dao.save(binder.create()));
         }
         throw SyncopeClientException.build(ClientExceptionType.EntityExists);
     }

--- a/core/am/logic/src/main/java/org/apache/syncope/core/logic/OIDCJWKSLogic.java
+++ b/core/am/logic/src/main/java/org/apache/syncope/core/logic/OIDCJWKSLogic.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.syncope.core.logic;
+
+import org.apache.syncope.common.lib.SyncopeClientException;
+import org.apache.syncope.common.lib.to.OIDCJWKSTO;
+import org.apache.syncope.common.lib.types.AMEntitlement;
+import org.apache.syncope.common.lib.types.ClientExceptionType;
+import org.apache.syncope.common.lib.types.IdRepoEntitlement;
+import org.apache.syncope.core.persistence.api.dao.NotFoundException;
+import org.apache.syncope.core.persistence.api.dao.auth.OIDCJWKSDAO;
+import org.apache.syncope.core.persistence.api.entity.auth.OIDCJWKS;
+import org.apache.syncope.core.provisioning.api.data.OIDCJWKSDataBinder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+@Component
+public class OIDCJWKSLogic extends AbstractTransactionalLogic<OIDCJWKSTO> {
+
+    @Autowired
+    private OIDCJWKSDataBinder binder;
+
+    @Autowired
+    private OIDCJWKSDAO dao;
+
+    @PreAuthorize("hasRole('" + AMEntitlement.OIDC_JWKS_READ + "') "
+        + "or hasRole('" + IdRepoEntitlement.ANONYMOUS + "')")
+    @Transactional(readOnly = true)
+    public OIDCJWKSTO get() {
+        return dao.get().
+            map(binder::get).
+            orElseThrow(() -> new NotFoundException("OIDC JWKS not found"));
+    }
+
+    @PreAuthorize("hasRole('" + AMEntitlement.OIDC_JWKS_CREATE + "') "
+        + "or hasRole('" + IdRepoEntitlement.ANONYMOUS + "')")
+    public OIDCJWKSTO set() {
+        Optional<OIDCJWKS> result = dao.get();
+        if (result.isEmpty()) {
+            return binder.get(dao.save(binder.create()));
+        }
+        throw SyncopeClientException.build(ClientExceptionType.EntityExists);
+    }
+
+    @PreAuthorize("hasRole('" + AMEntitlement.OIDC_JWKS_UPDATE + "')")
+    public OIDCJWKSTO update(final OIDCJWKSTO jwksTO) {
+        Optional<OIDCJWKS> result = dao.get();
+        if (result.isEmpty()) {
+            throw SyncopeClientException.build(ClientExceptionType.NotFound);
+        }
+        return binder.get(dao.save(binder.update(result.get(), jwksTO)));
+    }
+
+    @Override
+    protected OIDCJWKSTO resolveReference(final Method method, final Object... args) throws UnresolvedReferenceException {
+        return dao.get().
+            map(binder::get).
+            orElseThrow(UnresolvedReferenceException::new);
+    }
+}

--- a/core/am/logic/src/main/java/org/apache/syncope/core/logic/OIDCJWKSLogic.java
+++ b/core/am/logic/src/main/java/org/apache/syncope/core/logic/OIDCJWKSLogic.java
@@ -80,4 +80,9 @@ public class OIDCJWKSLogic extends AbstractTransactionalLogic<OIDCJWKSTO> {
             map(binder::get).
             orElseThrow(UnresolvedReferenceException::new);
     }
+
+    @PreAuthorize("hasRole('" + AMEntitlement.OIDC_JWKS_DELETE + "')")
+    public void delete() {
+         dao.delete();
+    }
 }

--- a/core/am/logic/src/main/java/org/apache/syncope/core/logic/OIDCJWKSLogic.java
+++ b/core/am/logic/src/main/java/org/apache/syncope/core/logic/OIDCJWKSLogic.java
@@ -74,7 +74,8 @@ public class OIDCJWKSLogic extends AbstractTransactionalLogic<OIDCJWKSTO> {
     }
 
     @Override
-    protected OIDCJWKSTO resolveReference(final Method method, final Object... args) throws UnresolvedReferenceException {
+    protected OIDCJWKSTO resolveReference(final Method method, final Object... args)
+        throws UnresolvedReferenceException {
         return dao.get().
             map(binder::get).
             orElseThrow(UnresolvedReferenceException::new);

--- a/core/am/logic/src/main/java/org/apache/syncope/core/logic/SAML2IdPMetadataLogic.java
+++ b/core/am/logic/src/main/java/org/apache/syncope/core/logic/SAML2IdPMetadataLogic.java
@@ -18,8 +18,6 @@
  */
 package org.apache.syncope.core.logic;
 
-import static org.apache.syncope.core.logic.AbstractLogic.LOG;
-
 import java.lang.reflect.Method;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.syncope.common.lib.SyncopeClientException;
@@ -30,7 +28,7 @@ import org.apache.syncope.common.lib.types.IdRepoEntitlement;
 import org.apache.syncope.core.persistence.api.dao.NotFoundException;
 import org.apache.syncope.core.persistence.api.dao.auth.SAML2IdPMetadataDAO;
 import org.apache.syncope.core.persistence.api.entity.auth.SAML2IdPMetadata;
-import org.apache.syncope.core.provisioning.api.data.SAML2IdPMetadataBinder;
+import org.apache.syncope.core.provisioning.api.data.SAML2IdPMetadataDataBinder;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Component;
@@ -40,7 +38,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class SAML2IdPMetadataLogic extends AbstractTransactionalLogic<SAML2IdPMetadataTO> {
 
     @Autowired
-    private SAML2IdPMetadataBinder binder;
+    private SAML2IdPMetadataDataBinder binder;
 
     @Autowired
     private SAML2IdPMetadataDAO saml2IdPMetadataDAO;

--- a/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/OIDCJWKSConfServiceImpl.java
+++ b/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/OIDCJWKSConfServiceImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.syncope.core.rest.cxf.service;
+
+import org.apache.syncope.common.lib.to.OIDCJWKSTO;
+import org.apache.syncope.common.rest.api.service.OIDCJWKSConfService;
+import org.apache.syncope.core.logic.OIDCJWKSLogic;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class OIDCJWKSConfServiceImpl extends AbstractServiceImpl implements OIDCJWKSConfService {
+
+    @Autowired
+    private OIDCJWKSLogic logic;
+
+    @Override
+    public void update(final OIDCJWKSTO jwksTO) {
+        logic.update(jwksTO);
+    }
+}

--- a/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/OIDCJWKSConfServiceImpl.java
+++ b/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/OIDCJWKSConfServiceImpl.java
@@ -24,6 +24,8 @@ import org.apache.syncope.core.logic.OIDCJWKSLogic;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import javax.ws.rs.core.Response;
+
 @Service
 public class OIDCJWKSConfServiceImpl extends AbstractServiceImpl implements OIDCJWKSConfService {
 
@@ -33,5 +35,11 @@ public class OIDCJWKSConfServiceImpl extends AbstractServiceImpl implements OIDC
     @Override
     public void update(final OIDCJWKSTO jwksTO) {
         logic.update(jwksTO);
+    }
+
+    @Override
+    public Response delete() {
+        logic.delete();
+        return Response.noContent().build();
     }
 }

--- a/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/wa/OIDCJWKSServiceImpl.java
+++ b/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/wa/OIDCJWKSServiceImpl.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.syncope.core.rest.cxf.service.wa;
+
+import org.apache.syncope.common.lib.to.OIDCJWKSTO;
+import org.apache.syncope.common.rest.api.RESTHeaders;
+import org.apache.syncope.common.rest.api.service.wa.OIDCJWKSService;
+import org.apache.syncope.core.logic.OIDCJWKSLogic;
+import org.apache.syncope.core.rest.cxf.service.AbstractServiceImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.ws.rs.core.Response;
+
+import java.net.URI;
+
+@Service
+public class OIDCJWKSServiceImpl extends AbstractServiceImpl implements OIDCJWKSService {
+    @Autowired
+    private OIDCJWKSLogic logic;
+
+    @Override
+    public OIDCJWKSTO get() {
+        return logic.get();
+    }
+
+    @Override
+    public Response set() {
+        OIDCJWKSTO jwks = logic.set();
+        URI location = uriInfo.getAbsolutePathBuilder().path(jwks.getKey()).build();
+        return Response.created(location).
+            header(RESTHeaders.RESOURCE_KEY, jwks.getKey()).
+            entity(jwks).
+            build();
+    }
+}

--- a/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/dao/auth/OIDCJWKSDAO.java
+++ b/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/dao/auth/OIDCJWKSDAO.java
@@ -27,4 +27,6 @@ public interface OIDCJWKSDAO extends DAO<OIDCJWKS> {
     Optional<OIDCJWKS> get();
 
     OIDCJWKS save(OIDCJWKS jwks);
+
+    void delete();
 }

--- a/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/dao/auth/OIDCJWKSDAO.java
+++ b/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/dao/auth/OIDCJWKSDAO.java
@@ -21,10 +21,8 @@ package org.apache.syncope.core.persistence.api.dao.auth;
 import org.apache.syncope.core.persistence.api.dao.DAO;
 import org.apache.syncope.core.persistence.api.entity.auth.OIDCJWKS;
 
-import java.util.Optional;
-
 public interface OIDCJWKSDAO extends DAO<OIDCJWKS> {
-    Optional<OIDCJWKS> get();
+    OIDCJWKS get();
 
     OIDCJWKS save(OIDCJWKS jwks);
 

--- a/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/dao/auth/OIDCJWKSDAO.java
+++ b/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/dao/auth/OIDCJWKSDAO.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.syncope.core.persistence.api.dao.auth;
+
+import org.apache.syncope.core.persistence.api.dao.DAO;
+import org.apache.syncope.core.persistence.api.entity.auth.OIDCJWKS;
+
+import java.util.Optional;
+
+public interface OIDCJWKSDAO extends DAO<OIDCJWKS> {
+    Optional<OIDCJWKS> get();
+
+    OIDCJWKS save(OIDCJWKS jwks);
+}

--- a/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/entity/auth/OIDCJWKS.java
+++ b/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/entity/auth/OIDCJWKS.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.syncope.core.persistence.api.entity.auth;
+
+import org.apache.syncope.core.persistence.api.entity.Entity;
+
+public interface OIDCJWKS extends Entity {
+
+    String getJson();
+
+    void setJson(String json);
+
+}

--- a/core/persistence-jpa-json/pom.xml
+++ b/core/persistence-jpa-json/pom.xml
@@ -86,6 +86,11 @@ under the License.
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/persistence-jpa/pom.xml
+++ b/core/persistence-jpa/pom.xml
@@ -138,6 +138,11 @@ under the License.
       <artifactId>bcprov-jdk15on</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/auth/JPAOIDCJWKSDAO.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/auth/JPAOIDCJWKSDAO.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.syncope.core.persistence.jpa.dao.auth;
+
+import org.apache.syncope.core.persistence.api.dao.auth.OIDCJWKSDAO;
+import org.apache.syncope.core.persistence.api.entity.auth.OIDCJWKS;
+import org.apache.syncope.core.persistence.jpa.dao.AbstractDAO;
+import org.apache.syncope.core.persistence.jpa.entity.auth.JPAOIDCJWKS;
+import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.persistence.NoResultException;
+import javax.persistence.TypedQuery;
+
+import java.util.Optional;
+
+@Repository
+public class JPAOIDCJWKSDAO extends AbstractDAO<OIDCJWKS> implements OIDCJWKSDAO {
+
+    @Transactional(readOnly = true)
+    @Override
+    public Optional<OIDCJWKS> get() {
+        try {
+            TypedQuery<OIDCJWKS> query = entityManager().
+                createQuery("SELECT e FROM " + JPAOIDCJWKS.class.getSimpleName() + " e", OIDCJWKS.class);
+            return Optional.of(query.getSingleResult());
+        } catch (final NoResultException e) {
+            LOG.debug(e.getMessage());
+        }
+        return Optional.empty();
+    }
+
+    @Override
+    public OIDCJWKS save(final OIDCJWKS jwks) {
+        return entityManager().merge(jwks);
+    }
+}

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/auth/JPAOIDCJWKSDAO.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/auth/JPAOIDCJWKSDAO.java
@@ -50,4 +50,11 @@ public class JPAOIDCJWKSDAO extends AbstractDAO<OIDCJWKS> implements OIDCJWKSDAO
     public OIDCJWKS save(final OIDCJWKS jwks) {
         return entityManager().merge(jwks);
     }
+
+    @Override
+    public void delete() {
+        entityManager()
+            .createQuery("DELETE FROM " + JPAOIDCJWKS.class.getSimpleName(), OIDCJWKS.class)
+            .executeUpdate();
+    }
 }

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/auth/JPAOIDCJWKSDAO.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/auth/JPAOIDCJWKSDAO.java
@@ -53,8 +53,8 @@ public class JPAOIDCJWKSDAO extends AbstractDAO<OIDCJWKS> implements OIDCJWKSDAO
 
     @Override
     public void delete() {
-        entityManager()
-            .createQuery("DELETE FROM " + JPAOIDCJWKS.class.getSimpleName(), OIDCJWKS.class)
-            .executeUpdate();
+        entityManager().
+            createQuery("DELETE FROM " + JPAOIDCJWKS.class.getSimpleName()).
+            executeUpdate();
     }
 }

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/auth/JPAOIDCJWKSDAO.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/auth/JPAOIDCJWKSDAO.java
@@ -28,22 +28,20 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.persistence.NoResultException;
 import javax.persistence.TypedQuery;
 
-import java.util.Optional;
-
 @Repository
 public class JPAOIDCJWKSDAO extends AbstractDAO<OIDCJWKS> implements OIDCJWKSDAO {
 
     @Transactional(readOnly = true)
     @Override
-    public Optional<OIDCJWKS> get() {
+    public OIDCJWKS get() {
         try {
             TypedQuery<OIDCJWKS> query = entityManager().
                 createQuery("SELECT e FROM " + JPAOIDCJWKS.class.getSimpleName() + " e", OIDCJWKS.class);
-            return Optional.of(query.getSingleResult());
+            return query.getSingleResult();
         } catch (final NoResultException e) {
             LOG.debug(e.getMessage());
         }
-        return Optional.empty();
+        return null;
     }
 
     @Override

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/entity/JPAEntityFactory.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/entity/JPAEntityFactory.java
@@ -59,6 +59,7 @@ import org.apache.syncope.core.persistence.api.entity.anyobject.AnyObject;
 import org.apache.syncope.core.persistence.api.entity.auth.AuthModule;
 import org.apache.syncope.core.persistence.api.entity.auth.AuthModuleItem;
 import org.apache.syncope.core.persistence.api.entity.auth.AuthProfile;
+import org.apache.syncope.core.persistence.api.entity.auth.OIDCJWKS;
 import org.apache.syncope.core.persistence.api.entity.auth.OIDCRP;
 import org.apache.syncope.core.persistence.api.entity.auth.SAML2IdPMetadata;
 import org.apache.syncope.core.persistence.api.entity.auth.SAML2SP;
@@ -114,6 +115,7 @@ import org.apache.syncope.core.persistence.jpa.entity.anyobject.JPAAPlainAttrVal
 import org.apache.syncope.core.persistence.jpa.entity.anyobject.JPAARelationship;
 import org.apache.syncope.core.persistence.jpa.entity.anyobject.JPAAnyObject;
 import org.apache.syncope.core.persistence.jpa.entity.auth.JPAAuthProfile;
+import org.apache.syncope.core.persistence.jpa.entity.auth.JPAOIDCJWKS;
 import org.apache.syncope.core.persistence.jpa.entity.auth.JPAOIDCRP;
 import org.apache.syncope.core.persistence.jpa.entity.auth.JPASAML2SP;
 import org.apache.syncope.core.persistence.jpa.entity.auth.JPASAML2SPKeystore;
@@ -337,6 +339,8 @@ public class JPAEntityFactory implements EntityFactory {
             result = (E) new JPASAML2SPKeystore();
         } else if (reference.equals(AuthProfile.class)) {
             result = (E) new JPAAuthProfile();
+        } else if (reference.equals(OIDCJWKS.class)) {
+            result = (E) new JPAOIDCJWKS();
         } else {
             throw new IllegalArgumentException("Could not find a JPA implementation of " + reference.getName());
         }

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/entity/auth/JPAOIDCJWKS.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/entity/auth/JPAOIDCJWKS.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.syncope.core.persistence.jpa.entity.auth;
+
+import org.apache.syncope.core.persistence.api.entity.auth.OIDCJWKS;
+import org.apache.syncope.core.persistence.jpa.entity.AbstractGeneratedKeyEntity;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Lob;
+import javax.persistence.Table;
+
+@Entity
+@Table(name = JPAOIDCJWKS.TABLE)
+public class JPAOIDCJWKS extends AbstractGeneratedKeyEntity implements OIDCJWKS {
+
+    public static final String TABLE = "OIDCJWKS";
+
+    private static final long serialVersionUID = 47352617217394093L;
+
+    @Column
+    @Lob
+    private String json;
+
+    @Override
+    public String getJson() {
+        return this.json;
+    }
+
+    @Override
+    public void setJson(final String json) {
+        this.json = json;
+    }
+}

--- a/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/OIDCJWKSTest.java
+++ b/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/OIDCJWKSTest.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.syncope.core.persistence.jpa.inner;
+
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import org.apache.syncope.core.persistence.api.dao.auth.OIDCJWKSDAO;
+import org.apache.syncope.core.persistence.api.entity.auth.OIDCJWKS;
+import org.apache.syncope.core.persistence.jpa.AbstractTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Transactional("Master")
+public class OIDCJWKSTest extends AbstractTest {
+
+    @Autowired
+    private OIDCJWKSDAO jwksDAO;
+
+    @Test
+    public void save() throws Exception {
+        OIDCJWKS jwks = entityFactory.newEntity(OIDCJWKS.class);
+
+        RSAKey jwk = new RSAKeyGenerator(2048)
+            .keyUse(KeyUse.SIGNATURE)
+            .keyID(UUID.randomUUID().toString())
+            .generate();
+
+        String json = new JWKSet(jwk).toString();
+        jwks.setJson(json);
+        jwks = jwksDAO.save(jwks);
+        assertNotNull(jwks);
+        assertNotNull(jwks.getKey());
+
+    }
+}

--- a/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/data/OIDCJWKSDataBinder.java
+++ b/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/data/OIDCJWKSDataBinder.java
@@ -18,15 +18,14 @@
  */
 package org.apache.syncope.core.provisioning.api.data;
 
-import org.apache.syncope.common.lib.to.SAML2IdPMetadataTO;
-import org.apache.syncope.core.persistence.api.entity.auth.SAML2IdPMetadata;
+import org.apache.syncope.common.lib.to.OIDCJWKSTO;
+import org.apache.syncope.core.persistence.api.entity.auth.OIDCJWKS;
 
-public interface SAML2IdPMetadataBinder {
+public interface OIDCJWKSDataBinder {
+    
+    OIDCJWKSTO get(OIDCJWKS jwks);
 
-    SAML2IdPMetadata create(SAML2IdPMetadataTO saml2IdPMetadataTO);
+    OIDCJWKS create();
 
-    SAML2IdPMetadata update(SAML2IdPMetadata saml2IdPMetadata, SAML2IdPMetadataTO saml2IdPMetadataTO);
-
-    SAML2IdPMetadataTO getSAML2IdPMetadataTO(SAML2IdPMetadata saml2IdPMetadata);
-
+    OIDCJWKS update(OIDCJWKS oidcjwks, OIDCJWKSTO jwksTO);
 }

--- a/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/data/SAML2IdPMetadataDataBinder.java
+++ b/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/data/SAML2IdPMetadataDataBinder.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.syncope.core.provisioning.api.data;
+
+import org.apache.syncope.common.lib.to.SAML2IdPMetadataTO;
+import org.apache.syncope.core.persistence.api.entity.auth.SAML2IdPMetadata;
+
+public interface SAML2IdPMetadataDataBinder {
+
+    SAML2IdPMetadata create(SAML2IdPMetadataTO saml2IdPMetadataTO);
+
+    SAML2IdPMetadata update(SAML2IdPMetadata saml2IdPMetadata, SAML2IdPMetadataTO saml2IdPMetadataTO);
+
+    SAML2IdPMetadataTO getSAML2IdPMetadataTO(SAML2IdPMetadata saml2IdPMetadata);
+
+}

--- a/core/provisioning-java/pom.xml
+++ b/core/provisioning-java/pom.xml
@@ -97,6 +97,11 @@ under the License.
     </dependency>
 
     <dependency>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.syncope.core</groupId>
       <artifactId>syncope-core-workflow-api</artifactId>
       <version>${project.version}</version>

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/OIDCJWKSDataBinderImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/OIDCJWKSDataBinderImpl.java
@@ -31,8 +31,6 @@ import org.apache.syncope.core.spring.security.SecureRandomUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.UUID;
-
 @Component
 public class OIDCJWKSDataBinderImpl implements OIDCJWKSDataBinder {
     @Autowired

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/OIDCJWKSDataBinderImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/OIDCJWKSDataBinderImpl.java
@@ -53,8 +53,7 @@ public class OIDCJWKSDataBinderImpl implements OIDCJWKSDataBinder {
                 .keyUse(KeyUse.SIGNATURE)
                 .keyID(UUID.randomUUID().toString())
                 .generate();
-            String json = JWKSet.parse(jwk.toJSONString()).toString();
-            jwks.setJson(json);
+            jwks.setJson(new JWKSet(jwk).toString());
             return jwks;
         } catch (final Exception e) {
             throw new RuntimeException("Unable to create OIDC JWKS", e);

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/OIDCJWKSDataBinderImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/OIDCJWKSDataBinderImpl.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.syncope.core.provisioning.java.data;
+
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import org.apache.syncope.common.lib.to.OIDCJWKSTO;
+import org.apache.syncope.core.persistence.api.entity.EntityFactory;
+import org.apache.syncope.core.persistence.api.entity.auth.OIDCJWKS;
+import org.apache.syncope.core.provisioning.api.data.OIDCJWKSDataBinder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.UUID;
+
+@Component
+public class OIDCJWKSDataBinderImpl implements OIDCJWKSDataBinder {
+    @Autowired
+    private EntityFactory entityFactory;
+
+    @Override
+    public OIDCJWKSTO get(final OIDCJWKS jwks) {
+        return new OIDCJWKSTO.Builder().
+            json(jwks.getJson()).
+            key(jwks.getKey()).
+            build();
+    }
+
+    @Override
+    public OIDCJWKS create() {
+        try {
+            OIDCJWKS jwks = entityFactory.newEntity(OIDCJWKS.class);
+            RSAKey jwk = new RSAKeyGenerator(2048)
+                .keyUse(KeyUse.SIGNATURE)
+                .keyID(UUID.randomUUID().toString())
+                .generate();
+            String json = JWKSet.parse(jwk.toJSONString()).toString();
+            jwks.setJson(json);
+            return jwks;
+        } catch (final Exception e) {
+            throw new RuntimeException("Unable to create OIDC JWKS", e);
+        }
+    }
+
+    @Override
+    public OIDCJWKS update(final OIDCJWKS oidcjwks, final OIDCJWKSTO jwksTO) {
+        oidcjwks.setJson(jwksTO.getJson());
+        return oidcjwks;
+    }
+}

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/OIDCJWKSDataBinderImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/OIDCJWKSDataBinderImpl.java
@@ -27,6 +27,7 @@ import org.apache.syncope.common.lib.to.OIDCJWKSTO;
 import org.apache.syncope.core.persistence.api.entity.EntityFactory;
 import org.apache.syncope.core.persistence.api.entity.auth.OIDCJWKS;
 import org.apache.syncope.core.provisioning.api.data.OIDCJWKSDataBinder;
+import org.apache.syncope.core.spring.security.SecureRandomUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -51,7 +52,7 @@ public class OIDCJWKSDataBinderImpl implements OIDCJWKSDataBinder {
             OIDCJWKS jwks = entityFactory.newEntity(OIDCJWKS.class);
             RSAKey jwk = new RSAKeyGenerator(2048)
                 .keyUse(KeyUse.SIGNATURE)
-                .keyID(UUID.randomUUID().toString())
+                .keyID(SecureRandomUtils.generateRandomUUID().toString())
                 .generate();
             jwks.setJson(new JWKSet(jwk).toString());
             return jwks;

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/SAML2IdPMetadataDataBinderImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/SAML2IdPMetadataDataBinderImpl.java
@@ -23,10 +23,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.apache.syncope.common.lib.to.SAML2IdPMetadataTO;
 import org.apache.syncope.core.persistence.api.entity.auth.SAML2IdPMetadata;
-import org.apache.syncope.core.provisioning.api.data.SAML2IdPMetadataBinder;
+import org.apache.syncope.core.provisioning.api.data.SAML2IdPMetadataDataBinder;
 
 @Component
-public class SAML2IdPMetadataBinderImpl implements SAML2IdPMetadataBinder {
+public class SAML2IdPMetadataDataBinderImpl implements SAML2IdPMetadataDataBinder {
 
     @Autowired
     private EntityFactory entityFactory;

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/AbstractITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/AbstractITCase.java
@@ -113,6 +113,7 @@ import org.apache.syncope.common.rest.api.service.ConnectorService;
 import org.apache.syncope.common.rest.api.service.DynRealmService;
 import org.apache.syncope.common.rest.api.service.LoggerService;
 import org.apache.syncope.common.rest.api.service.NotificationService;
+import org.apache.syncope.common.rest.api.service.OIDCJWKSConfService;
 import org.apache.syncope.common.rest.api.service.SAML2SPKeystoreConfService;
 import org.apache.syncope.common.rest.api.service.wa.GoogleMfaAuthAccountService;
 import org.apache.syncope.common.rest.api.service.wa.GoogleMfaAuthTokenService;
@@ -346,6 +347,8 @@ public abstract class AbstractITCase {
 
     protected static OIDCJWKSService oidcJwksService;
 
+    protected static OIDCJWKSConfService oidcJwksConfService;
+
     @BeforeAll
     public static void securitySetup() {
         try (InputStream propStream = Encryptor.class.getResourceAsStream("/security.properties")) {
@@ -427,6 +430,7 @@ public abstract class AbstractITCase {
         googleMfaAuthAccountService = adminClient.getService(GoogleMfaAuthAccountService.class);
         authProfileService = adminClient.getService(AuthProfileService.class);
         oidcJwksService = adminClient.getService(OIDCJWKSService.class);
+        oidcJwksConfService = adminClient.getService(OIDCJWKSConfService.class);
     }
 
     @Autowired

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/AbstractITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/AbstractITCase.java
@@ -116,6 +116,7 @@ import org.apache.syncope.common.rest.api.service.NotificationService;
 import org.apache.syncope.common.rest.api.service.SAML2SPKeystoreConfService;
 import org.apache.syncope.common.rest.api.service.wa.GoogleMfaAuthAccountService;
 import org.apache.syncope.common.rest.api.service.wa.GoogleMfaAuthTokenService;
+import org.apache.syncope.common.rest.api.service.wa.OIDCJWKSService;
 import org.apache.syncope.common.rest.api.service.wa.SAML2SPKeystoreService;
 import org.apache.syncope.common.rest.api.service.SAML2SPMetadataConfService;
 import org.apache.syncope.common.rest.api.service.wa.SAML2SPMetadataService;
@@ -343,6 +344,8 @@ public abstract class AbstractITCase {
 
     protected static AuthProfileService authProfileService;
 
+    protected static OIDCJWKSService oidcJwksService;
+
     @BeforeAll
     public static void securitySetup() {
         try (InputStream propStream = Encryptor.class.getResourceAsStream("/security.properties")) {
@@ -423,6 +426,7 @@ public abstract class AbstractITCase {
         googleMfaAuthTokenService = adminClient.getService(GoogleMfaAuthTokenService.class);
         googleMfaAuthAccountService = adminClient.getService(GoogleMfaAuthAccountService.class);
         authProfileService = adminClient.getService(AuthProfileService.class);
+        oidcJwksService = adminClient.getService(OIDCJWKSService.class);
     }
 
     @Autowired

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/OIDCJWKSConfITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/OIDCJWKSConfITCase.java
@@ -57,6 +57,8 @@ public class OIDCJWKSConfITCase extends AbstractITCase {
 
     @Test
     public void verifyJwks() throws Exception {
+        oidcJwksConfService.delete();
+
         RSAKey jwk = new RSAKeyGenerator(2048)
             .keyUse(KeyUse.SIGNATURE)
             .keyID(UUID.randomUUID().toString())

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/OIDCJWKSConfITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/OIDCJWKSConfITCase.java
@@ -37,7 +37,6 @@ import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 public class OIDCJWKSConfITCase extends AbstractITCase {
 

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/OIDCJWKSConfITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/OIDCJWKSConfITCase.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.syncope.fit.core;
+
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import org.apache.syncope.common.lib.SyncopeClientException;
+import org.apache.syncope.common.lib.to.OIDCJWKSTO;
+import org.apache.syncope.common.lib.types.ClientExceptionType;
+import org.apache.syncope.fit.AbstractITCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.springframework.http.HttpStatus;
+
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
+
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class OIDCJWKSConfITCase extends AbstractITCase {
+
+    private static OIDCJWKSTO getCurrentJwksTO() {
+        try {
+            return oidcJwksService.get();
+        } catch (final SyncopeClientException e) {
+            if (e.getType() == ClientExceptionType.NotFound) {
+                Response response = oidcJwksService.set();
+                assertEquals(HttpStatus.CREATED.value(), response.getStatus());
+                return response.readEntity(new GenericType<OIDCJWKSTO>() {
+                });
+            }
+        }
+        throw new RuntimeException("Unable to locate current OIDC JWKS");
+    }
+
+    @Test
+    public void verifyJwks() throws Exception {
+        RSAKey jwk = new RSAKeyGenerator(2048)
+            .keyUse(KeyUse.SIGNATURE)
+            .keyID(UUID.randomUUID().toString())
+            .generate();
+        String json = new JWKSet(jwk).toString();
+
+        assertDoesNotThrow(new Executable() {
+            @Override
+            public void execute() {
+                OIDCJWKSTO currentTO = getCurrentJwksTO();
+                currentTO.setJson(json);
+                oidcJwksConfService.update(currentTO);
+            }
+        });
+        OIDCJWKSTO currentTO = getCurrentJwksTO();
+        assertEquals(json, currentTO.getJson());
+    }
+
+}

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/OIDCJWKSITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/OIDCJWKSITCase.java
@@ -34,6 +34,8 @@ public class OIDCJWKSITCase extends AbstractITCase {
     @Test
     public void verifyJwks() {
         try {
+            oidcJwksConfService.delete();
+
             oidcJwksService.get();
             fail("Should not locate an OIDC JWKS");
         } catch (final SyncopeClientException e) {

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/OIDCJWKSITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/OIDCJWKSITCase.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.syncope.fit.core;
+
+import org.apache.syncope.common.lib.SyncopeClientException;
+import org.apache.syncope.common.lib.types.ClientExceptionType;
+import org.apache.syncope.fit.AbstractITCase;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import javax.ws.rs.core.Response;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class OIDCJWKSITCase extends AbstractITCase {
+
+    @Test
+    public void verifyJwks() {
+        try {
+            oidcJwksService.get();
+            fail("Should not locate an OIDC JWKS");
+        } catch (final SyncopeClientException e) {
+            assertEquals(ClientExceptionType.NotFound, e.getType());
+        }
+        Response response = oidcJwksService.set();
+        assertEquals(HttpStatus.CREATED.value(), response.getStatus());
+        try {
+            oidcJwksService.set();
+            fail("Should not recreate an OIDC JWKS");
+        } catch (final SyncopeClientException e) {
+            assertEquals(ClientExceptionType.EntityExists, e.getType());
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -452,6 +452,8 @@ under the License.
 
     <h2.version>1.4.200</h2.version>
 
+    <nimbus.jose.version>8.19</nimbus.jose.version>
+
     <junit.version>5.6.2</junit.version>
     <mockito.version>3.3.0</mockito.version>
 
@@ -1607,6 +1609,16 @@ under the License.
       </dependency>
       <dependency>
         <groupId>org.apereo.cas</groupId>
+        <artifactId>cas-server-support-oidc-core-api</artifactId>
+        <version>${cas.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apereo.cas</groupId>
+        <artifactId>cas-server-support-oidc-core</artifactId>
+        <version>${cas.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apereo.cas</groupId>
         <artifactId>cas-server-support-oauth-services</artifactId>
         <version>${cas.version}</version>
       </dependency>
@@ -1992,6 +2004,11 @@ under the License.
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk15on</artifactId>
         <version>${bouncycastle.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.nimbusds</groupId>
+        <artifactId>nimbus-jose-jwt</artifactId>
+        <version>${nimbus.jose.version}</version>
       </dependency>
 
       <!-- TEST -->

--- a/wa/starter/pom.xml
+++ b/wa/starter/pom.xml
@@ -180,6 +180,14 @@ under the License.
     </dependency>
     <dependency>
       <groupId>org.apereo.cas</groupId>
+      <artifactId>cas-server-support-oidc-core-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apereo.cas</groupId>
+      <artifactId>cas-server-support-oidc-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apereo.cas</groupId>
       <artifactId>cas-server-support-oauth-services</artifactId>
     </dependency>
     <dependency>

--- a/wa/starter/src/main/java/org/apache/syncope/wa/starter/config/SyncopeWAConfiguration.java
+++ b/wa/starter/src/main/java/org/apache/syncope/wa/starter/config/SyncopeWAConfiguration.java
@@ -190,7 +190,7 @@ public class SyncopeWAConfiguration {
         return new SyncopeWAGoogleMfaAuthCredentialRepository(restClient, googleAuthenticatorInstance);
     }
 
-    @Bean(initMethod = "generate")
+    @Bean
     @Autowired
     public OidcJsonWebKeystoreGeneratorService oidcJsonWebKeystoreGeneratorService(final WARestClient restClient) {
         return new SyncopeWAOIDCJWKSGeneratorService(restClient);

--- a/wa/starter/src/main/java/org/apache/syncope/wa/starter/config/SyncopeWAConfiguration.java
+++ b/wa/starter/src/main/java/org/apache/syncope/wa/starter/config/SyncopeWAConfiguration.java
@@ -20,6 +20,7 @@ package org.apache.syncope.wa.starter.config;
 
 import org.apereo.cas.audit.AuditTrailExecutionPlanConfigurer;
 import org.apereo.cas.configuration.CasConfigurationProperties;
+import org.apereo.cas.oidc.jwks.OidcJsonWebKeystoreGeneratorService;
 import org.apereo.cas.otp.repository.credentials.OneTimeTokenCredentialRepository;
 import org.apereo.cas.otp.repository.token.OneTimeTokenRepository;
 import org.apereo.cas.services.ServiceRegistryExecutionPlanConfigurer;
@@ -48,6 +49,7 @@ import org.apache.syncope.wa.starter.mapping.AuthMapper;
 import org.apache.syncope.wa.starter.mapping.ClientAppMapFor;
 import org.apache.syncope.wa.starter.mapping.ClientAppMapper;
 import org.apache.syncope.wa.starter.mapping.RegisteredServiceMapper;
+import org.apache.syncope.wa.starter.oidc.SyncopeWAOIDCJWKSGeneratorService;
 import org.apache.syncope.wa.starter.pac4j.saml.SyncopeWASAML2ClientCustomizer;
 import org.apache.syncope.wa.starter.saml.idp.metadata.RestfulSamlIdPMetadataGenerator;
 import org.apache.syncope.wa.starter.saml.idp.metadata.RestfulSamlIdPMetadataLocator;
@@ -186,6 +188,12 @@ public class SyncopeWAConfiguration {
     public OneTimeTokenCredentialRepository googleAuthenticatorAccountRegistry(
         final IGoogleAuthenticator googleAuthenticatorInstance, final WARestClient restClient) {
         return new SyncopeWAGoogleMfaAuthCredentialRepository(restClient, googleAuthenticatorInstance);
+    }
+
+    @Bean(initMethod = "generate")
+    @Autowired
+    public OidcJsonWebKeystoreGeneratorService oidcJsonWebKeystoreGeneratorService(final WARestClient restClient) {
+        return new SyncopeWAOIDCJWKSGeneratorService(restClient);
     }
 
     @Bean

--- a/wa/starter/src/main/java/org/apache/syncope/wa/starter/oidc/SyncopeWAOIDCJWKSGeneratorService.java
+++ b/wa/starter/src/main/java/org/apache/syncope/wa/starter/oidc/SyncopeWAOIDCJWKSGeneratorService.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.syncope.wa.starter.oidc;
+
+import org.apereo.cas.oidc.jwks.OidcJsonWebKeystoreGeneratorService;
+
+import org.apache.syncope.common.lib.SyncopeClientException;
+import org.apache.syncope.common.lib.to.OIDCJWKSTO;
+import org.apache.syncope.common.lib.types.ClientExceptionType;
+import org.apache.syncope.common.rest.api.service.wa.OIDCJWKSService;
+import org.apache.syncope.wa.bootstrap.WARestClient;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+
+import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.Response;
+
+import java.nio.charset.StandardCharsets;
+
+public class SyncopeWAOIDCJWKSGeneratorService implements OidcJsonWebKeystoreGeneratorService {
+    private final WARestClient waRestClient;
+
+    public SyncopeWAOIDCJWKSGeneratorService(final WARestClient restClient) {
+        this.waRestClient = restClient;
+    }
+
+    @Override
+    public Resource generate() {
+        OIDCJWKSService service = waRestClient.getSyncopeClient().
+            getService(OIDCJWKSService.class);
+        try {
+            Response response = service.set();
+            OIDCJWKSTO jwksTO = response.readEntity(new GenericType<OIDCJWKSTO>() {
+            });
+            return new ByteArrayResource(jwksTO.getJson().getBytes(StandardCharsets.UTF_8), "OIDC JWKS");
+        } catch (final SyncopeClientException e) {
+            if (e.getType() == ClientExceptionType.EntityExists) {
+                OIDCJWKSTO jwksTO = service.get();
+                return new ByteArrayResource(jwksTO.getJson().getBytes(StandardCharsets.UTF_8), "OIDC JWKS");
+            }
+        }
+        throw new RuntimeException("Unable to determine OIDC JWKS resource");
+    }
+}

--- a/wa/starter/src/main/java/org/apache/syncope/wa/starter/oidc/SyncopeWAOIDCJWKSGeneratorService.java
+++ b/wa/starter/src/main/java/org/apache/syncope/wa/starter/oidc/SyncopeWAOIDCJWKSGeneratorService.java
@@ -43,6 +43,10 @@ public class SyncopeWAOIDCJWKSGeneratorService implements OidcJsonWebKeystoreGen
 
     @Override
     public Resource generate() {
+        if (!WARestClient.isReady()) {
+            throw new RuntimeException("Syncope core is not yet ready");
+        }
+
         OIDCJWKSService service = waRestClient.getSyncopeClient().
             getService(OIDCJWKSService.class);
         try {


### PR DESCRIPTION
- Allows Syncope to manage the JWKS store via REST endpoints
- Uses the `nimbus-jose-jwt` library to generate keys with algorithm RSA and length 2048
- Provides two sets of APIs; one to be invoked by the admin console for delete/update tasks and the other may be used by WA. (Permissions are kept separate)
- Adds tests and integration tests.