### PR TITLE
SYNCOPE-1545: Enable Swagger support for WA

### DIFF
--- a/docker/wa/src/main/resources/wa.properties
+++ b/docker/wa/src/main/resources/wa.properties
@@ -49,3 +49,8 @@ cas.monitor.endpoints.endpoint.defaults.access=AUTHENTICATED
 
 spring.security.user.name=${anonymousUser}
 spring.security.user.password=${anonymousKey}
+
+springdoc.show-actuator=true
+springdoc.model-and-view-allowed=true
+springdoc.writer-with-default-pretty-printer=true
+springdoc.swagger-ui.displayRequestDuration=true

--- a/fit/wa-reference/src/main/resources/wa.properties
+++ b/fit/wa-reference/src/main/resources/wa.properties
@@ -54,3 +54,8 @@ cas.monitor.endpoints.endpoint.defaults.access=AUTHENTICATED
 
 spring.security.user.name=${anonymousUser}
 spring.security.user.password=${anonymousKey}
+
+springdoc.show-actuator=true
+springdoc.model-and-view-allowed=true
+springdoc.writer-with-default-pretty-printer=true
+springdoc.swagger-ui.displayRequestDuration=true

--- a/pom.xml
+++ b/pom.xml
@@ -1664,6 +1664,11 @@ under the License.
       </dependency>
       <dependency>
         <groupId>org.apereo.cas</groupId>
+        <artifactId>cas-server-support-swagger</artifactId>
+        <version>${cas.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apereo.cas</groupId>
         <artifactId>cas-server-core-authentication-attributes</artifactId>
         <version>${cas.version}</version>
       </dependency>

--- a/wa/starter/pom.xml
+++ b/wa/starter/pom.xml
@@ -250,7 +250,11 @@ under the License.
       <groupId>org.apereo.cas</groupId>
       <artifactId>cas-server-core-services-authentication</artifactId>
     </dependency>
-
+    <dependency>
+      <groupId>org.apereo.cas</groupId>
+      <artifactId>cas-server-support-swagger</artifactId>
+    </dependency>
+    
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>

--- a/wa/starter/src/main/java/org/apache/syncope/wa/starter/config/SyncopeWAConfiguration.java
+++ b/wa/starter/src/main/java/org/apache/syncope/wa/starter/config/SyncopeWAConfiguration.java
@@ -74,8 +74,6 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import javax.annotation.Resource;
-
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.Collection;

--- a/wa/starter/src/main/java/org/apache/syncope/wa/starter/config/SyncopeWAConfiguration.java
+++ b/wa/starter/src/main/java/org/apache/syncope/wa/starter/config/SyncopeWAConfiguration.java
@@ -38,6 +38,9 @@ import org.apereo.cas.util.crypto.CipherExecutor;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import com.warrenstrange.googleauth.IGoogleAuthenticator;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.syncope.common.keymaster.client.api.model.NetworkService;
 import org.apache.syncope.common.keymaster.client.api.startstop.KeymasterStart;
@@ -70,6 +73,8 @@ import org.springframework.cloud.context.config.annotation.RefreshScope;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.Resource;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -200,6 +205,19 @@ public class SyncopeWAConfiguration {
     }
 
     @Bean
+    public OpenAPI casSwaggerOpenApi() {
+        return new OpenAPI()
+            .info(new Info()
+                .title("Apache Syncope")
+                .description("Apache Syncope " + version())
+                .contact(new Contact()
+                    .name("The Apache Syncope community")
+                    .email("dev@syncope.apache.org")
+                    .url("http://syncope.apache.org"))
+                .version(version()));
+    }
+
+    @Bean
     @Autowired
     @RefreshScope
     public U2FDeviceRepository u2fDeviceRepository(final WARestClient restClient) {
@@ -220,5 +238,15 @@ public class SyncopeWAConfiguration {
     @Bean
     public KeymasterStop keymasterStop() {
         return new KeymasterStop(NetworkService.Type.WA);
+    }
+
+    @Bean
+    public String version() {
+        return applicationContext.getEnvironment().getProperty("version");
+    }
+
+    @Bean
+    public String buildNumber() {
+        return applicationContext.getEnvironment().getProperty("buildNumber");
     }
 }

--- a/wa/starter/src/main/java/org/apache/syncope/wa/starter/config/SyncopeWAConfiguration.java
+++ b/wa/starter/src/main/java/org/apache/syncope/wa/starter/config/SyncopeWAConfiguration.java
@@ -242,9 +242,4 @@ public class SyncopeWAConfiguration {
     public String version() {
         return applicationContext.getEnvironment().getProperty("version");
     }
-
-    @Bean
-    public String buildNumber() {
-        return applicationContext.getEnvironment().getProperty("buildNumber");
-    }
 }

--- a/wa/starter/src/main/resources/application.properties
+++ b/wa/starter/src/main/resources/application.properties
@@ -45,3 +45,6 @@ spring.main.allow-bean-definition-overriding=true
 spring.main.lazy-initialization=false
 
 service.discovery.address=http://localhost:8080/syncope-wa/
+
+version=${syncope.version}
+buildNumber=${buildNumber}

--- a/wa/starter/src/main/resources/application.properties
+++ b/wa/starter/src/main/resources/application.properties
@@ -47,4 +47,3 @@ spring.main.lazy-initialization=false
 service.discovery.address=http://localhost:8080/syncope-wa/
 
 version=${syncope.version}
-buildNumber=${buildNumber}

--- a/wa/starter/src/test/resources/dev/wa.properties
+++ b/wa/starter/src/test/resources/dev/wa.properties
@@ -54,3 +54,8 @@ cas.monitor.endpoints.endpoint.defaults.access=AUTHENTICATED
 
 spring.security.user.name=${anonymousUser}
 spring.security.user.password=${anonymousKey}
+
+springdoc.show-actuator=true
+springdoc.model-and-view-allowed=true
+springdoc.writer-with-default-pretty-printer=true
+springdoc.swagger-ui.displayRequestDuration=true


### PR DESCRIPTION
This pull request adjusts WA to turn on Swagger support via the `cas-server-support-swagger` dependency. In doing so,

1. The [CAS module is upgraded](https://apereo.github.io/cas/development/integration/Swagger-Integration.html) to base its swagger support on top of Swagger v2.1.x
2. The WA configuration does a simple bean override to present Syncope information to the Docklet, such as version, title, etc.
3. Default configuration is adjusted to consider actuators, controllers etc as part of Swagger UI.

![image](https://user-images.githubusercontent.com/1205228/87526392-02aa3e80-c6a0-11ea-979a-47f71b4b73c7.png)
