### PR TITLE
Upgrading CAS to 6.4.0-SNAPSHOT

### DIFF
--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/UserDirectoryPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/UserDirectoryPanel.java
@@ -81,7 +81,7 @@ public class UserDirectoryPanel extends AnyDirectoryPanel<UserTO, UserRestClient
                 modal.show(false);
             }
         });
-            }
+    }
 
     @Override
     protected String paginatorRowsKey() {
@@ -225,7 +225,7 @@ public class UserDirectoryPanel extends AnyDirectoryPanel<UserTO, UserRestClient
             SyncopeWebApplication.get().getAnyDirectoryPanelAdditionalActionLinksProvider().get(
                     model,
                     realm,
-                            altDefaultModal,
+                    altDefaultModal,
                     getString("any.edit", new Model<>(new AnyWrapper<>(model.getObject()))),
                     this,
                     pageRef).forEach(panel::add);
@@ -257,10 +257,10 @@ public class UserDirectoryPanel extends AnyDirectoryPanel<UserTO, UserRestClient
                     target.add(utilityModal);
                 }
             }, ActionType.NOTIFICATION_TASKS, IdRepoEntitlement.TASK_LIST);
-                }
+        }
 
-            if (wizardInModal) {
-                panel.add(new ActionLink<UserTO>() {
+        if (wizardInModal) {
+            panel.add(new ActionLink<UserTO>() {
 
                 private static final long serialVersionUID = -1978723352517770644L;
 

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/OIDCJWKSDataBinderImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/OIDCJWKSDataBinderImpl.java
@@ -23,6 +23,7 @@ import com.nimbusds.jose.jwk.JWKSet;
 import com.nimbusds.jose.jwk.KeyUse;
 import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jose.util.JSONObjectUtils;
 import org.apache.syncope.common.lib.SyncopeClientException;
 import org.apache.syncope.common.lib.to.OIDCJWKSTO;
 import org.apache.syncope.common.lib.types.ClientExceptionType;
@@ -58,7 +59,7 @@ public class OIDCJWKSDataBinderImpl implements OIDCJWKSDataBinder {
                     keyID(SecureRandomUtils.generateRandomUUID().toString()).
                     algorithm(new com.nimbusds.jose.JWSAlgorithm(algorithm.name())).
                     generate();
-            jwks.setJson(new JWKSet(jwk).toJSONObject(false).toString());
+            jwks.setJson(JSONObjectUtils.toJSONString(new JWKSet(jwk).toJSONObject(false)));
             return jwks;
         } catch (JOSEException e) {
             LOG.error("Could not create OIDC JWKS", e);

--- a/docker/wa/src/main/resources/application.properties
+++ b/docker/wa/src/main/resources/application.properties
@@ -26,7 +26,7 @@ server.servlet.encoding.force=true
 
 server.servlet.contextPath=/syncope-wa
 
-spring.resources.static-locations=classpath:/thymeleaf/static,classpath:/static
+spring.web.resources.static-locations=classpath:/thymeleaf/static,classpath:/static
 
 management.endpoints.web.exposure.include=health,loggers,refresh,registeredServices
 management.endpoint.health.show-details=always

--- a/fit/build-tools/src/main/java/org/apache/directory/server/core/normalization/NormalizationInterceptor.java
+++ b/fit/build-tools/src/main/java/org/apache/directory/server/core/normalization/NormalizationInterceptor.java
@@ -532,6 +532,7 @@ public class NormalizationInterceptor extends BaseInterceptor
                 }
                 else if ( leafNode instanceof EqualityNode )
                 {
+                    @SuppressWarnings("unchecked")
                     Value value = ( ( EqualityNode<String> ) leafNode ).getValue();
 
                     if ( value.equals( SchemaConstants.TOP_OC ) )

--- a/fit/build-tools/src/main/java/org/apache/syncope/fit/buildtools/cxf/DateParamConverterProvider.java
+++ b/fit/build-tools/src/main/java/org/apache/syncope/fit/buildtools/cxf/DateParamConverterProvider.java
@@ -23,7 +23,7 @@ import java.lang.reflect.Type;
 import java.util.Date;
 import javax.ws.rs.ext.ParamConverter;
 import javax.ws.rs.ext.ParamConverterProvider;
-import org.springframework.util.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public class DateParamConverterProvider implements ParamConverterProvider {
 
@@ -31,7 +31,7 @@ public class DateParamConverterProvider implements ParamConverterProvider {
 
         @Override
         public Date fromString(final String value) {
-            if (StringUtils.isEmpty(value)) {
+            if (StringUtils.isBlank(value)) {
                 return null;
             }
             try {

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/UserSelfITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/UserSelfITCase.java
@@ -527,8 +527,7 @@ public class UserSelfITCase extends AbstractITCase {
         JdbcTemplate jdbcTemplate = new JdbcTemplate(testDataSource);
         Exception exception = null;
         try {
-            jdbcTemplate.queryForObject("SELECT id FROM test WHERE id=?",
-                    new String[] { userTO.getUsername() }, Integer.class);
+            jdbcTemplate.queryForObject("SELECT id FROM test WHERE id=?", Integer.class, userTO.getUsername());
         } catch (EmptyResultDataAccessException e) {
             exception = e;
         }
@@ -565,8 +564,7 @@ public class UserSelfITCase extends AbstractITCase {
 
         Exception exception = null;
         try {
-            jdbcTemplate.queryForObject("SELECT id FROM test WHERE id=?",
-                    new String[] { userTO.getUsername() }, Integer.class);
+            jdbcTemplate.queryForObject("SELECT id FROM test WHERE id=?", Integer.class, userTO.getUsername());
         } catch (EmptyResultDataAccessException e) {
             exception = e;
         }

--- a/fit/wa-reference/pom.xml
+++ b/fit/wa-reference/pom.xml
@@ -34,6 +34,8 @@ under the License.
   <packaging>war</packaging>
   
   <properties>
+    <nimbus-jose-jwt.version>8.20.1</nimbus-jose-jwt.version>
+
     <ianal.skip>true</ianal.skip>
 
     <rootpom.basedir>${basedir}/../..</rootpom.basedir>

--- a/pom.xml
+++ b/pom.xml
@@ -815,37 +815,24 @@ under the License.
         <version>${jackson.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.module</groupId>
+        <artifactId>jackson-module-jaxb-annotations</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-json-provider</artifactId>
         <version>${jackson.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-jaxb-annotations</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-xml-provider</artifactId>
         <version>${jackson.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-jaxb-annotations</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-yaml-provider</artifactId>
         <version>${jackson.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-jaxb-annotations</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
@@ -872,10 +859,6 @@ under the License.
         <artifactId>jackson-dataformat-xml</artifactId>
         <version>${jackson.version}</version>
         <exclusions>
-          <exclusion>
-            <groupId>com.fasterxml.jackson.module</groupId>
-            <artifactId>jackson-module-jaxb-annotations</artifactId>
-          </exclusion>
           <exclusion>
             <groupId>org.codehaus.woodstox</groupId>
             <artifactId>stax2-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -406,6 +406,7 @@ under the License.
 
     <cxf.version>3.4.2</cxf.version>
     <bouncycastle.version>1.68</bouncycastle.version>
+    <nimbus-jose-jwt.version>9.4</nimbus-jose-jwt.version>
 
     <jackson.version>2.12.1-SNAPSHOT</jackson.version>
 
@@ -810,18 +811,41 @@ under the License.
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
+        <artifactId>jackson-jaxrs-base</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-json-provider</artifactId>
         <version>${jackson.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-jaxb-annotations</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-xml-provider</artifactId>
         <version>${jackson.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-jaxb-annotations</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.jaxrs</groupId>
         <artifactId>jackson-jaxrs-yaml-provider</artifactId>
         <version>${jackson.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-jaxb-annotations</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.module</groupId>
@@ -849,6 +873,10 @@ under the License.
         <version>${jackson.version}</version>
         <exclusions>
           <exclusion>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-jaxb-annotations</artifactId>
+          </exclusion>
+          <exclusion>
             <groupId>org.codehaus.woodstox</groupId>
             <artifactId>stax2-api</artifactId>
           </exclusion>
@@ -864,10 +892,25 @@ under the License.
         <version>${jackson.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.fasterxml.jackson.dataformat</groupId>
+        <artifactId>jackson-dataformat-properties</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
         <groupId>com.fasterxml.jackson.datatype</groupId>
         <artifactId>jackson-datatype-jsr310</artifactId>
         <version>${jackson.version}</version>
-      </dependency>  
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-jdk8</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.datatype</groupId>
+        <artifactId>jackson-datatype-guava</artifactId>
+        <version>${jackson.version}</version>
+      </dependency>
 
       <dependency>
         <groupId>org.springframework.boot</groupId>
@@ -903,6 +946,21 @@ under the License.
           <exclusion>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-parameter-names</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-webflux</artifactId>
+        <version>${spring-boot.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-parameter-names</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -1994,7 +2052,7 @@ under the License.
       <dependency>
         <groupId>com.nimbusds</groupId>
         <artifactId>nimbus-jose-jwt</artifactId>
-        <version>8.20.1</version>
+        <version>${nimbus-jose-jwt.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -409,10 +409,10 @@ under the License.
 
     <jackson.version>2.12.1-SNAPSHOT</jackson.version>
 
-    <spring.version>5.2.12.RELEASE</spring.version>
+    <spring.version>5.3.2</spring.version>
     <spring-security.version>5.4.2</spring-security.version>
-    <spring-boot.version>2.3.7.RELEASE</spring-boot.version>
-    <spring-cloud-gateway.version>2.2.6.RELEASE</spring-cloud-gateway.version>
+    <spring-boot.version>2.4.1</spring-boot.version>
+    <spring-cloud-gateway.version>3.0.0</spring-cloud-gateway.version>
 
     <openjpa.version>3.1.3-SNAPSHOT</openjpa.version>
     <hikaricp.version>3.4.5</hikaricp.version>
@@ -450,7 +450,7 @@ under the License.
 
     <pac4j.version>4.3.0</pac4j.version>
 
-    <cas.version>6.3.0</cas.version>
+    <cas.version>6.4.0-SNAPSHOT</cas.version>
     <cas-client.version>3.6.2</cas-client.version>
 
     <h2.version>1.4.200</h2.version>
@@ -1286,6 +1286,7 @@ under the License.
           </exclusion>
         </exclusions>
       </dependency>
+
       <!-- Flowable -->
       <dependency>
         <groupId>org.flowable</groupId>
@@ -2018,8 +2019,7 @@ under the License.
       <dependency>
         <groupId>org.springframework.cloud</groupId>
         <artifactId>spring-cloud-contract-wiremock</artifactId>
-        <!-- TMP: revert to ${spring-cloud-gateway.version} as soon as available -->
-        <version>2.2.5.RELEASE</version>
+        <version>${spring-cloud-gateway.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -2981,10 +2981,6 @@ under the License.
       </activation>
 
       <properties>
-        <spring.version>5.3.2</spring.version>
-        <spring-boot.version>2.4.1</spring-boot.version>
-        <spring-cloud-gateway.version>3.0.0</spring-cloud-gateway.version>
-
         <argLine>-Xms512m -Xmx1024m -Xss256k -Dnet.bytebuddy.experimental=true</argLine>
       </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -408,7 +408,7 @@ under the License.
     <bouncycastle.version>1.68</bouncycastle.version>
     <nimbus-jose-jwt.version>9.4.1</nimbus-jose-jwt.version>
 
-    <jackson.version>2.12.1-SNAPSHOT</jackson.version>
+    <jackson.version>2.12.1</jackson.version>
 
     <spring.version>5.3.2</spring.version>
     <spring-security.version>5.4.2</spring-security.version>

--- a/pom.xml
+++ b/pom.xml
@@ -406,7 +406,7 @@ under the License.
 
     <cxf.version>3.4.2</cxf.version>
     <bouncycastle.version>1.68</bouncycastle.version>
-    <nimbus-jose-jwt.version>9.4</nimbus-jose-jwt.version>
+    <nimbus-jose-jwt.version>9.4.1</nimbus-jose-jwt.version>
 
     <jackson.version>2.12.1-SNAPSHOT</jackson.version>
 

--- a/sra/src/main/java/org/apache/syncope/sra/SecurityConfig.java
+++ b/sra/src/main/java/org/apache/syncope/sra/SecurityConfig.java
@@ -66,6 +66,7 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.client.registration.InMemoryReactiveClientRegistrationRepository;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.oidc.OidcScopes;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.jwt.JwtValidators;
 import org.springframework.security.oauth2.jwt.MappedJwtClaimSetConverter;
@@ -138,6 +139,9 @@ public class SecurityConfig {
                         registrationId("OIDC").
                         clientId(env.getProperty("am.oidc.client.id")).
                         clientSecret(env.getProperty("am.oidc.client.secret")).
+                        scope(env.getProperty("am.oidc.scopes", String[].class,
+                                new String[] { OidcScopes.OPENID, OidcScopes.ADDRESS, OidcScopes.EMAIL,
+                                    OidcScopes.PHONE, OidcScopes.PROFILE })).
                         build());
     }
 

--- a/sra/src/main/java/org/apache/syncope/sra/SecurityConfig.java
+++ b/sra/src/main/java/org/apache/syncope/sra/SecurityConfig.java
@@ -170,7 +170,7 @@ public class SecurityConfig {
     public InMemoryReactiveClientRegistrationRepository oauth2ClientRegistrationRepository() {
         return new InMemoryReactiveClientRegistrationRepository(
                 ClientRegistration.withRegistrationId("OAUTH2").
-                        redirectUriTemplate("{baseUrl}/{action}/oauth2/code/{registrationId}").
+                        redirectUri("{baseUrl}/{action}/oauth2/code/{registrationId}").
                         tokenUri(env.getProperty("am.oauth2.tokenUri")).
                         authorizationUri(env.getProperty("am.oauth2.authorizationUri")).
                         userInfoUri(env.getProperty("am.oauth2.userInfoUri")).

--- a/sra/src/main/java/org/apache/syncope/sra/security/oauth2/OAuth2SecurityConfigUtils.java
+++ b/sra/src/main/java/org/apache/syncope/sra/security/oauth2/OAuth2SecurityConfigUtils.java
@@ -117,8 +117,6 @@ public final class OAuth2SecurityConfigUtils {
             final LogoutRouteMatcher logoutRouteMatcher,
             final ConfigurableApplicationContext ctx) {
 
-        builder.and().logout().disable();
-
         LogoutWebFilter logoutWebFilter = new LogoutWebFilter();
         logoutWebFilter.setRequiresLogoutMatcher(logoutRouteMatcher);
         logoutWebFilter.setLogoutHandler(new OAuth2SessionRemovalServerLogoutHandler(cacheManager));
@@ -136,7 +134,7 @@ public final class OAuth2SecurityConfigUtils {
             }
         }
 
-        builder.and().addFilterAt(logoutWebFilter, SecurityWebFiltersOrder.LOGOUT);
+        builder.and().logout().disable().addFilterAt(logoutWebFilter, SecurityWebFiltersOrder.LOGOUT);
     }
 
     private OAuth2SecurityConfigUtils() {

--- a/sra/src/main/java/org/apache/syncope/sra/security/oauth2/OAuth2SessionRemovalServerLogoutHandler.java
+++ b/sra/src/main/java/org/apache/syncope/sra/security/oauth2/OAuth2SessionRemovalServerLogoutHandler.java
@@ -23,6 +23,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.server.WebFilterExchange;
 import org.springframework.security.web.server.authentication.logout.ServerLogoutHandler;
+import org.springframework.web.server.WebSession;
 import reactor.core.publisher.Mono;
 
 public class OAuth2SessionRemovalServerLogoutHandler implements ServerLogoutHandler {
@@ -35,9 +36,8 @@ public class OAuth2SessionRemovalServerLogoutHandler implements ServerLogoutHand
 
     @Override
     public Mono<Void> logout(final WebFilterExchange exchange, final Authentication authentication) {
-        return exchange.getExchange().getSession().flatMap(session -> {
-            cacheManager.getCache(SessionConfig.DEFAULT_CACHE).evictIfPresent(session.getId());
-            return session.invalidate();
-        });
+        return exchange.getExchange().getSession().
+                doOnNext(session -> cacheManager.getCache(SessionConfig.DEFAULT_CACHE).evictIfPresent(session.getId())).
+                flatMap(WebSession::invalidate);
     }
 }

--- a/wa/pom.xml
+++ b/wa/pom.xml
@@ -33,6 +33,8 @@ under the License.
   <packaging>pom</packaging>
   
   <properties>
+    <nimbus-jose-jwt.version>8.20.1</nimbus-jose-jwt.version>
+
     <rootpom.basedir>${basedir}/..</rootpom.basedir>
   </properties>
 

--- a/wa/starter/pom.xml
+++ b/wa/starter/pom.xml
@@ -298,14 +298,17 @@ under the License.
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
     </dependency>
+
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
     </dependency>
+
     <dependency>
       <groupId>com.squareup.okio</groupId>
       <artifactId>okio</artifactId>
     </dependency>
+
     <dependency>
       <groupId>org.apache.cxf</groupId>
       <artifactId>cxf-rt-transports-http-jetty</artifactId>
@@ -416,28 +419,6 @@ under the License.
             <filtering>true</filtering>
           </resource>
         </resources>
-      </build>
-    </profile>
-
-    <profile>
-      <id>jdk16-plus</id>
-
-      <activation>
-        <jdk>[16,)</jdk>
-      </activation>
-      
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <includes>
-                <include>**/SyncopeWASAML2*.java</include>
-              </includes>            
-            </configuration>
-          </plugin>          
-        </plugins>
       </build>
     </profile>
   </profiles>

--- a/wa/starter/src/main/java/org/apache/syncope/wa/starter/mapping/OIDCRPTOMapper.java
+++ b/wa/starter/src/main/java/org/apache/syncope/wa/starter/mapping/OIDCRPTOMapper.java
@@ -51,7 +51,7 @@ public class OIDCRPTOMapper implements ClientAppMapper {
 
     private static final Logger LOG = LoggerFactory.getLogger(OIDCRPTOMapper.class);
 
-    public static final String CUSTOM_SCOPE = "syncope";
+    private static final String CUSTOM_SCOPE = "syncope";
 
     @Override
     public RegisteredService build(

--- a/wa/starter/src/main/resources/application.properties
+++ b/wa/starter/src/main/resources/application.properties
@@ -26,7 +26,7 @@ server.servlet.encoding.force=true
 
 server.servlet.contextPath=/syncope-wa
 
-spring.resources.static-locations=classpath:/thymeleaf/static,classpath:/static
+spring.web.resources.static-locations=classpath:/thymeleaf/static,classpath:/static
 
 management.endpoints.web.exposure.include=health,loggers,refresh,registeredServices
 management.endpoint.health.show-details=always

--- a/wa/starter/src/test/resources/debug/application-debug.properties
+++ b/wa/starter/src/test/resources/debug/application-debug.properties
@@ -14,3 +14,4 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
+#debug=true


### PR DESCRIPTION
By this upgrade, we can also upgrade Spring Boot and Spring Cloud Gateway to latest releases, thus removing the need of different dependency versions for JDK 16.