### PR TITLE
Update CXF, Spring Framework and Security dependencies to fix CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -411,8 +411,8 @@ under the License.
 
     <jackson.version>2.12.7</jackson.version>
 
-    <spring.version>5.2.24.RELEASE</spring.version>
-    <spring-security.version>5.3.13.RELEASE</spring-security.version>
+    <spring.version>5.3.33</spring.version>
+    <spring-security.version>5.7.12</spring-security.version>
 
     <openjpa.version>3.2.2</openjpa.version>
     <hikaricp.version>4.0.3</hikaricp.version>

--- a/pom.xml
+++ b/pom.xml
@@ -407,7 +407,7 @@ under the License.
     <connid.okta.version>3.0.1</connid.okta.version>
     <connid.cmd.version>0.5</connid.cmd.version>
 
-    <cxf.version>3.3.13</cxf.version>
+    <cxf.version>3.5.6</cxf.version>
 
     <jackson.version>2.12.7</jackson.version>
 


### PR DESCRIPTION
3 CVEs detected on this branch needed an fix. 
Upgrade to cxf 3.5.6 , spring 5.3.33 , spring security to 5.7.12 and owasp-java-html-sanitizer to 20211018.1 fix them.
Unit tests are stable, and our integration tests did not show regression.