### PR TITLE
Disable CXF Services Listing

### DIFF
--- a/core/rest-cxf/src/main/resources/META-INF/web-fragment.xml
+++ b/core/rest-cxf/src/main/resources/META-INF/web-fragment.xml
@@ -34,6 +34,10 @@ under the License.
       <param-name>openapi.context.id</param-name>
       <param-value>openapi.context.id.default</param-value>
     </init-param>
+    <init-param>
+      <param-name>hide-service-list-page</param-name>
+      <param-value>true</param-value>
+    </init-param>
     <load-on-startup>1</load-on-startup>
   </servlet>
   <servlet-mapping>


### PR DESCRIPTION
As Syncope 2.1.x is stuck on CXF 3.2.x, it is vulnerable to:

http://cxf.apache.org/security-advisories.data/CVE-2020-13954.txt.asc

I confirmed with this PR you can no longer see the services page (http://localhost:9080/syncope/rest/services)