### PR TITLE
NOJIRA: Fix OIDC JWKS generation and properties

### DIFF
--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/OIDCJWKSDataBinderImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/OIDCJWKSDataBinderImpl.java
@@ -19,6 +19,7 @@
 
 package org.apache.syncope.core.provisioning.java.data;
 
+import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
@@ -51,8 +52,9 @@ public class OIDCJWKSDataBinderImpl implements OIDCJWKSDataBinder {
             RSAKey jwk = new RSAKeyGenerator(2048)
                 .keyUse(KeyUse.SIGNATURE)
                 .keyID(SecureRandomUtils.generateRandomUUID().toString())
+                .algorithm(JWSAlgorithm.RS256)
                 .generate();
-            jwks.setJson(new JWKSet(jwk).toString());
+            jwks.setJson(new JWKSet(jwk).toJSONObject(false).toString());
             return jwks;
         } catch (final Exception e) {
             throw new RuntimeException("Unable to create OIDC JWKS", e);

--- a/fit/wa-reference/src/main/resources/wa.properties
+++ b/fit/wa-reference/src/main/resources/wa.properties
@@ -24,11 +24,16 @@ conf.directory=${conf.directory}
 cas.standalone.configurationDirectory=${conf.directory}
 cas.authn.oidc.jwks.jwks-file=file:${conf.directory}/oidc.keystore
 
-cas.server.name=http://localhost:8080
+cas.server.name=http://localhost:9080
 cas.server.prefix=${cas.server.name}/syncope-wa
 cas.server.scope=syncope.org
 
 cas.authn.saml-idp.entity-id=https://syncope.apache.org/saml
+
+cas.authn.oidc.issuer=http://localhost:9080/syncope-wa/oidc/
+
+cas.authn.syncope.url=http://localhost:9080/syncope
+cas.tgc.secure=false
 
 # Disable access to the login endpoint
 # if no target application is specified.


### PR DESCRIPTION
1. Fixes issues with OIDC JWKS generation, set to include private key and algorithm
2. Updates `wa.properties` for `wa-reference`  module to better match the given WA setup.

With these changes, and most recent CAS snapshot (WIP), OIDC functionality is restored back to normal.