### PR TITLE
NOJIRA: upgrade WA to build against 6.3 RC4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -449,8 +449,8 @@ under the License.
 
     <pac4j.version>4.1.0</pac4j.version>
 
-    <cas.version>6.3.0-SNAPSHOT</cas.version>
-    <cas-client.version>3.6.1</cas-client.version>
+    <cas.version>6.3.0-RC4</cas.version>
+    <cas-client.version>3.6.2</cas-client.version>
 
     <h2.version>1.4.200</h2.version>
 


### PR DESCRIPTION
This should be followed up with RC5 in late Nov with the final 6.3 GA release by late Dec, if not earlier.