### PR TITLE
Auto-configure session tracking modes

### DIFF
--- a/wa/starter/src/main/java/org/apache/syncope/wa/starter/SyncopeWAApplication.java
+++ b/wa/starter/src/main/java/org/apache/syncope/wa/starter/SyncopeWAApplication.java
@@ -45,10 +45,10 @@ import org.springframework.boot.autoconfigure.jersey.JerseyAutoConfiguration;
 import org.springframework.boot.autoconfigure.jmx.JmxAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.autoconfigure.web.ServerProperties;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.web.servlet.server.Session;
 import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.PropertySource;
@@ -97,7 +97,7 @@ public class SyncopeWAApplication extends SpringBootServletInitializer {
     private SchedulerFactoryBean scheduler;
 
     @Autowired
-    private Session sessionProperties;
+    private ServerProperties serverProperties;
 
     @Value("${contextRefreshDelay:15}")
     private long contextRefreshDelay;
@@ -112,7 +112,7 @@ public class SyncopeWAApplication extends SpringBootServletInitializer {
 
     @Override
     public void onStartup(final ServletContext servletContext) throws ServletException {
-        Set<SessionTrackingMode> trackingModes = sessionProperties.getTrackingModes().
+        Set<SessionTrackingMode> trackingModes = serverProperties.getServlet().getSession().getTrackingModes().
             stream().
             map(mode -> SessionTrackingMode.valueOf(mode.name())).
             collect(Collectors.toSet());

--- a/wa/starter/src/test/java/org/apache/syncope/wa/starter/AbstractTest.java
+++ b/wa/starter/src/test/java/org/apache/syncope/wa/starter/AbstractTest.java
@@ -19,9 +19,13 @@
 package org.apache.syncope.wa.starter;
 
 import java.util.UUID;
+
+import org.springframework.boot.autoconfigure.web.ServerProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.boot.web.servlet.server.Session;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.context.ContextConfiguration;
@@ -35,6 +39,7 @@ import org.springframework.test.context.ContextConfiguration;
         "cas.sso.allow-missing-service-parameter=true"
 })
 @ContextConfiguration(initializers = ZookeeperTestingServer.class)
+@EnableConfigurationProperties(ServerProperties.class)
 public abstract class AbstractTest {
 
     @LocalServerPort


### PR DESCRIPTION
When running with initializr in separate servlet container, session tracking modes are left to their defaults and `SessionConfiguringInitializer` backs away, as it only affects embedded servlet containers. This makes both COOKIE and URL modes available to the underlying response, which cause very strange behavior with URL encoding and inclusion of `jsessionid` in the URL, which in turn causes Spring Security to block the request as it sees `;` as a malicious character.

In this patch, the behavior for `SessionConfiguringInitializer` is partially emulated to set the session tracking modes based on configured application properties.