### PR TITLE
SYNCOPE-1835: Support Credential Criteria for LDAP authentication

### DIFF
--- a/common/am/lib/src/main/java/org/apache/syncope/common/lib/auth/LDAPAuthModuleConf.java
+++ b/common/am/lib/src/main/java/org/apache/syncope/common/lib/auth/LDAPAuthModuleConf.java
@@ -157,6 +157,17 @@ public class LDAPAuthModuleConf extends AbstractLDAPConf implements AuthModuleCo
      */
     private boolean collectDnAttribute;
 
+    /**
+     * A number of authentication handlers are allowed to determine whether they can operate on the provided credential
+     * and as such lend themselves to be tried and tested during the authentication handler selection phase.
+     * The credential criteria may be one of the following options:<ul>
+     * <li>1) A regular expression pattern that is tested against the credential identifier.</li>
+     * <li>2) A fully qualified class name of your own design that implements {@code Predicate}.</li>
+     * <li>3) Path to an external Groovy script that implements the same interface.</li>
+     * </ul>
+     */
+    private String credentialCriteria;
+    
     public AuthenticationType getAuthenticationType() {
         return authenticationType;
     }
@@ -241,6 +252,14 @@ public class LDAPAuthModuleConf extends AbstractLDAPConf implements AuthModuleCo
 
     public void setCollectDnAttribute(final boolean collectDnAttribute) {
         this.collectDnAttribute = collectDnAttribute;
+    }
+
+    public String getCredentialCriteria() {
+        return credentialCriteria;
+    }
+
+    public void setCredentialCriteria(final String credentialCriteria) {
+        this.credentialCriteria = credentialCriteria;
     }
 
     @Override

--- a/wa/bootstrap/src/main/java/org/apache/syncope/wa/bootstrap/mapping/AuthModulePropertySourceMapper.java
+++ b/wa/bootstrap/src/main/java/org/apache/syncope/wa/bootstrap/mapping/AuthModulePropertySourceMapper.java
@@ -125,8 +125,8 @@ public class AuthModulePropertySourceMapper extends PropertySourceMapper impleme
         props.setAllowMultiplePrincipalAttributeValues(conf.isAllowMultiplePrincipalAttributeValues());
         props.setAdditionalAttributes(conf.getAdditionalAttributes());
         props.setAllowMissingPrincipalAttributeValue(conf.isAllowMissingPrincipalAttributeValue());
-        props.setCollectDnAttribute(props.isCollectDnAttribute());
-
+        props.setCollectDnAttribute(conf.isCollectDnAttribute());
+        props.setCredentialCriteria(conf.getCredentialCriteria());
         props.getPasswordPolicy().setType(AbstractLdapProperties.LdapType.valueOf(conf.getLdapType().name()));
 
         fill(props, conf);


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/SYNCOPE-1835

<img width="781" alt="image" src="https://github.com/user-attachments/assets/9cecf2e8-dcff-4961-be49-d225416103dc">

PS Also fixes a small bug wrt to collecting the DN attribute.