### PR TITLE
Chore: remove service annotation from spring beans

### DIFF
--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/RESTProperties.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/RESTProperties.java
@@ -20,10 +20,12 @@ package org.apache.syncope.core.rest.cxf;
 
 import org.apache.syncope.core.provisioning.java.ExecutorProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.NestedConfigurationProperty;
 
 @ConfigurationProperties("rest")
 public class RESTProperties {
 
+    @NestedConfigurationProperty
     private final ExecutorProperties batchExecutor = new ExecutorProperties();
 
     public ExecutorProperties getBatchExecutor() {

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AccessTokenServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AccessTokenServiceImpl.java
@@ -30,9 +30,7 @@ import org.apache.syncope.common.rest.api.service.AccessTokenService;
 import org.apache.syncope.core.logic.AccessTokenLogic;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Service;
 
-@Service
 public class AccessTokenServiceImpl extends AbstractService implements AccessTokenService {
 
     protected final AccessTokenLogic logic;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AnyObjectServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AnyObjectServiceImpl.java
@@ -35,9 +35,7 @@ import org.apache.syncope.core.logic.AnyObjectLogic;
 import org.apache.syncope.core.persistence.api.dao.AnyDAO;
 import org.apache.syncope.core.persistence.api.dao.AnyObjectDAO;
 import org.apache.syncope.core.persistence.api.search.SearchCondVisitor;
-import org.springframework.stereotype.Service;
 
-@Service
 public class AnyObjectServiceImpl extends AbstractAnyService<AnyObjectTO, AnyObjectCR, AnyObjectUR>
         implements AnyObjectService {
 

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AnyTypeClassServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AnyTypeClassServiceImpl.java
@@ -25,9 +25,7 @@ import org.apache.syncope.common.lib.to.AnyTypeClassTO;
 import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.common.rest.api.service.AnyTypeClassService;
 import org.apache.syncope.core.logic.AnyTypeClassLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class AnyTypeClassServiceImpl extends AbstractService implements AnyTypeClassService {
 
     protected final AnyTypeClassLogic logic;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AnyTypeServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AnyTypeServiceImpl.java
@@ -25,9 +25,7 @@ import org.apache.syncope.common.lib.to.AnyTypeTO;
 import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.common.rest.api.service.AnyTypeService;
 import org.apache.syncope.core.logic.AnyTypeLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class AnyTypeServiceImpl extends AbstractService implements AnyTypeService {
 
     protected final AnyTypeLogic logic;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AuditServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AuditServiceImpl.java
@@ -27,9 +27,7 @@ import org.apache.syncope.common.rest.api.beans.AuditQuery;
 import org.apache.syncope.common.rest.api.service.AuditService;
 import org.apache.syncope.core.logic.AuditLogic;
 import org.springframework.data.domain.Page;
-import org.springframework.stereotype.Service;
 
-@Service
 public class AuditServiceImpl extends AbstractService implements AuditService {
 
     protected final AuditLogic logic;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/CommandServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/CommandServiceImpl.java
@@ -25,9 +25,7 @@ import org.apache.syncope.common.rest.api.beans.CommandQuery;
 import org.apache.syncope.common.rest.api.service.CommandService;
 import org.apache.syncope.core.logic.CommandLogic;
 import org.springframework.data.domain.Page;
-import org.springframework.stereotype.Service;
 
-@Service
 public class CommandServiceImpl extends AbstractService implements CommandService {
 
     protected final CommandLogic logic;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/DelegationServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/DelegationServiceImpl.java
@@ -25,9 +25,7 @@ import org.apache.syncope.common.lib.to.DelegationTO;
 import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.common.rest.api.service.DelegationService;
 import org.apache.syncope.core.logic.DelegationLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class DelegationServiceImpl extends AbstractService implements DelegationService {
 
     protected final DelegationLogic logic;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/DynRealmServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/DynRealmServiceImpl.java
@@ -25,9 +25,7 @@ import org.apache.syncope.common.lib.to.DynRealmTO;
 import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.common.rest.api.service.DynRealmService;
 import org.apache.syncope.core.logic.DynRealmLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class DynRealmServiceImpl extends AbstractService implements DynRealmService {
 
     protected final DynRealmLogic logic;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/FIQLQueryServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/FIQLQueryServiceImpl.java
@@ -25,9 +25,7 @@ import org.apache.syncope.common.lib.to.FIQLQueryTO;
 import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.common.rest.api.service.FIQLQueryService;
 import org.apache.syncope.core.logic.FIQLQueryLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class FIQLQueryServiceImpl extends AbstractService implements FIQLQueryService {
 
     protected final FIQLQueryLogic logic;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/GroupServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/GroupServiceImpl.java
@@ -32,9 +32,7 @@ import org.apache.syncope.core.logic.GroupLogic;
 import org.apache.syncope.core.persistence.api.dao.AnyDAO;
 import org.apache.syncope.core.persistence.api.dao.GroupDAO;
 import org.apache.syncope.core.persistence.api.search.SearchCondVisitor;
-import org.springframework.stereotype.Service;
 
-@Service
 public class GroupServiceImpl extends AbstractAnyService<GroupTO, GroupCR, GroupUR> implements GroupService {
 
     protected final GroupDAO groupDAO;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/ImplementationServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/ImplementationServiceImpl.java
@@ -25,9 +25,7 @@ import org.apache.syncope.common.lib.to.ImplementationTO;
 import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.common.rest.api.service.ImplementationService;
 import org.apache.syncope.core.logic.ImplementationLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class ImplementationServiceImpl extends AbstractService implements ImplementationService {
 
     protected final ImplementationLogic logic;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/MailTemplateServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/MailTemplateServiceImpl.java
@@ -32,9 +32,7 @@ import org.apache.syncope.common.lib.types.MailTemplateFormat;
 import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.common.rest.api.service.MailTemplateService;
 import org.apache.syncope.core.logic.MailTemplateLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class MailTemplateServiceImpl extends AbstractService implements MailTemplateService {
 
     protected final MailTemplateLogic logic;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/NotificationServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/NotificationServiceImpl.java
@@ -27,9 +27,7 @@ import org.apache.syncope.common.lib.types.JobAction;
 import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.common.rest.api.service.NotificationService;
 import org.apache.syncope.core.logic.NotificationLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class NotificationServiceImpl extends AbstractService implements NotificationService {
 
     protected final NotificationLogic logic;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/PolicyServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/PolicyServiceImpl.java
@@ -26,9 +26,7 @@ import org.apache.syncope.common.lib.types.PolicyType;
 import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.common.rest.api.service.PolicyService;
 import org.apache.syncope.core.logic.PolicyLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class PolicyServiceImpl extends AbstractService implements PolicyService {
 
     protected final PolicyLogic logic;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/RealmServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/RealmServiceImpl.java
@@ -31,9 +31,7 @@ import org.apache.syncope.common.rest.api.beans.RealmQuery;
 import org.apache.syncope.common.rest.api.service.RealmService;
 import org.apache.syncope.core.logic.RealmLogic;
 import org.springframework.data.domain.Page;
-import org.springframework.stereotype.Service;
 
-@Service
 public class RealmServiceImpl extends AbstractService implements RealmService {
 
     protected final RealmLogic logic;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/RelationshipTypeServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/RelationshipTypeServiceImpl.java
@@ -25,9 +25,7 @@ import org.apache.syncope.common.lib.to.RelationshipTypeTO;
 import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.common.rest.api.service.RelationshipTypeService;
 import org.apache.syncope.core.logic.RelationshipTypeLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class RelationshipTypeServiceImpl extends AbstractService implements RelationshipTypeService {
 
     protected final RelationshipTypeLogic logic;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/ReportServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/ReportServiceImpl.java
@@ -28,9 +28,7 @@ import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.common.rest.api.service.ReportService;
 import org.apache.syncope.core.logic.AbstractExecutableLogic;
 import org.apache.syncope.core.logic.ReportLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class ReportServiceImpl extends AbstractExecutableService implements ReportService {
 
     protected final ReportLogic logic;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/RoleServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/RoleServiceImpl.java
@@ -32,9 +32,7 @@ import org.apache.syncope.common.lib.to.RoleTO;
 import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.common.rest.api.service.RoleService;
 import org.apache.syncope.core.logic.RoleLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class RoleServiceImpl extends AbstractService implements RoleService {
 
     protected final RoleLogic logic;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/SchemaServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/SchemaServiceImpl.java
@@ -30,9 +30,7 @@ import org.apache.syncope.common.rest.api.beans.SchemaQuery;
 import org.apache.syncope.common.rest.api.service.SchemaService;
 import org.apache.syncope.core.logic.SchemaLogic;
 import org.identityconnectors.common.CollectionUtil;
-import org.springframework.stereotype.Service;
 
-@Service
 public class SchemaServiceImpl extends AbstractService implements SchemaService {
 
     protected final SchemaLogic logic;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/SecurityQuestionServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/SecurityQuestionServiceImpl.java
@@ -25,9 +25,7 @@ import org.apache.syncope.common.lib.to.SecurityQuestionTO;
 import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.common.rest.api.service.SecurityQuestionService;
 import org.apache.syncope.core.logic.SecurityQuestionLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class SecurityQuestionServiceImpl extends AbstractService implements SecurityQuestionService {
 
     protected final SecurityQuestionLogic logic;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/SyncopeServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/SyncopeServiceImpl.java
@@ -56,9 +56,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Service;
 
-@Service
 public class SyncopeServiceImpl extends AbstractService implements SyncopeService {
 
     protected final SyncopeLogic logic;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/TaskServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/TaskServiceImpl.java
@@ -41,10 +41,8 @@ import org.apache.syncope.common.rest.api.service.TaskService;
 import org.apache.syncope.core.logic.AbstractExecutableLogic;
 import org.apache.syncope.core.logic.TaskLogic;
 import org.springframework.data.domain.Page;
-import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 
-@Service
 public class TaskServiceImpl extends AbstractExecutableService implements TaskService {
 
     protected final TaskLogic logic;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/UserSelfServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/UserSelfServiceImpl.java
@@ -34,9 +34,7 @@ import org.apache.syncope.common.rest.api.beans.ComplianceQuery;
 import org.apache.syncope.common.rest.api.service.UserSelfService;
 import org.apache.syncope.core.logic.SyncopeLogic;
 import org.apache.syncope.core.logic.UserLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class UserSelfServiceImpl extends AbstractService implements UserSelfService {
 
     protected final UserLogic logic;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/UserServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/UserServiceImpl.java
@@ -31,9 +31,7 @@ import org.apache.syncope.core.logic.UserLogic;
 import org.apache.syncope.core.persistence.api.dao.AnyDAO;
 import org.apache.syncope.core.persistence.api.dao.UserDAO;
 import org.apache.syncope.core.persistence.api.search.SearchCondVisitor;
-import org.springframework.stereotype.Service;
 
-@Service
 public class UserServiceImpl extends AbstractAnyService<UserTO, UserCR, UserUR> implements UserService {
 
     protected final UserDAO userDAO;


### PR DESCRIPTION
This pull request removes the `@Service` annotation from implementations that are explicitly created as beans. 