### PR TITLE
SYNCOPE-1765: encrypt/decrypt values/settings for AuthModuleConf

### DIFF
--- a/common/am/lib/src/main/java/org/apache/syncope/common/lib/AbstractLDAPConf.java
+++ b/common/am/lib/src/main/java/org/apache/syncope/common/lib/AbstractLDAPConf.java
@@ -577,4 +577,9 @@ public abstract class AbstractLDAPConf implements Serializable {
     public void setBinaryAttributes(final List<String> binaryAttributes) {
         this.binaryAttributes = binaryAttributes;
     }
+
+    @Override
+    protected AbstractLDAPConf clone() throws CloneNotSupportedException {
+        return (AbstractLDAPConf) super.clone();
+    }
 }

--- a/common/am/lib/src/main/java/org/apache/syncope/common/lib/auth/AbstractOAuth20AuthModuleConf.java
+++ b/common/am/lib/src/main/java/org/apache/syncope/common/lib/auth/AbstractOAuth20AuthModuleConf.java
@@ -108,4 +108,20 @@ public abstract class AbstractOAuth20AuthModuleConf extends Pac4jAuthModuleConf 
     public void setUserIdAttribute(final String userIdAttribute) {
         this.userIdAttribute = userIdAttribute;
     }
+
+    @Override
+    protected AbstractOAuth20AuthModuleConf clone() throws CloneNotSupportedException {
+        return (AbstractOAuth20AuthModuleConf) super.clone();
+    }
+
+    @Override
+    public AuthModuleConf cipher(final Cipher encoder) {
+        try {
+            final AbstractOAuth20AuthModuleConf conf = clone();
+            conf.setClientSecret(encoder.cipher(getClientSecret()));
+            return conf;
+        } catch (final Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
 }

--- a/common/am/lib/src/main/java/org/apache/syncope/common/lib/auth/AuthModuleConf.java
+++ b/common/am/lib/src/main/java/org/apache/syncope/common/lib/auth/AuthModuleConf.java
@@ -24,7 +24,12 @@ import org.apache.syncope.common.lib.BaseBean;
 import org.apache.syncope.common.lib.to.AuthModuleTO;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, include = JsonTypeInfo.As.PROPERTY, property = "_class")
-public interface AuthModuleConf extends BaseBean {
+public interface AuthModuleConf extends BaseBean, Cloneable {
+
+    @FunctionalInterface
+    interface Cipher {
+        String cipher(String value) throws Exception;
+    }
 
     interface Mapper {
 
@@ -56,4 +61,8 @@ public interface AuthModuleConf extends BaseBean {
     }
 
     Map<String, Object> map(AuthModuleTO authModule, Mapper mapper);
+
+    default AuthModuleConf cipher(Cipher encoder) throws Exception {
+        return this;
+    }
 }

--- a/common/am/lib/src/main/java/org/apache/syncope/common/lib/auth/DuoMfaAuthModuleConf.java
+++ b/common/am/lib/src/main/java/org/apache/syncope/common/lib/auth/DuoMfaAuthModuleConf.java
@@ -74,4 +74,22 @@ public class DuoMfaAuthModuleConf implements MFAAuthModuleConf {
     public Map<String, Object> map(final AuthModuleTO authModule, final Mapper mapper) {
         return mapper.map(authModule, this);
     }
+
+    @Override
+    protected DuoMfaAuthModuleConf clone() throws CloneNotSupportedException {
+        return (DuoMfaAuthModuleConf) super.clone();
+    }
+
+    @Override
+    public AuthModuleConf cipher(final Cipher encoder) {
+        try {
+            final DuoMfaAuthModuleConf conf = clone();
+            conf.setSecretKey(encoder.cipher(getSecretKey()));
+            conf.setIntegrationKey(encoder.cipher(getIntegrationKey()));
+            conf.setApplicationKey(encoder.cipher(getApplicationKey()));
+            return conf;
+        } catch (final Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
 }

--- a/common/am/lib/src/main/java/org/apache/syncope/common/lib/auth/LDAPAuthModuleConf.java
+++ b/common/am/lib/src/main/java/org/apache/syncope/common/lib/auth/LDAPAuthModuleConf.java
@@ -247,4 +247,15 @@ public class LDAPAuthModuleConf extends AbstractLDAPConf implements AuthModuleCo
     public Map<String, Object> map(final AuthModuleTO authModule, final Mapper mapper) {
         return mapper.map(authModule, this);
     }
+
+    @Override
+    public AuthModuleConf cipher(final Cipher encoder) {
+        try {
+            final LDAPAuthModuleConf conf = (LDAPAuthModuleConf) clone();
+            conf.setBindCredential(encoder.cipher(getBindCredential()));
+            return conf;
+        } catch (final Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
 }

--- a/common/am/lib/src/main/java/org/apache/syncope/common/lib/auth/SAML2IdPAuthModuleConf.java
+++ b/common/am/lib/src/main/java/org/apache/syncope/common/lib/auth/SAML2IdPAuthModuleConf.java
@@ -390,4 +390,21 @@ public class SAML2IdPAuthModuleConf extends Pac4jAuthModuleConf implements AuthM
     public Map<String, Object> map(final AuthModuleTO authModule, final Mapper mapper) {
         return mapper.map(authModule, this);
     }
+
+    @Override
+    protected SAML2IdPAuthModuleConf clone() throws CloneNotSupportedException {
+        return (SAML2IdPAuthModuleConf) super.clone();
+    }
+
+    @Override
+    public AuthModuleConf cipher(final Cipher cipher) {
+        try {
+            final SAML2IdPAuthModuleConf conf = clone();
+            conf.setKeystorePassword(cipher.cipher(getKeystorePassword()));
+            conf.setPrivateKeyPassword(cipher.cipher(getPrivateKeyPassword()));
+            return conf;
+        } catch (final Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
 }

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/ProvisioningContext.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/ProvisioningContext.java
@@ -194,7 +194,10 @@ import org.springframework.scheduling.quartz.SchedulerFactoryBean;
 import org.springframework.transaction.PlatformTransactionManager;
 
 @EnableAsync
-@EnableConfigurationProperties(ProvisioningProperties.class)
+@EnableConfigurationProperties({
+    SecurityProperties.class,
+    ProvisioningProperties.class
+})
 @Configuration(proxyBeanMethods = false)
 public class ProvisioningContext {
 
@@ -833,8 +836,9 @@ public class ProvisioningContext {
 
     @ConditionalOnMissingBean
     @Bean
-    public AuthModuleDataBinder authModuleDataBinder(final EntityFactory entityFactory) {
-        return new AuthModuleDataBinderImpl(entityFactory);
+    public AuthModuleDataBinder authModuleDataBinder(final EntityFactory entityFactory,
+                                                     final SecurityProperties securityProperties) {
+        return new AuthModuleDataBinderImpl(entityFactory, securityProperties);
     }
 
     @ConditionalOnMissingBean

--- a/core/provisioning-java/src/test/java/org/apache/syncope/core/provisioning/java/AuthModuleDataBinderTest.java
+++ b/core/provisioning-java/src/test/java/org/apache/syncope/core/provisioning/java/AuthModuleDataBinderTest.java
@@ -1,0 +1,95 @@
+package org.apache.syncope.core.provisioning.java;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.util.UUID;
+import org.apache.syncope.common.lib.auth.AuthModuleConf;
+import org.apache.syncope.common.lib.auth.LDAPAuthModuleConf;
+import org.apache.syncope.common.lib.auth.OIDCAuthModuleConf;
+import org.apache.syncope.common.lib.auth.SAML2IdPAuthModuleConf;
+import org.apache.syncope.common.lib.auth.StaticAuthModuleConf;
+import org.apache.syncope.common.lib.to.AuthModuleTO;
+import org.apache.syncope.core.persistence.api.entity.EntityFactory;
+import org.apache.syncope.core.persistence.api.entity.am.AuthModule;
+import org.apache.syncope.core.provisioning.api.data.AuthModuleDataBinder;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional("Master")
+public class AuthModuleDataBinderTest extends AbstractTest {
+    @Autowired
+    private AuthModuleDataBinder authModuleDataBinder;
+
+    @Autowired
+    private EntityFactory entityFactory;
+
+    @Test
+    public void verifySAML2IdPAuthConf() {
+        final SAML2IdPAuthModuleConf samlAuth = new SAML2IdPAuthModuleConf();
+        samlAuth.setKeystorePassword(UUID.randomUUID().toString());
+        samlAuth.setPrivateKeyPassword(UUID.randomUUID().toString());
+        
+        final AuthModuleTO originalAuthModuleTO = new AuthModuleTO();
+        originalAuthModuleTO.setConf(samlAuth);
+        AuthModule authModule = authModuleDataBinder.create(originalAuthModuleTO);
+        SAML2IdPAuthModuleConf samlAuthModuleConfCreated = (SAML2IdPAuthModuleConf)  authModule.getConf();
+        assertNotEquals(samlAuthModuleConfCreated.getKeystorePassword(), samlAuth.getKeystorePassword());
+        assertNotEquals(samlAuthModuleConfCreated.getPrivateKeyPassword(), samlAuth.getPrivateKeyPassword());
+
+        AuthModuleTO authModuleTO = authModuleDataBinder.getAuthModuleTO(authModule);
+        final SAML2IdPAuthModuleConf finalConf = (SAML2IdPAuthModuleConf) authModuleTO.getConf();
+        assertEquals(finalConf.getKeystorePassword(), samlAuth.getKeystorePassword());
+        assertEquals(finalConf.getPrivateKeyPassword(), samlAuth.getPrivateKeyPassword());
+    }
+
+    @Test
+    public void verifyStaticAuthModuleConf() {
+        final StaticAuthModuleConf staticAuth = new StaticAuthModuleConf();
+        staticAuth.getUsers().put("Syncope", "P@$$w0rd");
+        AuthModule authModule = getAuthModule(staticAuth);
+        AuthModuleTO authModuleTO = authModuleDataBinder.getAuthModuleTO(authModule);
+        final StaticAuthModuleConf finalConf = (StaticAuthModuleConf) authModuleTO.getConf();
+        assertEquals(finalConf.getUsers(), staticAuth.getUsers());
+    }
+
+    @Test
+    public void verifyLdapAuthConf() {
+        final LDAPAuthModuleConf oidcConf = new LDAPAuthModuleConf();
+        oidcConf.setBindCredential(UUID.randomUUID().toString());
+
+        final AuthModuleTO originalAuthModuleTO = new AuthModuleTO();
+        originalAuthModuleTO.setConf(oidcConf);
+        AuthModule authModule = authModuleDataBinder.create(originalAuthModuleTO);
+        LDAPAuthModuleConf samlAuthModuleConfCreated = (LDAPAuthModuleConf)  authModule.getConf();
+        assertNotEquals(samlAuthModuleConfCreated.getBindCredential(), oidcConf.getBindCredential());
+
+        AuthModuleTO authModuleTO = authModuleDataBinder.getAuthModuleTO(authModule);
+        final LDAPAuthModuleConf finalConf = (LDAPAuthModuleConf) authModuleTO.getConf();
+        assertEquals(finalConf.getBindCredential(), oidcConf.getBindCredential());
+    }
+
+    @Test
+    public void verifyOidcAuthConf() {
+        final OIDCAuthModuleConf oidcConf = new OIDCAuthModuleConf();
+        oidcConf.setClientSecret(UUID.randomUUID().toString());
+        oidcConf.setId(UUID.randomUUID().toString());
+
+        final AuthModuleTO originalAuthModuleTO = new AuthModuleTO();
+        originalAuthModuleTO.setConf(oidcConf);
+        AuthModule authModule = authModuleDataBinder.create(originalAuthModuleTO);
+        OIDCAuthModuleConf samlAuthModuleConfCreated = (OIDCAuthModuleConf)  authModule.getConf();
+        assertNotEquals(samlAuthModuleConfCreated.getClientSecret(), oidcConf.getClientSecret());
+
+        AuthModuleTO authModuleTO = authModuleDataBinder.getAuthModuleTO(authModule);
+        final OIDCAuthModuleConf finalConf = (OIDCAuthModuleConf) authModuleTO.getConf();
+        assertEquals(finalConf.getClientSecret(), oidcConf.getClientSecret());
+    }
+
+    private AuthModule getAuthModule(final AuthModuleConf authModuleConf) {
+        AuthModule authModule = entityFactory.newEntity(AuthModule.class);
+        authModule.setConf(authModuleConf);
+        return authModule;
+    }
+}

--- a/core/provisioning-java/src/test/java/org/apache/syncope/core/provisioning/java/AuthModuleDataBinderTest.java
+++ b/core/provisioning-java/src/test/java/org/apache/syncope/core/provisioning/java/AuthModuleDataBinderTest.java
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.syncope.core.provisioning.java;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;


### PR DESCRIPTION
cc @fmartelli 

https://issues.apache.org/jira/browse/SYNCOPE-1765

Allow AuthModuleConf implementations to support selective encryption/decryption of sensitive settings. For backward compatibility, values that cannot be decrypted are returned back verbatim.