### PR TITLE
Clean up: Simplify optional call chains

### DIFF
--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/rest/ConnectorRestClient.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/rest/ConnectorRestClient.java
@@ -102,10 +102,8 @@ public class ConnectorRestClient extends BaseRestClient {
                 filter(object -> object.getType().equalsIgnoreCase(objectClass)).
                 findAny();
 
-        return connIdObjectClass.isPresent()
-                ? connIdObjectClass.get().getAttributes().stream().
-                        map(PlainSchemaTO::getKey).collect(Collectors.toList())
-                : List.of();
+        return connIdObjectClass.map(connIdObjectClassTO -> connIdObjectClassTO.getAttributes().stream().
+            map(PlainSchemaTO::getKey).collect(Collectors.toList())).orElseGet(List::of);
     }
 
     /**

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/status/LinkedAccountStatusPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/status/LinkedAccountStatusPanel.java
@@ -59,8 +59,6 @@ public class LinkedAccountStatusPanel extends RemoteObjectPanel {
     protected Pair<ConnObjectTO, ConnObjectTO> getConnObjectTOs() {
         Optional<ReconStatus> status = ReconStatusUtils.getReconStatus(anyTypeKey, connObjectKeyValue, resource);
 
-        return status.isPresent()
-                ? Pair.of(status.get().getOnSyncope(), status.get().getOnResource())
-                : null;
+        return status.map(reconStatus -> Pair.of(reconStatus.getOnSyncope(), reconStatus.getOnResource())).orElse(null);
     }
 }

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/any/LinkedAccountPlainAttrsPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/any/LinkedAccountPlainAttrsPanel.java
@@ -252,7 +252,7 @@ public class LinkedAccountPlainAttrsPanel extends AbstractAttrsWizardStep<PlainS
                     AbstractFieldPanel<?> panel = setPanel(
                         schemas,
                         item,
-                        !linkedAccountTO.getPlainAttr(attrTO.getSchema()).isPresent());
+                        linkedAccountTO.getPlainAttr(attrTO.getSchema()).isEmpty());
 
                     panel.showExternAction(checkboxToggle(attrTO, panel, isMultivalue));
                 }

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/resources/ResourceProvisionPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/resources/ResourceProvisionPanel.java
@@ -93,13 +93,12 @@ public class ResourceProvisionPanel extends AbstractModalPanel<Serializable> {
             protected ResourceProvision getActualItem(
                 final ResourceProvision item, final List<ResourceProvision> list) {
 
-                return Optional.ofNullable(item)
-                    .map(resourceProvision -> list.stream()
-                        .filter(in -> ((resourceProvision.getKey() == null && in.getKey() == null)
-                            || (in.getKey() != null && in.getKey().equals(resourceProvision.getKey())))
-                            && ((resourceProvision.getAnyType() == null && in.getAnyType() == null)
-                            || (in.getAnyType() != null && in.getAnyType().equals(resourceProvision.getAnyType())))).
-                            findAny().orElse(null)).orElse(null);
+                return Optional.ofNullable(item).flatMap(resourceProvision -> list.stream()
+                    .filter(in -> ((resourceProvision.getKey() == null && in.getKey() == null)
+                        || (in.getKey() != null && in.getKey().equals(resourceProvision.getKey())))
+                        && ((resourceProvision.getAnyType() == null && in.getAnyType() == null)
+                        || (in.getAnyType() != null && in.getAnyType().equals(resourceProvision.getAnyType())))).
+                    findAny()).orElse(null);
             }
 
             @Override

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/WizardMgtPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/WizardMgtPanel.java
@@ -217,25 +217,18 @@ public abstract class WizardMgtPanel<T extends Serializable> extends AbstractWiz
                     fragment.add(Component.class.cast(modalPanel));
                     container.addOrReplace(fragment);
                 }
-                if (target.isPresent()) {
-                    customActionCallback(target.get());
-                }
+                target.ifPresent(this::customActionCallback);
             } else if (event.getPayload() instanceof AjaxWizard.NewItemCancelEvent) {
                 if (wizardInModal) {
-                    if (target.isPresent()) {
-                        modal.close(target.get());
-                    }
+                    target.ifPresent(modal::close);
                 } else {
                     container.addOrReplace(initialFragment);
                 }
-                if (target.isPresent()) {
-                    customActionOnCancelCallback(target.get());
-                }
+                target.ifPresent(this::customActionOnCancelCallback);
             } else if (event.getPayload() instanceof AjaxWizard.NewItemFinishEvent) {
                 SyncopeConsoleSession.get().success(getString(Constants.OPERATION_SUCCEEDED));
-                if (target.isPresent()) {
-                    ((BaseWebPage) pageRef.getPage()).getNotificationPanel().refresh(target.get());
-                }
+                target.ifPresent(ajaxRequestTarget ->
+                    ((BaseWebPage) pageRef.getPage()).getNotificationPanel().refresh(ajaxRequestTarget));
 
                 if (wizardInModal && showResultPage) {
                     modal.setContent(new ResultPage<>(
@@ -256,15 +249,11 @@ public abstract class WizardMgtPanel<T extends Serializable> extends AbstractWiz
                     });
                     target.ifPresent(t -> t.add(modal.getForm()));
                 } else if (wizardInModal) {
-                    if (target.isPresent()) {
-                        modal.close(target.get());
-                    }
+                    target.ifPresent(modal::close);
                 } else {
                     container.addOrReplace(initialFragment);
                 }
-                if (target.isPresent()) {
-                    customActionOnFinishCallback(target.get());
-                }
+                target.ifPresent(this::customActionOnFinishCallback);
             }
 
             if (containerAutoRefresh) {

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/AbstractAttrsWizardStep.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/AbstractAttrsWizardStep.java
@@ -425,7 +425,7 @@ public abstract class AbstractAttrsWizardStep<S extends SchemaTO> extends Wizard
                     ? Optional.empty()
                     : previousObject.getPlainAttr(attr.getSchema());
             if (previousObject != null
-                    && ((!prevAttr.isPresent() && attr.getValues().stream().anyMatch(StringUtils::isNotBlank))
+                    && ((prevAttr.isEmpty() && attr.getValues().stream().anyMatch(StringUtils::isNotBlank))
                     || (prevAttr.isPresent() && !ListUtils.isEqualList(
                     prevAttr.get().getValues().stream().
                             filter(StringUtils::isNotBlank).collect(Collectors.toList()),

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/AnyWizardBuilder.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/AnyWizardBuilder.java
@@ -186,10 +186,10 @@ public abstract class AnyWizardBuilder<A extends AnyTO> extends AbstractAnyWizar
                     forEach(oMemb -> GroupableRelatableTO.class.cast(updated).getMembership(oMemb.getGroupKey()).
                     ifPresent(uMemb -> {
                         oMemb.getPlainAttrs().stream().
-                                filter(attr -> !uMemb.getPlainAttr(attr.getSchema()).isPresent()).
+                                filter(attr -> uMemb.getPlainAttr(attr.getSchema()).isEmpty()).
                                 forEach(attr -> uMemb.getPlainAttrs().add(attr));
                         oMemb.getVirAttrs().stream().
-                                filter(attr -> !uMemb.getVirAttr(attr.getSchema()).isPresent()).
+                                filter(attr -> uMemb.getVirAttr(attr.getSchema()).isEmpty()).
                                 forEach(attr -> uMemb.getVirAttrs().add(attr));
                     }));
         }

--- a/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/panels/AnyFormPanel.java
+++ b/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/panels/AnyFormPanel.java
@@ -142,12 +142,12 @@ public abstract class AnyFormPanel extends AbstractAnyFormPanel<UserWrapper> {
         // re-add to the updated object any missing plain or virtual attribute (compared to original): this to cope with
         // form layout, which might have not included some plain or virtual attributes
         for (Attr plainAttr : original.getPlainAttrs()) {
-            if (!updated.getPlainAttr(plainAttr.getSchema()).isPresent()) {
+            if (updated.getPlainAttr(plainAttr.getSchema()).isEmpty()) {
                 updated.getPlainAttrs().add(plainAttr);
             }
         }
         for (Attr virAttr : original.getVirAttrs()) {
-            if (!updated.getVirAttr(virAttr.getSchema()).isPresent()) {
+            if (updated.getVirAttr(virAttr.getSchema()).isEmpty()) {
                 updated.getVirAttrs().add(virAttr);
             }
         }
@@ -159,11 +159,11 @@ public abstract class AnyFormPanel extends AbstractAnyFormPanel<UserWrapper> {
                         .cast(updated).getMembership(oMemb.getGroupKey()).ifPresent(uMemb -> {
                     oMemb.getPlainAttrs()
                             .stream().
-                            filter(attr -> !uMemb.getPlainAttr(attr.getSchema()).isPresent()).
+                            filter(attr -> uMemb.getPlainAttr(attr.getSchema()).isEmpty()).
                             forEach(attr -> uMemb.getPlainAttrs().add(attr));
                     oMemb.getVirAttrs()
                             .stream().
-                            filter(attr -> !uMemb.getVirAttr(attr.getSchema()).isPresent()).
+                            filter(attr -> uMemb.getVirAttr(attr.getSchema()).isEmpty()).
                             forEach(attr -> uMemb.getVirAttrs().add(attr));
                 }
                 );

--- a/core/idm/logic/src/main/java/org/apache/syncope/core/logic/ReconciliationLogic.java
+++ b/core/idm/logic/src/main/java/org/apache/syncope/core/logic/ReconciliationLogic.java
@@ -468,7 +468,7 @@ public class ReconciliationLogic extends AbstractTransactionalLogic<EntityTO> {
 
         Any<?> any = getAny(provision, anyKey);
 
-        if (!provision.getMapping().getConnObjectKeyItem().isPresent()) {
+        if (provision.getMapping().getConnObjectKeyItem().isEmpty()) {
             throw new NotFoundException(
                     "ConnObjectKey cannot be determined for mapping " + provision.getMapping().getKey());
         }

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/SyncopeOpenApiCustomizer.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/SyncopeOpenApiCustomizer.java
@@ -139,7 +139,7 @@ public class SyncopeOpenApiCustomizer extends OpenApiCustomizer {
 
         Optional<Parameter> delegatedByHeaderParameter = parameters.stream().
                 filter(p -> p instanceof HeaderParameter && RESTHeaders.DELEGATED_BY.equals(p.getName())).findFirst();
-        if (!delegatedByHeaderParameter.isPresent()) {
+        if (delegatedByHeaderParameter.isEmpty()) {
             HeaderParameter parameter = new HeaderParameter();
             parameter.setName(RESTHeaders.DELEGATED_BY);
             parameter.setRequired(false);

--- a/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/search/FilterVisitor.java
+++ b/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/search/FilterVisitor.java
@@ -83,7 +83,7 @@ public class FilterVisitor extends AbstractSearchConditionVisitor<SearchBean, Fi
         switch (ct) {
             case EQUALS:
             case NOT_EQUALS:
-                if (!specialAttrName.isPresent()) {
+                if (specialAttrName.isEmpty()) {
                     if (specialAttrValue.isPresent() && specialAttrValue.get() == SpecialAttr.NULL) {
                         Filter empty = FilterBuilder.startsWith(AttributeBuilder.build(name, StringUtils.EMPTY));
                         if (ct == ConditionType.NOT_EQUALS) {

--- a/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/search/SearchCondVisitor.java
+++ b/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/search/SearchCondVisitor.java
@@ -128,7 +128,7 @@ public class SearchCondVisitor extends AbstractSearchConditionVisitor<SearchBean
         switch (ct) {
             case EQUALS:
             case NOT_EQUALS:
-                if (!specialAttrName.isPresent()) {
+                if (specialAttrName.isEmpty()) {
                     if (specialAttrValue.isPresent() && specialAttrValue.get() == SpecialAttr.NULL) {
                         attrCond.setType(AttrCond.Type.ISNULL);
                         attrCond.setExpression(null);

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/JPAAnyMatchDAO.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/JPAAnyMatchDAO.java
@@ -165,13 +165,9 @@ public class JPAAnyMatchDAO extends AbstractDAO<Any<?>> implements AnyMatchDAO {
 
                 if (match == null) {
                     Optional<AnyCond> anyCond = cond.getLeaf(AnyCond.class);
-                    if (anyCond.isPresent()) {
-                        match = matches(any, anyCond.get(), not);
-                    } else {
-                        match = cond.getLeaf(AttrCond.class).
-                                map(leaf -> matches(any, leaf, not)).
-                                orElse(null);
-                    }
+                    match = anyCond.map(value -> matches(any, value, not)).orElseGet(() -> cond.getLeaf(AttrCond.class).
+                        map(leaf -> matches(any, leaf, not)).
+                        orElse(null));
                 }
 
                 if (match == null) {

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/notification/DefaultNotificationManager.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/notification/DefaultNotificationManager.java
@@ -343,7 +343,7 @@ public class DefaultNotificationManager implements NotificationManager {
                 if (!notification.getEvents().contains(currentEvent)) {
                     LOG.debug("No events found about {}", any);
                 } else if (anyType == null || any == null
-                        || !notification.getAbout(anyType).isPresent()
+                        || notification.getAbout(anyType).isEmpty()
                         || anyMatchDAO.matches(any, SearchCondConverter.convert(
                                 searchCondVisitor, notification.getAbout(anyType).get().get()))) {
 

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/propagation/AbstractPropagationTaskExecutor.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/propagation/AbstractPropagationTaskExecutor.java
@@ -345,7 +345,7 @@ public abstract class AbstractPropagationTaskExecutor implements PropagationTask
             provision = task.getResource().getProvision(new ObjectClass(task.getObjectClassName())).orElse(null);
             orgUnit = task.getResource().getOrgUnit();
 
-            if (taskInfo.getBeforeObj() == null || !taskInfo.getBeforeObj().isPresent()) {
+            if (taskInfo.getBeforeObj() == null || taskInfo.getBeforeObj().isEmpty()) {
                 // Try to read remote object BEFORE any actual operation
                 beforeObj = provision == null && orgUnit == null
                         ? null

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/propagation/PropagationManagerImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/propagation/PropagationManagerImpl.java
@@ -455,8 +455,7 @@ public class PropagationManagerImpl implements PropagationManager {
         propByRes.asMap().forEach((resourceKey, operation) -> {
             ExternalResource resource = resourceDAO.find(resourceKey);
             Provision provision = Optional.ofNullable(resource).
-                    map(externalResource -> externalResource.getProvision(any.getType()).
-                    orElse(null)).orElse(null);
+                flatMap(externalResource -> externalResource.getProvision(any.getType())).orElse(null);
             Stream<? extends Item> mappingItems = provision == null
                     ? Stream.empty()
                     : MappingUtils.getPropagationItems(provision.getMapping().getItems().stream());

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/DefaultUserPullResultHandler.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/DefaultUserPullResultHandler.java
@@ -478,7 +478,7 @@ public class DefaultUserPullResultHandler extends AbstractPullResultHandler impl
                     attrsToRemove.add(connObjectAttr.getSchema());
                 } else {
                     Optional<Attr> updateAttr = update.getPlainAttr(connObjectAttr.getSchema());
-                    if (!updateAttr.isPresent() || !updateAttr.get().getValues().equals(connObjectAttr.getValues())) {
+                    if (updateAttr.isEmpty() || !updateAttr.get().getValues().equals(connObjectAttr.getValues())) {
                         attrsToRemove.add(connObjectAttr.getSchema());
                         update.getPlainAttrs().add(connObjectAttr);
                     }

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/DefaultUserPushResultHandler.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/DefaultUserPushResultHandler.java
@@ -224,17 +224,16 @@ public class DefaultUserPushResultHandler extends AbstractPushResultHandler impl
 
         // Try to read remote object BEFORE any actual operation
         Optional<ConnectorObject> connObj = MappingUtils.getConnObjectKeyItem(provision).
-                map(connObjectKeyItem -> outboundMatcher.matchByConnObjectKeyValue(
-                profile.getConnector(),
-                connObjectKeyItem,
-                account.getConnObjectKeyValue(),
-                provision,
-                Optional.empty(),
-                Optional.empty())).
-                orElse(Optional.empty());
+            flatMap(connObjectKeyItem -> outboundMatcher.matchByConnObjectKeyValue(
+            profile.getConnector(),
+            connObjectKeyItem,
+            account.getConnObjectKeyValue(),
+            provision,
+            Optional.empty(),
+            Optional.empty()));
         LOG.debug("Match found for linked account {} as {}: {}", account, provision.getObjectClass(), connObj);
 
-        ConnectorObject beforeObj = connObj.isPresent() ? connObj.get() : null;
+        ConnectorObject beforeObj = connObj.orElse(null);
 
         if (profile.isDryRun()) {
             if (beforeObj == null) {

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/InboundMatcher.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/InboundMatcher.java
@@ -174,9 +174,7 @@ public class InboundMatcher {
                     }
 
                     result = matches.stream().filter(match -> match.getAny() != null).findFirst();
-                    if (result.isPresent()) {
-                        virAttrHandler.setValues(result.get().getAny(), connObj);
-                    }
+                    result.ifPresent(pullMatch -> virAttrHandler.setValues(pullMatch.getAny(), connObj));
                 }
             } catch (IllegalArgumentException e) {
                 LOG.warn(e.getMessage());

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/OutboundMatcher.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/OutboundMatcher.java
@@ -128,14 +128,13 @@ public class OutboundMatcher {
                         Optional.of(moreAttrsToGet.toArray(new String[0])),
                         Optional.empty()));
             } else {
-                MappingUtils.getConnObjectKeyItem(provision).ifPresent(connObjectKeyItem -> matchByConnObjectKeyValue(
-                        connector,
-                        connObjectKeyItem,
-                        connObjectKeyValue,
-                        provision,
-                        Optional.of(moreAttrsToGet.toArray(new String[0])),
-                        Optional.empty()).
-                        ifPresent(result::add));
+                MappingUtils.getConnObjectKeyItem(provision).flatMap(connObjectKeyItem -> matchByConnObjectKeyValue(
+                    connector,
+                    connObjectKeyItem,
+                    connObjectKeyValue,
+                    provision,
+                    Optional.of(moreAttrsToGet.toArray(new String[0])),
+                    Optional.empty())).ifPresent(result::add);
             }
         } catch (RuntimeException e) {
             LOG.error("Could not match {} with any existing {}", any, provision.getObjectClass(), e);
@@ -167,7 +166,7 @@ public class OutboundMatcher {
             }
         });
         Optional<String[]> effectiveMATG = Optional.of(Stream.concat(
-                moreAttrsToGet.map(Stream::of).orElse(Stream.empty()),
+            moreAttrsToGet.stream().flatMap(Stream::of),
                 matgFromPropagationActions.stream()).toArray(String[]::new));
 
         Optional<PushCorrelationRule> rule = rule(provision);

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/utils/TemplateUtils.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/utils/TemplateUtils.java
@@ -125,14 +125,14 @@ public class TemplateUtils {
 
     private static void fillRelationships(final GroupableRelatableTO any, final GroupableRelatableTO template) {
         template.getRelationships().stream().
-                filter(relationship -> !any.getRelationship(
-                relationship.getOtherEndKey(), relationship.getOtherEndKey()).isPresent()).
+                filter(relationship -> any.getRelationship(
+                relationship.getOtherEndKey(), relationship.getOtherEndKey()).isEmpty()).
                 forEachOrdered(relationship -> any.getRelationships().add(relationship));
     }
 
     private static void fillMemberships(final GroupableRelatableTO any, final GroupableRelatableTO template) {
         template.getMemberships().stream().
-                filter(membership -> !any.getMembership(membership.getGroupKey()).isPresent()).
+                filter(membership -> any.getMembership(membership.getGroupKey()).isEmpty()).
                 forEachOrdered(membership -> any.getMemberships().add(membership));
     }
 

--- a/ext/saml2sp4ui/logic/src/main/java/org/apache/syncope/core/logic/saml2/SAML2ClientCache.java
+++ b/ext/saml2sp4ui/logic/src/main/java/org/apache/syncope/core/logic/saml2/SAML2ClientCache.java
@@ -66,9 +66,7 @@ public class SAML2ClientCache {
     public static Optional<String> getSPMetadataPath(final String spEntityID) {
         String entityIDPath = StringUtils.replaceChars(
                 StringUtils.removeStart(StringUtils.removeStart(spEntityID, "https://"), "http://"), ":/", "__");
-        return Optional.ofNullable(METADATA_PATH).
-                map(path -> Optional.of(path.resolve(entityIDPath).toAbsolutePath().toString())).
-                orElse(Optional.empty());
+        return Optional.ofNullable(METADATA_PATH).map(path -> path.resolve(entityIDPath).toAbsolutePath().toString());
     }
 
     private final List<SAML2Client> cache = Collections.synchronizedList(new ArrayList<>());

--- a/fit/build-tools/src/main/java/org/apache/syncope/fit/buildtools/cxf/UserServiceImpl.java
+++ b/fit/build-tools/src/main/java/org/apache/syncope/fit/buildtools/cxf/UserServiceImpl.java
@@ -136,7 +136,7 @@ public class UserServiceImpl implements UserService {
                 filter(meta -> !meta.isDeleted() && username.equals(meta.getUser().getUsername())).
                 findFirst().map(UserMetadata::getUser);
 
-        if (!user.isPresent()) {
+        if (user.isEmpty()) {
             throw new NotFoundException(username);
         }
         if (!password.equals(user.get().getPassword())) {

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/SearchITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/SearchITCase.java
@@ -595,7 +595,7 @@ public class SearchITCase extends AbstractITCase {
                         SyncopeClient.getConnObjectTOFiqlSearchConditionBuilder().
                                 is("homePhone").nullValue().query()).build());
         assertTrue(matches.getResult().stream().
-                anyMatch(connObject -> !connObject.getAttr("homePhone").isPresent()));
+                anyMatch(connObject -> connObject.getAttr("homePhone").isEmpty()));
     }
 
     @Test


### PR DESCRIPTION
- Simplify `if(Optional.isPresent())` that can be rewritten in the functional style.
- Simplify optional call chains to use `isPresent()` or `isEmpty()` correctly.

A more accurate description of changes can be seen at: https://github.com/apache/syncope/pull/284/files?w=1

