### PR TITLE
[SYNCOPE-1797] Compatibility of SCIM 2.0 requests from Microsoft Entra

### DIFF
--- a/ext/scimv2/logic/pom.xml
+++ b/ext/scimv2/logic/pom.xml
@@ -61,7 +61,19 @@ under the License.
       <groupId>org.antlr</groupId>
       <artifactId>antlr4-runtime</artifactId>
     </dependency>
-    
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/ext/scimv2/logic/pom.xml
+++ b/ext/scimv2/logic/pom.xml
@@ -64,16 +64,9 @@ under the License.
 
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.mockito</groupId>
       <artifactId>mockito-junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
-
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/ext/scimv2/logic/src/main/java/org/apache/syncope/core/logic/SCIMDataBinder.java
+++ b/ext/scimv2/logic/src/main/java/org/apache/syncope/core/logic/SCIMDataBinder.java
@@ -815,6 +815,17 @@ public class SCIMDataBinder {
 
             case "active":
                 if (!CollectionUtils.isEmpty(op.getValue())) {
+
+                    // Workaround for Microsoft Entra being not SCIM compliant on PATCH requests
+                    if (op.getValue().get(0) instanceof String) {
+                        String a = (String) op.getValue().get(0);
+                        if (a.equalsIgnoreCase("true")) {
+                            op.setValue(List.of(true));
+                        } else if (a.equalsIgnoreCase("false")) {
+                            op.setValue(List.of(false));
+                        }
+                    }
+
                     statusR = new StatusR.Builder(
                             before.getKey(),
                             (boolean) op.getValue().get(0) ? StatusRType.REACTIVATE : StatusRType.SUSPEND).

--- a/ext/scimv2/logic/src/main/java/org/apache/syncope/core/logic/SCIMDataBinder.java
+++ b/ext/scimv2/logic/src/main/java/org/apache/syncope/core/logic/SCIMDataBinder.java
@@ -819,11 +819,7 @@ public class SCIMDataBinder {
                     // Workaround for Microsoft Entra being not SCIM compliant on PATCH requests
                     if (op.getValue().get(0) instanceof String) {
                         String a = (String) op.getValue().get(0);
-                        if (a.equalsIgnoreCase("true")) {
-                            op.setValue(List.of(true));
-                        } else if (a.equalsIgnoreCase("false")) {
-                            op.setValue(List.of(false));
-                        }
+                        op.setValue(List.of(BooleanUtils.toBoolean(a)));
                     }
 
                     statusR = new StatusR.Builder(

--- a/ext/scimv2/logic/src/test/java/org/apache/syncope/core/logic/SCIMDataBinderTest.java
+++ b/ext/scimv2/logic/src/test/java/org/apache/syncope/core/logic/SCIMDataBinderTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.syncope.core.logic;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.apache.syncope.common.lib.scim.SCIMConf;
+import org.apache.syncope.common.lib.to.UserTO;
+import org.apache.syncope.core.logic.scim.SCIMConfManager;
+import org.apache.syncope.core.spring.security.AuthDataAccessor;
+import org.apache.syncope.ext.scimv2.api.data.SCIMPatchOperation;
+import org.apache.syncope.ext.scimv2.api.data.SCIMPatchPath;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@ExtendWith(MockitoExtension.class)
+class IVUSCIMDataBinderTest {
+
+    private SCIMDataBinder dataBinder;
+
+    private static Stream<String> getValue() {
+        return Stream.of("True", "False");
+    }
+
+    @BeforeAll
+    void setup() {
+        SCIMConfManager scimConfManager = mock(SCIMConfManager.class);
+        when(scimConfManager.get()).thenReturn(new SCIMConf());
+        UserLogic userLogic = mock(UserLogic.class);
+        AuthDataAccessor authDataAccessor = mock(AuthDataAccessor.class);
+        dataBinder = new SCIMDataBinder(scimConfManager, userLogic, authDataAccessor);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getValue")
+    void toUserUpdate(final String value) {
+        SCIMPatchOperation operation = new SCIMPatchOperation();
+        SCIMPatchPath scimPatchPath = new SCIMPatchPath();
+        scimPatchPath.setAttribute("active");
+        operation.setPath(scimPatchPath);
+        operation.setValue(List.of(value));
+        assertDoesNotThrow(() -> dataBinder.toUserUpdate(new UserTO(), operation));
+    }
+}


### PR DESCRIPTION
Following the [SCIM 2.0 specification](https://www.rfc-editor.org/rfc/rfc7643#section-4.1.1), the singular attribute `active` is specified of type Boolean. Deviating from this, some cloud providers (namely Microsoft Entra) on PATCH requests send this as a string value of `"True"` or `"False"`. 

To ensure compatibility, with this PR string representations (`"true"` and `"false"`, case insensitive) also get interpreted as Boolean values.

(Apache id: philipp-trenz)