### PR TITLE
SYNCOPE-1723 remove non-reproducible entries from git.properties

### DIFF
--- a/archetype/pom.xml
+++ b/archetype/pom.xml
@@ -131,18 +131,18 @@ under the License.
         <includes>
           <include>core.properties</include>
         </includes>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/core/src/main/resources</targetPath>
+        <targetPath>archetype-resources/core/src/main/resources</targetPath>
       </resource>
       <resource>
         <directory>../core/provisioning-java/src/main/resources</directory>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/core/src/main/resources</targetPath>
+        <targetPath>archetype-resources/core/src/main/resources</targetPath>
       </resource>
       <resource>
         <directory>../core/persistence-jpa/src/main/resources</directory>
         <excludes>
           <exclude>META-INF/spring-persistence.xml</exclude>
         </excludes>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/core/src/main/resources</targetPath>
+        <targetPath>archetype-resources/core/src/main/resources</targetPath>
       </resource>
       <resource>
         <directory>../core/persistence-jpa-json/src/main/resources/</directory>
@@ -150,41 +150,41 @@ under the License.
           <include>META-INF/*</include>
           <include>audit/*</include>
         </includes>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/core/src/main/resources</targetPath>
+        <targetPath>archetype-resources/core/src/main/resources</targetPath>
       </resource>
       <resource>
         <directory>../core/persistence-jpa/src/test/resources/domains</directory>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/core/src/test/resources/domains</targetPath>
+        <targetPath>archetype-resources/core/src/test/resources/domains</targetPath>
       </resource>
       <resource>
         <directory>../fit/core-reference/src/main/resources</directory>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/core/src/main/resources</targetPath>
+        <targetPath>archetype-resources/core/src/main/resources</targetPath>
         <includes>
           <include>log4j2.xml</include>
         </includes>
       </resource>
       <resource>
         <directory>../fit/core-reference/src/test/resources</directory>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/core/src/test/resources</targetPath>
+        <targetPath>archetype-resources/core/src/test/resources</targetPath>
         <includes>
           <include>keystore</include>
         </includes>
       </resource>
       <resource>
         <directory>../fit/core-reference/src/test/resources/scriptedsql</directory>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/core/src/test/resources/scriptedsql</targetPath>
+        <targetPath>archetype-resources/core/src/test/resources/scriptedsql</targetPath>
       </resource>
       <resource>
         <directory>../fit/core-reference/src/test/resources/rest</directory>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/core/src/test/resources/rest</targetPath>
+        <targetPath>archetype-resources/core/src/test/resources/rest</targetPath>
       </resource>
       <resource>
         <directory>../fit/core-reference/src/main/webapp/WEB-INF</directory>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/core/src/main/webapp/WEB-INF</targetPath>
+        <targetPath>archetype-resources/core/src/main/webapp/WEB-INF</targetPath>
       </resource>
       <resource>
         <directory>../fit/core-reference/src/main/resources</directory>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/core/src/test/resources</targetPath>
+        <targetPath>archetype-resources/core/src/test/resources</targetPath>
         <includes>
           <include>core-embedded.properties</include>
           <include>core-all.properties</include>
@@ -195,25 +195,25 @@ under the License.
             
       <resource>
         <directory>../client/idrepo/console/src/main/resources</directory>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/console/src/main/resources</targetPath>
+        <targetPath>archetype-resources/console/src/main/resources</targetPath>
         <includes>
           <include>console.properties</include>
         </includes>
       </resource>
       <resource>
         <directory>../fit/console-reference/src/main/resources</directory>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/console/src/main/resources</targetPath>
+        <targetPath>archetype-resources/console/src/main/resources</targetPath>
         <includes>
           <include>log4j2.xml</include>
         </includes>
       </resource>
       <resource>
         <directory>../fit/console-reference/src/main/webapp/WEB-INF</directory>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/console/src/main/webapp/WEB-INF</targetPath>
+        <targetPath>archetype-resources/console/src/main/webapp/WEB-INF</targetPath>
       </resource>
       <resource>
         <directory>../fit/console-reference/src/main/resources</directory>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/console/src/test/resources</targetPath>
+        <targetPath>archetype-resources/console/src/test/resources</targetPath>
         <includes>
           <include>console-embedded.properties</include>
           <include>console-https.properties</include>
@@ -222,7 +222,7 @@ under the License.
       
       <resource>
         <directory>../client/idrepo/enduser/src/main/resources</directory>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/enduser/src/main/resources</targetPath>
+        <targetPath>archetype-resources/enduser/src/main/resources</targetPath>
         <includes>
           <include>enduser.properties</include>
           <include>customFormLayout.json</include>
@@ -230,18 +230,18 @@ under the License.
       </resource>
       <resource>
         <directory>../fit/enduser-reference/src/main/resources</directory>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/enduser/src/main/resources</targetPath>
+        <targetPath>archetype-resources/enduser/src/main/resources</targetPath>
         <includes>
           <include>log4j2.xml</include>
         </includes>
       </resource>
       <resource>
         <directory>../fit/enduser-reference/src/main/webapp/WEB-INF</directory>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/enduser/src/main/webapp/WEB-INF</targetPath>
+        <targetPath>archetype-resources/enduser/src/main/webapp/WEB-INF</targetPath>
       </resource>
       <resource>
         <directory>../fit/enduser-reference/src/main/resources</directory>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/enduser/src/test/resources</targetPath>
+        <targetPath>archetype-resources/enduser/src/test/resources</targetPath>
         <includes>
           <include>enduser-embedded.properties</include>
           <include>enduser-https.properties</include>
@@ -250,11 +250,11 @@ under the License.
       
       <resource>
         <directory>../sra/src/main/resources</directory>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/sra/src/main/resources</targetPath>
+        <targetPath>archetype-resources/sra/src/main/resources</targetPath>
       </resource>
       <resource>
         <directory>../fit/wa-reference/src/test/resources</directory>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/sra/src/test/resources</targetPath>
+        <targetPath>archetype-resources/sra/src/test/resources</targetPath>
         <includes>
           <include>sra-*.properties</include>
         </includes>
@@ -266,22 +266,22 @@ under the License.
           <include>cas-theme-default.properties</include>
           <include>wa.properties</include>
         </includes>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/wa/src/main/resources</targetPath>
+        <targetPath>archetype-resources/wa/src/main/resources</targetPath>
       </resource>
       <resource>
         <directory>../fit/wa-reference/src/main/webapp/WEB-INF</directory>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/wa/src/main/webapp/WEB-INF</targetPath>
+        <targetPath>archetype-resources/wa/src/main/webapp/WEB-INF</targetPath>
       </resource>
       <resource>
         <directory>../fit/wa-reference/src/main/resources</directory>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/wa/src/main/resources</targetPath>
+        <targetPath>archetype-resources/wa/src/main/resources</targetPath>
         <includes>
           <include>log4j2.xml</include>
         </includes>
       </resource>
       <resource>
         <directory>../fit/wa-reference/src/main/resources</directory>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/wa/src/test/resources</targetPath>
+        <targetPath>archetype-resources/wa/src/test/resources</targetPath>
         <includes>
           <include>wa-embedded.properties</include>
         </includes>
@@ -289,7 +289,7 @@ under the License.
 
       <resource>
         <directory>../fit/wa-reference/src/test/resources</directory>
-        <targetPath>${project.build.outputDirectory}/archetype-resources/fit/src/test/resources</targetPath>
+        <targetPath>archetype-resources/fit/src/test/resources</targetPath>
         <includes>
           <include>keystore.jks</include>
         </includes>

--- a/fit/build-tools/pom.xml
+++ b/fit/build-tools/pom.xml
@@ -231,7 +231,8 @@ under the License.
 
                 <jar destfile="${bundles.directory}/net.tirasa.connid.bundles.soap-${connid.soap.version}-bundle.jar"
                      basedir="${bundles.directory}/soap"
-                     filesetmanifest="merge"/>                  
+                     filesetmanifest="merge"
+                     modificationtime="${project.build.outputTimestamp}"/>                  
 
                 <delete dir="${bundles.directory}/soap"/>
               </target>

--- a/pom.xml
+++ b/pom.xml
@@ -1443,8 +1443,17 @@ under the License.
           <configuration>
             <verbose>true</verbose>
             <dateFormat>yyyy-MM-dd'T'HH:mm:ssZ</dateFormat>
+            <dateFormatTimeZone>Zulu</dateFormatTimeZone>
             <generateGitPropertiesFile>true</generateGitPropertiesFile>
             <generateGitPropertiesFilename>${project.build.outputDirectory}/git.properties</generateGitPropertiesFilename>
+            <excludeProperties>
+              <excludeProperty>git.build.time</excludeProperty>
+              <excludeProperty>git.build.user.*</excludeProperty>
+              <excludeProperty>git.build.host</excludeProperty>
+              <excludeProperty>git.commit.user.*</excludeProperty>
+              <excludeProperty>git.tags</excludeProperty>
+              <excludeProperty>git.total.commit.count</excludeProperty>
+            </excludeProperties>
           </configuration>
         </plugin>
 


### PR DESCRIPTION
see https://issues.apache.org/jira/browse/SYNCOPE-1723

this PR fixes one source of non-reproducible bits

for full path in properties, it would be easy to change value in pom.xml https://github.com/apache/syncope/blob/master/pom.xml#L513 to drop the absolute path, but I don't know if this will break for the builder: what i doubt is that people consuming the resulting artifact can use the value, because the path does not point to anything useful beyond the builder