### PR TITLE
NOJIRA - Turn off bean proxying for WA; fixes typo

### DIFF
--- a/wa/starter/src/main/java/org/apache/syncope/wa/starter/config/SyncopeWAConfiguration.java
+++ b/wa/starter/src/main/java/org/apache/syncope/wa/starter/config/SyncopeWAConfiguration.java
@@ -93,7 +93,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-@Configuration(value = "SyncopeWAConfiguration", proxyBeanMethods = true)
+@Configuration(value = "SyncopeWAConfiguration", proxyBeanMethods = false)
 public class SyncopeWAConfiguration {
 
     @Autowired
@@ -240,7 +240,7 @@ public class SyncopeWAConfiguration {
         return plan -> plan.registerAuditTrailManager(new SyncopeWAAuditTrailManager(restClient));
     }
 
-    @ConditionalOnMissingBean(name = "syncopWaEventRepositoryFilter")
+    @ConditionalOnMissingBean(name = "syncopeWaEventRepositoryFilter")
     @Bean
     public CasEventRepositoryFilter syncopeWAEventRepositoryFilter() {
         return CasEventRepositoryFilter.noOp();
@@ -248,8 +248,10 @@ public class SyncopeWAConfiguration {
 
     @Autowired
     @Bean
-    public CasEventRepository casEventRepository(final WARestClient restClient) {
-        return new SyncopeWAEventRepository(syncopeWAEventRepositoryFilter(), restClient);
+    public CasEventRepository casEventRepository(final WARestClient restClient,
+                                                 @Qualifier("syncopeWAEventRepositoryFilter")
+                                                 final CasEventRepositoryFilter syncopeWAEventRepositoryFilter) {
+        return new SyncopeWAEventRepository(syncopeWAEventRepositoryFilter, restClient);
     }
 
     @Autowired


### PR DESCRIPTION
This pull request turns off and disables CGLIB bean proxying for the WA module. This is the recommended practice from Spring which would help WA in the future to compile better and easier against GraalVM. Without bean proxying, bean methods can no longer call each other directly during construction, as there is no proxy to intercept. Instead, references either need to be passed as auto-wired parameters (the approach used here), or they need to be injected into configuration classes using injections. (The latter approach is generally more preferable, if the number of injected parameters grows unwieldy) 

Also fixes a bean name typo (missing `e`).

This approach might also be used for #287 as well. 