### PR TITLE
Splitting wa-reference test classes into separate runs on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ notifications:
     - dev@syncope.apache.org
 stages:
   - build
-#  - validate
-#  - test
+  - validate
+  - test
   - fit
 jobs:
   include:
@@ -77,44 +77,44 @@ jobs:
       name: "Persistence Unit Tests via JDK 11: MySQL (JSON)"
       script: mvn -f core/persistence-jpa-json/pom.xml -P mysql -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Dsass.skip=true
       ######################################################
-#    - stage: fit
-#      name: "Integration Tests: Tomcat / H2 / JSON Content-Type"
-#      script: mvn -f fit/core-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
-#    - stage: fit
-#      name: "Integration Tests: Tomcat / H2 / XML Content-Type"
-#      script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/xml -Dit.test=org.apache.syncope.fit.core.*ITCase -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
-#    - stage: fit
-#      name: "Integration Tests: Tomcat / H2 / YAML Content-Type"
-#      script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/yaml -Dit.test=org.apache.syncope.fit.core.*ITCase -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
-#    - stage: fit
-#      name: "Integration Tests: Wildfly / H2 / JSON Content-Type"
-#      script: mvn -f fit/core-reference/pom.xml -P wildfly-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
-#    - stage: fit
-#      name: "Integration Tests: Payara / H2 / JSON Content-Type"
-#      script: mvn -f fit/core-reference/pom.xml -P payara-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
-#    - stage: fit
-#      name: "Integration Tests: Tomcat / PostgreSQL / JSON Content-Type"
-#      script: mvn -f fit/core-reference/pom.xml -P postgres-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
-#    - stage: fit
-#      name: "Integration Tests: Tomcat / PostgreSQL (JSONB) / JSON Content-Type"
-#      script: mvn -f fit/core-reference/pom.xml -P pgjsonb-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
-#    - stage: fit
-#      name: "Integration Tests: Tomcat / MySQL / JSON Content-Type"
-#      script: mvn -f fit/core-reference/pom.xml -P mysql-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
-#    - stage: fit
-#      name: "Integration Tests: Tomcat / MySQL (JSON) / JSON Content-Type"
-#      script: mvn -f fit/core-reference/pom.xml -P myjson-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
-#    - stage: fit
-#      name: "Integration Tests: Tomcat / MariaDB / JSON Content-Type"
-#      script: mvn -f fit/core-reference/pom.xml -P mariadb-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
-#    - stage: fit
-#      name: "Integration Tests: Tomcat / H2 / JSON Content-Type + Elasticsearch"
-#      script: mvn -f fit/core-reference/pom.xml -P elasticsearch-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
-#    - stage: fit
-#      name: "Integration Tests: Tomcat / H2 / JSON Content-Type + Zookeeper"
-#      script: mvn -f fit/core-reference/pom.xml -P zookeeper-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Integration Tests: SRA / CAS"
+      name: "Integration Tests: Tomcat / H2 / JSON Content-Type"
+      script: mvn -f fit/core-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+    - stage: fit
+      name: "Integration Tests: Tomcat / H2 / XML Content-Type"
+      script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/xml -Dit.test=org.apache.syncope.fit.core.*ITCase -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+    - stage: fit
+      name: "Integration Tests: Tomcat / H2 / YAML Content-Type"
+      script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/yaml -Dit.test=org.apache.syncope.fit.core.*ITCase -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+    - stage: fit
+      name: "Integration Tests: Wildfly / H2 / JSON Content-Type"
+      script: mvn -f fit/core-reference/pom.xml -P wildfly-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+    - stage: fit
+      name: "Integration Tests: Payara / H2 / JSON Content-Type"
+      script: mvn -f fit/core-reference/pom.xml -P payara-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+    - stage: fit
+      name: "Integration Tests: Tomcat / PostgreSQL / JSON Content-Type"
+      script: mvn -f fit/core-reference/pom.xml -P postgres-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+    - stage: fit
+      name: "Integration Tests: Tomcat / PostgreSQL (JSONB) / JSON Content-Type"
+      script: mvn -f fit/core-reference/pom.xml -P pgjsonb-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+    - stage: fit
+      name: "Integration Tests: Tomcat / MySQL / JSON Content-Type"
+      script: mvn -f fit/core-reference/pom.xml -P mysql-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+    - stage: fit
+      name: "Integration Tests: Tomcat / MySQL (JSON) / JSON Content-Type"
+      script: mvn -f fit/core-reference/pom.xml -P myjson-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+    - stage: fit
+      name: "Integration Tests: Tomcat / MariaDB / JSON Content-Type"
+      script: mvn -f fit/core-reference/pom.xml -P mariadb-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+    - stage: fit
+      name: "Integration Tests: Tomcat / H2 / JSON Content-Type + Elasticsearch"
+      script: mvn -f fit/core-reference/pom.xml -P elasticsearch-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+    - stage: fit
+      name: "Integration Tests: Tomcat / H2 / JSON Content-Type + Zookeeper"
+      script: mvn -f fit/core-reference/pom.xml -P zookeeper-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+    - stage: fit
+      name: "Integration Tests: SRA / CAS client"
       script: mvn -f fit/wa-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true -Dit.test=org.apache.syncope.fit.sra.CASSRAITCase
     - stage: fit
       name: "Integration Tests: SRA / OAuth 2.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,8 +40,8 @@ notifications:
     - dev@syncope.apache.org
 stages:
   - build
-  - validate
-  - test
+#  - validate
+#  - test
   - fit
 jobs:
   include:
@@ -77,43 +77,55 @@ jobs:
       name: "Persistence Unit Tests via JDK 11: MySQL (JSON)"
       script: mvn -f core/persistence-jpa-json/pom.xml -P mysql -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Dsass.skip=true
       ######################################################
+#    - stage: fit
+#      name: "Integration Tests: Tomcat / H2 / JSON Content-Type"
+#      script: mvn -f fit/core-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+#    - stage: fit
+#      name: "Integration Tests: Tomcat / H2 / XML Content-Type"
+#      script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/xml -Dit.test=org.apache.syncope.fit.core.*ITCase -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+#    - stage: fit
+#      name: "Integration Tests: Tomcat / H2 / YAML Content-Type"
+#      script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/yaml -Dit.test=org.apache.syncope.fit.core.*ITCase -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+#    - stage: fit
+#      name: "Integration Tests: Wildfly / H2 / JSON Content-Type"
+#      script: mvn -f fit/core-reference/pom.xml -P wildfly-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+#    - stage: fit
+#      name: "Integration Tests: Payara / H2 / JSON Content-Type"
+#      script: mvn -f fit/core-reference/pom.xml -P payara-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+#    - stage: fit
+#      name: "Integration Tests: Tomcat / PostgreSQL / JSON Content-Type"
+#      script: mvn -f fit/core-reference/pom.xml -P postgres-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+#    - stage: fit
+#      name: "Integration Tests: Tomcat / PostgreSQL (JSONB) / JSON Content-Type"
+#      script: mvn -f fit/core-reference/pom.xml -P pgjsonb-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+#    - stage: fit
+#      name: "Integration Tests: Tomcat / MySQL / JSON Content-Type"
+#      script: mvn -f fit/core-reference/pom.xml -P mysql-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+#    - stage: fit
+#      name: "Integration Tests: Tomcat / MySQL (JSON) / JSON Content-Type"
+#      script: mvn -f fit/core-reference/pom.xml -P myjson-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+#    - stage: fit
+#      name: "Integration Tests: Tomcat / MariaDB / JSON Content-Type"
+#      script: mvn -f fit/core-reference/pom.xml -P mariadb-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+#    - stage: fit
+#      name: "Integration Tests: Tomcat / H2 / JSON Content-Type + Elasticsearch"
+#      script: mvn -f fit/core-reference/pom.xml -P elasticsearch-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+#    - stage: fit
+#      name: "Integration Tests: Tomcat / H2 / JSON Content-Type + Zookeeper"
+#      script: mvn -f fit/core-reference/pom.xml -P zookeeper-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Integration Tests: Tomcat / H2 / JSON Content-Type"
-      script: mvn -f fit/core-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+      name: "Integration Tests: SRA / CAS"
+      script: mvn -f fit/wa-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true -Dit.test=org.apache.syncope.fit.sra.CASSRAITCase
     - stage: fit
-      name: "Integration Tests: Tomcat / H2 / XML Content-Type"
-      script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/xml -Dit.test=org.apache.syncope.fit.core.*ITCase -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+      name: "Integration Tests: SRA / OAuth 2.0"
+      script: mvn -f fit/wa-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true -Dit.test=org.apache.syncope.fit.sra.OAUTH2SRAITCase
     - stage: fit
-      name: "Integration Tests: Tomcat / H2 / YAML Content-Type"
-      script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/yaml -Dit.test=org.apache.syncope.fit.core.*ITCase -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+      name: "Integration Tests: SRA / OIDC 1.0"
+      script: mvn -f fit/wa-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true -Dit.test=org.apache.syncope.fit.sra.OIDCSRAITCase
     - stage: fit
-      name: "Integration Tests: Wildfly / H2 / JSON Content-Type"
-      script: mvn -f fit/core-reference/pom.xml -P wildfly-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
+      name: "Integration Tests: SRA / SAML 2.0"
+      script: mvn -f fit/wa-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true -Dit.test=org.apache.syncope.fit.sra.SAML2SRAITCase
     - stage: fit
-      name: "Integration Tests: Payara / H2 / JSON Content-Type"
-      script: mvn -f fit/core-reference/pom.xml -P payara-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
-    - stage: fit
-      name: "Integration Tests: Tomcat / PostgreSQL / JSON Content-Type"
-      script: mvn -f fit/core-reference/pom.xml -P postgres-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
-    - stage: fit
-      name: "Integration Tests: Tomcat / PostgreSQL (JSONB) / JSON Content-Type"
-      script: mvn -f fit/core-reference/pom.xml -P pgjsonb-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
-    - stage: fit
-      name: "Integration Tests: Tomcat / MySQL / JSON Content-Type"
-      script: mvn -f fit/core-reference/pom.xml -P mysql-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
-    - stage: fit
-      name: "Integration Tests: Tomcat / MySQL (JSON) / JSON Content-Type"
-      script: mvn -f fit/core-reference/pom.xml -P myjson-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
-    - stage: fit
-      name: "Integration Tests: Tomcat / MariaDB / JSON Content-Type"
-      script: mvn -f fit/core-reference/pom.xml -P mariadb-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
-    - stage: fit
-      name: "Integration Tests: Tomcat / H2 / JSON Content-Type + Elasticsearch"
-      script: mvn -f fit/core-reference/pom.xml -P elasticsearch-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
-    - stage: fit
-      name: "Integration Tests: Tomcat / H2 / JSON Content-Type + Zookeeper"
-      script: mvn -f fit/core-reference/pom.xml -P zookeeper-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
-    - stage: fit
-      name: "Integration Tests: SRA and WA"
-      script: mvn -f fit/wa-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true "-Dit.test=!*SAML*"
+      name: "Integration Tests: SAML2SP4UI / OIDC4UI"
+      script: mvn -f fit/wa-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true -Dit.test=org.apache.syncope.fit.ui.*ITCase
     #####################################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,40 +78,40 @@ jobs:
       script: mvn -f core/persistence-jpa-json/pom.xml -P mysql -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Dsass.skip=true
       ######################################################
     - stage: fit
-      name: "Core Integration Tests: Tomcat / H2 / JSON Content-Type"
+      name: "Core Integration Tests: Tomcat / H2 / JSON"
       script: mvn -f fit/core-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Core Integration Tests: Tomcat / H2 / XML Content-Type"
+      name: "Core Integration Tests: Tomcat / H2 / XML"
       script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/xml -Dit.test=org.apache.syncope.fit.core.*ITCase -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Core Integration Tests: Tomcat / H2 / YAML Content-Type"
+      name: "Core Integration Tests: Tomcat / H2 / YAML"
       script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/yaml -Dit.test=org.apache.syncope.fit.core.*ITCase -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Core Integration Tests: Wildfly / H2 / JSON Content-Type"
+      name: "Core Integration Tests: Wildfly / H2 / JSON"
       script: mvn -f fit/core-reference/pom.xml -P wildfly-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Core Integration Tests: Payara / H2 / JSON Content-Type"
+      name: "Core Integration Tests: Payara / H2 / JSON"
       script: mvn -f fit/core-reference/pom.xml -P payara-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Core Integration Tests: Tomcat / PostgreSQL / JSON Content-Type"
+      name: "Core Integration Tests: Tomcat / PostgreSQL / JSON"
       script: mvn -f fit/core-reference/pom.xml -P postgres-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Core Integration Tests: Tomcat / PostgreSQL (JSONB) / JSON Content-Type"
+      name: "Core Integration Tests: Tomcat / PostgreSQL (JSONB) / JSON"
       script: mvn -f fit/core-reference/pom.xml -P pgjsonb-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Core Integration Tests: Tomcat / MySQL / JSON Content-Type"
+      name: "Core Integration Tests: Tomcat / MySQL / JSON"
       script: mvn -f fit/core-reference/pom.xml -P mysql-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Core Integration Tests: Tomcat / MySQL (JSON) / JSON Content-Type"
+      name: "Core Integration Tests: Tomcat / MySQL (JSON) / JSON"
       script: mvn -f fit/core-reference/pom.xml -P myjson-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Core Integration Tests: Tomcat / MariaDB / JSON Content-Type"
+      name: "Core Integration Tests: Tomcat / MariaDB / JSON"
       script: mvn -f fit/core-reference/pom.xml -P mariadb-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Core Integration Tests: Tomcat / H2 / JSON Content-Type + Elasticsearch"
+      name: "Core Integration Tests: Tomcat / H2 / JSON + Elasticsearch"
       script: mvn -f fit/core-reference/pom.xml -P elasticsearch-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Core Integration Tests: Tomcat / H2 / JSON Content-Type + Zookeeper"
+      name: "Core Integration Tests: Tomcat / H2 / JSON + Zookeeper"
       script: mvn -f fit/core-reference/pom.xml -P zookeeper-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
       name: "SRA Integration Tests: CAS client"

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ git:
   depth: 2
 env:
   global:
-  - TMPDIR=$TRAVIS_BUILD_DIR/tmp
   - MAVEN_OPTS="-Xmx4096M -Xss128M -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify"
   - jaxrsContentType=application/json
   - TestCommand="mvn -U -T 1C clean test -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Dsass.skip=true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,54 +77,54 @@ jobs:
       script: mvn -f core/persistence-jpa-json/pom.xml -P mysql -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Dsass.skip=true
       ######################################################
     - stage: fit
-      name: "Core Integration Tests: Tomcat / H2 / JSON"
+      name: "Integration Tests: Tomcat / H2 / JSON"
       script: mvn -f fit/core-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Core Integration Tests: Tomcat / H2 / XML"
+      name: "Integration Tests: Tomcat / H2 / XML"
       script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/xml -Dit.test=org.apache.syncope.fit.core.*ITCase -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Core Integration Tests: Tomcat / H2 / YAML"
+      name: "Integration Tests: Tomcat / H2 / YAML"
       script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/yaml -Dit.test=org.apache.syncope.fit.core.*ITCase -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Core Integration Tests: Wildfly / H2 / JSON"
+      name: "Integration Tests: Wildfly / H2 / JSON"
       script: mvn -f fit/core-reference/pom.xml -P wildfly-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Core Integration Tests: Payara / H2 / JSON"
+      name: "Integration Tests: Payara / H2 / JSON"
       script: mvn -f fit/core-reference/pom.xml -P payara-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Core Integration Tests: Tomcat / PostgreSQL / JSON"
+      name: "Integration Tests: Tomcat / PostgreSQL / JSON"
       script: mvn -f fit/core-reference/pom.xml -P postgres-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Core Integration Tests: Tomcat / PostgreSQL (JSONB) / JSON"
+      name: "Integration Tests: Tomcat / PostgreSQL (JSONB) / JSON"
       script: mvn -f fit/core-reference/pom.xml -P pgjsonb-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Core Integration Tests: Tomcat / MySQL / JSON"
+      name: "Integration Tests: Tomcat / MySQL / JSON"
       script: mvn -f fit/core-reference/pom.xml -P mysql-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Core Integration Tests: Tomcat / MySQL (JSON) / JSON"
+      name: "Integration Tests: Tomcat / MySQL (JSON) / JSON"
       script: mvn -f fit/core-reference/pom.xml -P myjson-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Core Integration Tests: Tomcat / MariaDB / JSON"
+      name: "Integration Tests: Tomcat / MariaDB / JSON"
       script: mvn -f fit/core-reference/pom.xml -P mariadb-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Core Integration Tests: Tomcat / H2 / JSON + Elasticsearch"
+      name: "Integration Tests: Tomcat / H2 / JSON + Elasticsearch"
       script: mvn -f fit/core-reference/pom.xml -P elasticsearch-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Core Integration Tests: Tomcat / H2 / JSON + Zookeeper"
+      name: "Integration Tests: Tomcat / H2 / JSON + Zookeeper"
       script: mvn -f fit/core-reference/pom.xml -P zookeeper-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "SRA Integration Tests: CAS client"
+      name: "WA: SRA Integration Tests: CAS client"
       script: mvn -f fit/wa-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true -Dit.test=org.apache.syncope.fit.sra.CASSRAITCase
     - stage: fit
-      name: "SRA Integration Tests: OAuth 2.0"
+      name: "WA: SRA Integration Tests: OAuth 2.0"
       script: mvn -f fit/wa-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true -Dit.test=org.apache.syncope.fit.sra.OAUTH2SRAITCase
     - stage: fit
-      name: "SRA Integration Tests:OIDC 1.0"
+      name: "WA: SRA Integration Tests:OIDC 1.0"
       script: mvn -f fit/wa-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true -Dit.test=org.apache.syncope.fit.sra.OIDCSRAITCase
     - stage: fit
-      name: "SRA Integration Tests:  SAML 2.0"
+      name: "WA: SRA Integration Tests:  SAML 2.0"
       script: mvn -f fit/wa-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true -Dit.test=org.apache.syncope.fit.sra.SAML2SRAITCase
     - stage: fit
-      name: "SSO Integration Tests: SAML2SP4UI / OIDC4UI"
-      script: mvn -f fit/wa-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true -Dit.test=org.apache.syncope.fit.ui.*ITCase
+      name: "WA: SSO Integration Tests: SAML2SP4UI / OIDC4UI"
+      script: mvn -f fit/wa-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true -Dit.test=org.apache.syncope.fit.ui.OIDC4UIITCase
     #####################################################

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ git:
   depth: 2
 env:
   global:
+  - TMPDIR=/tmp
   - MAVEN_OPTS="-Xmx4096M -Xss128M -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify"
-  - DBMS=H2
   - jaxrsContentType=application/json
   - TestCommand="mvn -U -T 1C clean test -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Dsass.skip=true"
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ git:
   depth: 2
 env:
   global:
-  - TMPDIR=/tmp
+  - TMPDIR=$TRAVIS_BUILD_DIR/tmp
   - MAVEN_OPTS="-Xmx4096M -Xss128M -XX:+TieredCompilation -XX:TieredStopAtLevel=1 -noverify"
   - jaxrsContentType=application/json
   - TestCommand="mvn -U -T 1C clean test -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Dsass.skip=true"

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,54 +78,54 @@ jobs:
       script: mvn -f core/persistence-jpa-json/pom.xml -P mysql -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Dsass.skip=true
       ######################################################
     - stage: fit
-      name: "Integration Tests: Tomcat / H2 / JSON Content-Type"
+      name: "Core Integration Tests: Tomcat / H2 / JSON Content-Type"
       script: mvn -f fit/core-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Integration Tests: Tomcat / H2 / XML Content-Type"
+      name: "Core Integration Tests: Tomcat / H2 / XML Content-Type"
       script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/xml -Dit.test=org.apache.syncope.fit.core.*ITCase -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Integration Tests: Tomcat / H2 / YAML Content-Type"
+      name: "Core Integration Tests: Tomcat / H2 / YAML Content-Type"
       script: mvn -f fit/core-reference/pom.xml verify -Djaxrs.content.type=application/yaml -Dit.test=org.apache.syncope.fit.core.*ITCase -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Integration Tests: Wildfly / H2 / JSON Content-Type"
+      name: "Core Integration Tests: Wildfly / H2 / JSON Content-Type"
       script: mvn -f fit/core-reference/pom.xml -P wildfly-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Integration Tests: Payara / H2 / JSON Content-Type"
+      name: "Core Integration Tests: Payara / H2 / JSON Content-Type"
       script: mvn -f fit/core-reference/pom.xml -P payara-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Integration Tests: Tomcat / PostgreSQL / JSON Content-Type"
+      name: "Core Integration Tests: Tomcat / PostgreSQL / JSON Content-Type"
       script: mvn -f fit/core-reference/pom.xml -P postgres-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Integration Tests: Tomcat / PostgreSQL (JSONB) / JSON Content-Type"
+      name: "Core Integration Tests: Tomcat / PostgreSQL (JSONB) / JSON Content-Type"
       script: mvn -f fit/core-reference/pom.xml -P pgjsonb-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Integration Tests: Tomcat / MySQL / JSON Content-Type"
+      name: "Core Integration Tests: Tomcat / MySQL / JSON Content-Type"
       script: mvn -f fit/core-reference/pom.xml -P mysql-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Integration Tests: Tomcat / MySQL (JSON) / JSON Content-Type"
+      name: "Core Integration Tests: Tomcat / MySQL (JSON) / JSON Content-Type"
       script: mvn -f fit/core-reference/pom.xml -P myjson-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Integration Tests: Tomcat / MariaDB / JSON Content-Type"
+      name: "Core Integration Tests: Tomcat / MariaDB / JSON Content-Type"
       script: mvn -f fit/core-reference/pom.xml -P mariadb-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Integration Tests: Tomcat / H2 / JSON Content-Type + Elasticsearch"
+      name: "Core Integration Tests: Tomcat / H2 / JSON Content-Type + Elasticsearch"
       script: mvn -f fit/core-reference/pom.xml -P elasticsearch-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Integration Tests: Tomcat / H2 / JSON Content-Type + Zookeeper"
+      name: "Core Integration Tests: Tomcat / H2 / JSON Content-Type + Zookeeper"
       script: mvn -f fit/core-reference/pom.xml -P zookeeper-it -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true
     - stage: fit
-      name: "Integration Tests: SRA / CAS client"
+      name: "SRA Integration Tests: CAS client"
       script: mvn -f fit/wa-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true -Dit.test=org.apache.syncope.fit.sra.CASSRAITCase
     - stage: fit
-      name: "Integration Tests: SRA / OAuth 2.0"
+      name: "SRA Integration Tests: OAuth 2.0"
       script: mvn -f fit/wa-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true -Dit.test=org.apache.syncope.fit.sra.OAUTH2SRAITCase
     - stage: fit
-      name: "Integration Tests: SRA / OIDC 1.0"
+      name: "SRA Integration Tests:OIDC 1.0"
       script: mvn -f fit/wa-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true -Dit.test=org.apache.syncope.fit.sra.OIDCSRAITCase
     - stage: fit
-      name: "Integration Tests: SRA / SAML 2.0"
+      name: "SRA Integration Tests:  SAML 2.0"
       script: mvn -f fit/wa-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true -Dit.test=org.apache.syncope.fit.sra.SAML2SRAITCase
     - stage: fit
-      name: "Integration Tests: SAML2SP4UI / OIDC4UI"
+      name: "SSO Integration Tests: SAML2SP4UI / OIDC4UI"
       script: mvn -f fit/wa-reference/pom.xml verify -Dinvoker.streamLogs=true -Dmodernizer.skip=true -Dianal.skip=true -Drat.skip=true -Dcheckstyle.skip=true -Djacoco.skip=true -Dit.test=org.apache.syncope.fit.ui.*ITCase
     #####################################################

--- a/ext/saml2sp4ui/logic/src/main/java/org/apache/syncope/core/logic/saml2/SAML2ClientCache.java
+++ b/ext/saml2sp4ui/logic/src/main/java/org/apache/syncope/core/logic/saml2/SAML2ClientCache.java
@@ -20,7 +20,6 @@ package org.apache.syncope.core.logic.saml2;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -28,6 +27,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.cxf.helpers.IOUtils;
 import org.apache.syncope.common.lib.to.ItemTO;
 import org.apache.syncope.common.lib.to.SAML2SP4UIIdPTO;
@@ -44,7 +44,6 @@ import org.apache.syncope.core.persistence.api.entity.SAML2SP4UIIdP;
 import org.pac4j.saml.metadata.SAML2IdentityProviderMetadataResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.util.UriUtils;
 
 /**
  * Basic in-memory cache for available {@link SAML2Client} instances.
@@ -65,9 +64,10 @@ public class SAML2ClientCache {
     }
 
     public static Optional<String> getSPMetadataPath(final String spEntityID) {
+        String entityIDPath = StringUtils.replaceChars(
+                StringUtils.removeStart(StringUtils.removeStart(spEntityID, "https://"), "http://"), ":/", "__");
         return Optional.ofNullable(METADATA_PATH).
-                map(path -> Optional.of(path.resolve(
-                UriUtils.encodePath(spEntityID, StandardCharsets.UTF_8)).toAbsolutePath().toString())).
+                map(path -> Optional.of(path.resolve(entityIDPath).toAbsolutePath().toString())).
                 orElse(Optional.empty());
     }
 

--- a/ext/saml2sp4ui/logic/src/main/java/org/apache/syncope/core/logic/saml2/SAML2ClientCache.java
+++ b/ext/saml2sp4ui/logic/src/main/java/org/apache/syncope/core/logic/saml2/SAML2ClientCache.java
@@ -20,6 +20,7 @@ package org.apache.syncope.core.logic.saml2;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -43,6 +44,7 @@ import org.apache.syncope.core.persistence.api.entity.SAML2SP4UIIdP;
 import org.pac4j.saml.metadata.SAML2IdentityProviderMetadataResolver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.web.util.UriUtils;
 
 /**
  * Basic in-memory cache for available {@link SAML2Client} instances.
@@ -64,7 +66,8 @@ public class SAML2ClientCache {
 
     public static Optional<String> getSPMetadataPath(final String spEntityID) {
         return Optional.ofNullable(METADATA_PATH).
-                map(path -> Optional.of(path.resolve(spEntityID).toAbsolutePath().toString())).
+                map(path -> Optional.of(path.resolve(
+                UriUtils.encodePath(spEntityID, StandardCharsets.UTF_8)).toAbsolutePath().toString())).
                 orElse(Optional.empty());
     }
 


### PR DESCRIPTION
This is an attempt to allow Travis CI run painfully the integration tests under `fit/wa-reference`