### PR TITLE
Switch to SPDX identifier for the license

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@ under the License.
 
   <licenses>
     <license>
-      <name>Apache License, Version 2.0</name>
+      <name>Apache-2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
       <distribution>repo</distribution>
     </license>


### PR DESCRIPTION
https://maven.apache.org/pom.html#Licenses
"Using an [SPDX identifier](https://spdx.org/licenses/) as the license name is recommended."