### PR TITLE
Chore: sequential collections can use getFirst() instead of get(0)

### DIFF
--- a/client/am/console/src/main/java/org/apache/syncope/client/console/pages/WA.java
+++ b/client/am/console/src/main/java/org/apache/syncope/client/console/pages/WA.java
@@ -126,7 +126,8 @@ public class WA extends BasePage {
         body.add(content);
 
         if (!instances.isEmpty()) {
-            String actuatorEndpoint = StringUtils.appendIfMissing(instances.getFirst().getAddress(), "/") + "actuator/env";
+            String actuatorEndpoint = StringUtils.appendIfMissing(
+                instances.getFirst().getAddress(), "/") + "actuator/env";
             try {
                 Response response = WebClientBuilder.build(actuatorEndpoint,
                         SyncopeWebApplication.get().getAnonymousUser(),

--- a/client/am/console/src/main/java/org/apache/syncope/client/console/pages/WA.java
+++ b/client/am/console/src/main/java/org/apache/syncope/client/console/pages/WA.java
@@ -126,7 +126,7 @@ public class WA extends BasePage {
         body.add(content);
 
         if (!instances.isEmpty()) {
-            String actuatorEndpoint = StringUtils.appendIfMissing(instances.get(0).getAddress(), "/") + "actuator/env";
+            String actuatorEndpoint = StringUtils.appendIfMissing(instances.getFirst().getAddress(), "/") + "actuator/env";
             try {
                 Response response = WebClientBuilder.build(actuatorEndpoint,
                         SyncopeWebApplication.get().getAnonymousUser(),
@@ -153,7 +153,7 @@ public class WA extends BasePage {
             }
 
             if (StringUtils.isBlank(waPrefix)) {
-                waPrefix = StringUtils.removeEnd(instances.get(0).getAddress(), "/");
+                waPrefix = StringUtils.removeEnd(instances.getFirst().getAddress(), "/");
             }
         }
     }

--- a/client/am/console/src/main/java/org/apache/syncope/client/console/rest/SRASessionRestClient.java
+++ b/client/am/console/src/main/java/org/apache/syncope/client/console/rest/SRASessionRestClient.java
@@ -37,7 +37,7 @@ public final class SRASessionRestClient extends AMSessionRestClient {
 
     @Override
     protected String getActuatorEndpoint() {
-        return instances.get(0).getAddress() + "actuator/sraSessions";
+        return instances.getFirst().getAddress() + "actuator/sraSessions";
     }
 
     @Override

--- a/client/am/console/src/main/java/org/apache/syncope/client/console/rest/SRAStatisticsRestClient.java
+++ b/client/am/console/src/main/java/org/apache/syncope/client/console/rest/SRAStatisticsRestClient.java
@@ -39,7 +39,7 @@ public final class SRAStatisticsRestClient {
             List.of(new JacksonJsonProvider(JsonMapper.builder().findAndAddModules().build()));
 
     protected String getActuatorEndpoint(final List<NetworkService> instances) {
-        return instances.get(0).getAddress() + "actuator/metrics/spring.cloud.gateway.requests";
+        return instances.getFirst().getAddress() + "actuator/metrics/spring.cloud.gateway.requests";
     }
 
     public SRAStatistics get(final List<NetworkService> instances, final List<Pair<String, String>> selected) {

--- a/client/am/console/src/main/java/org/apache/syncope/client/console/rest/WASessionRestClient.java
+++ b/client/am/console/src/main/java/org/apache/syncope/client/console/rest/WASessionRestClient.java
@@ -44,7 +44,7 @@ public final class WASessionRestClient extends AMSessionRestClient {
 
     @Override
     protected String getActuatorEndpoint() {
-        return instances.get(0).getAddress() + "actuator/ssoSessions";
+        return instances.getFirst().getAddress() + "actuator/ssoSessions";
     }
 
     @Override

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/panels/ConnObjects.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/panels/ConnObjects.java
@@ -55,7 +55,7 @@ public class ConnObjects extends Panel implements ModalPanel {
                 sorted(AnyTypeRestClient.KEY_COMPARATOR).
                 collect(Collectors.toList());
         if (resource.getOrgUnit() != null) {
-            availableAnyTypes.add(0, SyncopeConstants.REALM_ANYTYPE);
+            availableAnyTypes.addFirst(SyncopeConstants.REALM_ANYTYPE);
         }
 
         anyTypes = new AjaxDropDownChoicePanel<>("anyTypes", "anyTypes", new Model<>());
@@ -67,7 +67,7 @@ public class ConnObjects extends Panel implements ModalPanel {
         } else if (availableAnyTypes.contains(AnyTypeKind.GROUP.name())) {
             anyTypes.setDefaultModelObject(AnyTypeKind.GROUP.name());
         } else if (!availableAnyTypes.isEmpty()) {
-            anyTypes.setDefaultModelObject(availableAnyTypes.get(0));
+            anyTypes.setDefaultModelObject(availableAnyTypes.getFirst());
         }
         add(anyTypes);
 

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/status/AnyStatusDirectoryPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/status/AnyStatusDirectoryPanel.java
@@ -334,7 +334,7 @@ public class AnyStatusDirectoryPanel
 
                 return StatusUtils.getStatusBean(actual,
                         resource,
-                        statuses.isEmpty() ? null : statuses.get(0).getRight().getOnResource(),
+                        statuses.isEmpty() ? null : statuses.getFirst().getRight().getOnResource(),
                         actual instanceof GroupTO);
             }).collect(Collectors.toList());
 
@@ -367,7 +367,7 @@ public class AnyStatusDirectoryPanel
                 syncope.setStatus(syncopeStatus);
 
                 statusBeans.sort(comparator);
-                statusBeans.add(0, syncope);
+                statusBeans.addFirst(syncope);
             } else {
                 statusBeans.addAll(resources.stream().
                         filter(resource -> !actual.getResources().contains(resource)).

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/status/ReconStatusPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/status/ReconStatusPanel.java
@@ -66,6 +66,6 @@ public class ReconStatusPanel extends RemoteObjectPanel {
 
         return statuses.isEmpty()
                 ? null
-                : Pair.of(statuses.get(0).getRight().getOnSyncope(), statuses.get(0).getRight().getOnResource());
+                : Pair.of(statuses.getFirst().getRight().getOnSyncope(), statuses.getFirst().getRight().getOnResource());
     }
 }

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/status/ReconStatusPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/status/ReconStatusPanel.java
@@ -66,6 +66,7 @@ public class ReconStatusPanel extends RemoteObjectPanel {
 
         return statuses.isEmpty()
                 ? null
-                : Pair.of(statuses.getFirst().getRight().getOnSyncope(), statuses.getFirst().getRight().getOnResource());
+                : Pair.of(statuses.getFirst().getRight().getOnSyncope(),
+                          statuses.getFirst().getRight().getOnResource());
     }
 }

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/any/LinkedAccountDetailsPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/any/LinkedAccountDetailsPanel.java
@@ -180,7 +180,7 @@ public class LinkedAccountDetailsPanel extends WizardStep {
                 new SortParam<>(resourceRemoteKey.get(), true));
 
         connObjectKeyFieldValues = items.getRight().stream().
-                map(item -> item.getAttr(resourceRemoteKey.get()).map(attr -> attr.getValues().get(0)).orElse(null)).
+                map(item -> item.getAttr(resourceRemoteKey.get()).map(attr -> attr.getValues().getFirst()).orElse(null)).
                 filter(Objects::nonNull).
                 collect(Collectors.toList());
         ajaxTextFieldPanel.setChoices(connObjectKeyFieldValues);

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/any/LinkedAccountDetailsPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/any/LinkedAccountDetailsPanel.java
@@ -180,7 +180,8 @@ public class LinkedAccountDetailsPanel extends WizardStep {
                 new SortParam<>(resourceRemoteKey.get(), true));
 
         connObjectKeyFieldValues = items.getRight().stream().
-                map(item -> item.getAttr(resourceRemoteKey.get()).map(attr -> attr.getValues().getFirst()).orElse(null)).
+                map(item -> item.getAttr(resourceRemoteKey.get()).
+                    map(attr -> attr.getValues().getFirst()).orElse(null)).
                 filter(Objects::nonNull).
                 collect(Collectors.toList());
         ajaxTextFieldPanel.setChoices(connObjectKeyFieldValues);

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/resources/ConnectorDetailsPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/resources/ConnectorDetailsPanel.java
@@ -125,7 +125,7 @@ public class ConnectorDetailsPanel extends WizardStep {
                         map(bundle -> Pair.of(bundle.getConnectorName(), bundle.getVersion())).
                         collect(Collectors.toList());
                 if (connectors.size() == 1) {
-                    Pair<String, String> entry = connectors.get(0);
+                    Pair<String, String> entry = connectors.getFirst();
 
                     connInstanceTO.setConnectorName(entry.getLeft());
                     connectorName.getField().setModelObject(entry.getLeft());
@@ -143,8 +143,8 @@ public class ConnectorDetailsPanel extends WizardStep {
                     version.setChoices(versions);
 
                     if (versions.size() == 1) {
-                        connInstanceTO.setVersion(versions.get(0));
-                        version.getField().setModelObject(versions.get(0));
+                        connInstanceTO.setVersion(versions.getFirst());
+                        version.getField().setModelObject(versions.getFirst());
                     } else {
                         connInstanceTO.setVersion(null);
                         version.getField().setModelObject(null);
@@ -167,8 +167,8 @@ public class ConnectorDetailsPanel extends WizardStep {
                         && bundle.getConnectorName().equals(connInstanceTO.getConnectorName())).
                         map(ConnIdBundle::getVersion).collect(Collectors.toList());
                 if (versions.size() == 1) {
-                    connInstanceTO.setVersion(versions.get(0));
-                    version.getField().setModelObject(versions.get(0));
+                    connInstanceTO.setVersion(versions.getFirst());
+                    version.getField().setModelObject(versions.getFirst());
                 }
                 version.setChoices(versions);
 

--- a/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/BaseLogin.java
+++ b/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/BaseLogin.java
@@ -86,7 +86,7 @@ public abstract class BaseLogin extends WebPage {
         protected List<String> load() {
             List<String> current = new ArrayList<>();
             current.addAll(domainOps.list().stream().map(Domain::getKey).sorted().collect(Collectors.toList()));
-            current.add(0, SyncopeConstants.MASTER_DOMAIN);
+            current.addFirst(SyncopeConstants.MASTER_DOMAIN);
             return current;
         }
     };
@@ -282,7 +282,7 @@ public abstract class BaseLogin extends WebPage {
 
             getModel().setObject(filtered.isEmpty()
                     ? Locale.ENGLISH
-                    : filtered.get(0));
+                    : filtered.getFirst());
         }
     }
 }

--- a/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/markup/html/form/AjaxCheckBoxPanel.java
+++ b/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/markup/html/form/AjaxCheckBoxPanel.java
@@ -73,7 +73,7 @@ public class AjaxCheckBoxPanel extends FieldPanel<Boolean> {
                 Boolean value = null;
 
                 if (list != null && !list.isEmpty()) {
-                    value = Boolean.TRUE.toString().equalsIgnoreCase(list.get(0).toString());
+                    value = Boolean.TRUE.toString().equalsIgnoreCase(list.getFirst().toString());
                 }
 
                 return value;
@@ -138,7 +138,7 @@ public class AjaxCheckBoxPanel extends FieldPanel<Boolean> {
             @Override
             public Serializable getObject() {
                 return attributable.getPlainAttr(schema).map(Attr::getValues).filter(Predicate.not(List::isEmpty)).
-                        map(values -> Boolean.TRUE.toString().equalsIgnoreCase(values.get(0))).
+                        map(values -> Boolean.TRUE.toString().equalsIgnoreCase(values.getFirst())).
                         orElse(null);
             }
 

--- a/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/markup/html/form/AjaxNumberFieldPanel.java
+++ b/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/markup/html/form/AjaxNumberFieldPanel.java
@@ -108,18 +108,18 @@ public final class AjaxNumberFieldPanel<T extends Number & Comparable<T>> extend
             public T getObject() {
                 T value = null;
 
-                if (list != null && !list.isEmpty() && list.get(0) != null && !list.get(0).toString().isEmpty()) {
+                if (list != null && !list.isEmpty() && list.getFirst() != null && !list.getFirst().toString().isEmpty()) {
                     value = reference.equals(Integer.class)
-                            ? reference.cast(NumberUtils.toInt(list.get(0).toString()))
+                            ? reference.cast(NumberUtils.toInt(list.getFirst().toString()))
                             : reference.equals(Long.class)
-                            ? reference.cast(NumberUtils.toLong(list.get(0).toString()))
+                            ? reference.cast(NumberUtils.toLong(list.getFirst().toString()))
                             : reference.equals(Short.class)
-                            ? reference.cast(NumberUtils.toShort(list.get(0).toString()))
+                            ? reference.cast(NumberUtils.toShort(list.getFirst().toString()))
                             : reference.equals(Float.class)
-                            ? reference.cast(NumberUtils.toFloat(list.get(0).toString()))
+                            ? reference.cast(NumberUtils.toFloat(list.getFirst().toString()))
                             : reference.equals(byte.class)
-                            ? reference.cast(NumberUtils.toByte(list.get(0).toString()))
-                            : reference.cast(NumberUtils.toDouble(list.get(0).toString()));
+                            ? reference.cast(NumberUtils.toByte(list.getFirst().toString()))
+                            : reference.cast(NumberUtils.toDouble(list.getFirst().toString()));
                 }
 
                 return value;
@@ -205,16 +205,16 @@ public final class AjaxNumberFieldPanel<T extends Number & Comparable<T>> extend
             public T getObject() {
                 return attributable.getPlainAttr(schema).map(Attr::getValues).filter(Predicate.not(List::isEmpty)).
                         map(values -> reference.equals(Integer.class)
-                        ? reference.cast(NumberUtils.toInt(values.get(0)))
+                        ? reference.cast(NumberUtils.toInt(values.getFirst()))
                         : reference.equals(Long.class)
-                        ? reference.cast(NumberUtils.toLong(values.get(0)))
+                        ? reference.cast(NumberUtils.toLong(values.getFirst()))
                         : reference.equals(Short.class)
-                        ? reference.cast(NumberUtils.toShort(values.get(0)))
+                        ? reference.cast(NumberUtils.toShort(values.getFirst()))
                         : reference.equals(Float.class)
-                        ? reference.cast(NumberUtils.toFloat(values.get(0)))
+                        ? reference.cast(NumberUtils.toFloat(values.getFirst()))
                         : reference.equals(byte.class)
-                        ? reference.cast(NumberUtils.toByte(values.get(0)))
-                        : reference.cast(NumberUtils.toDouble(values.get(0)))).
+                        ? reference.cast(NumberUtils.toByte(values.getFirst()))
+                        : reference.cast(NumberUtils.toDouble(values.getFirst()))).
                         orElse(null);
             }
 

--- a/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/markup/html/form/AjaxNumberFieldPanel.java
+++ b/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/markup/html/form/AjaxNumberFieldPanel.java
@@ -108,7 +108,8 @@ public final class AjaxNumberFieldPanel<T extends Number & Comparable<T>> extend
             public T getObject() {
                 T value = null;
 
-                if (list != null && !list.isEmpty() && list.getFirst() != null && !list.getFirst().toString().isEmpty()) {
+                if (list != null && !list.isEmpty() && list.getFirst() != null
+                    && !list.getFirst().toString().isEmpty()) {
                     value = reference.equals(Integer.class)
                             ? reference.cast(NumberUtils.toInt(list.getFirst().toString()))
                             : reference.equals(Long.class)

--- a/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/markup/html/form/DateFieldPanel.java
+++ b/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/markup/html/form/DateFieldPanel.java
@@ -55,10 +55,10 @@ public abstract class DateFieldPanel extends FieldPanel<Date> {
             @Override
             public Date getObject() {
                 Date date = null;
-                if (list != null && !list.isEmpty() && StringUtils.hasText(list.get(0).toString())) {
+                if (list != null && !list.isEmpty() && StringUtils.hasText(list.getFirst().toString())) {
                     try {
                         // Parse string using datePattern
-                        date = fmt.parse(list.get(0).toString());
+                        date = fmt.parse(list.getFirst().toString());
                     } catch (ParseException e) {
                         LOG.error("invalid parse exception", e);
                     }
@@ -134,7 +134,7 @@ public abstract class DateFieldPanel extends FieldPanel<Date> {
                 return attributable.getPlainAttr(schema).map(Attr::getValues).filter(Predicate.not(List::isEmpty)).
                         map(values -> {
                             try {
-                                return fmt.parse(values.get(0));
+                                return fmt.parse(values.getFirst());
                             } catch (ParseException e) {
                                 LOG.error("While parsing date", e);
                                 return null;

--- a/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/markup/html/form/FieldPanel.java
+++ b/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/markup/html/form/FieldPanel.java
@@ -140,7 +140,7 @@ public abstract class FieldPanel<T extends Serializable> extends AbstractFieldPa
             @Override
             public Serializable getObject() {
                 return attributable.getPlainAttr(schema).map(Attr::getValues).filter(Predicate.not(List::isEmpty)).
-                        map(values -> values.get(0)).
+                        map(values -> values.getFirst()).
                         orElse(null);
             }
 
@@ -194,7 +194,7 @@ public abstract class FieldPanel<T extends Serializable> extends AbstractFieldPa
 
             @Override
             public Serializable getObject() {
-                return list == null || list.isEmpty() ? null : list.get(0);
+                return list == null || list.isEmpty() ? null : list.getFirst();
             }
 
             @Override

--- a/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/status/StatusUtils.java
+++ b/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/status/StatusUtils.java
@@ -80,14 +80,14 @@ public final class StatusUtils implements Serializable {
     public static Boolean isEnabled(final ConnObject connObject) {
         return connObject.getAttr(ConnIdSpecialName.ENABLE).
                 filter(s -> !s.getValues().isEmpty()).
-                map(s -> Boolean.valueOf(s.getValues().get(0))).
+                map(s -> Boolean.valueOf(s.getValues().getFirst())).
                 orElse(Boolean.FALSE);
     }
 
     public static String getConnObjectLink(final ConnObject connObject) {
         return connObject.getAttr(ConnIdSpecialName.NAME).
                 filter(s -> !s.getValues().isEmpty()).
-                map(s -> s.getValues().get(0)).
+                map(s -> s.getValues().getFirst()).
                 orElse(null);
     }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/PreferenceManager.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/PreferenceManager.java
@@ -101,7 +101,7 @@ public final class PreferenceManager implements Serializable {
     }
 
     public static Integer getPaginatorRows(final String key) {
-        Integer result = getPaginatorChoices().get(0);
+        Integer result = getPaginatorChoices().getFirst();
 
         String value = get(key);
         if (value != null) {

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/audit/AuditHistoryDetails.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/audit/AuditHistoryDetails.java
@@ -298,7 +298,7 @@ public abstract class AuditHistoryDetails<T extends Serializable> extends Panel 
                 REST_SORT));
 
         // the default selected is the newest one, if any
-        latestAuditEventTO = auditEntries.isEmpty() ? null : auditEntries.get(0);
+        latestAuditEventTO = auditEntries.isEmpty() ? null : auditEntries.getFirst();
         after = latestAuditEventTO == null ? null : buildAfterAuditEventTO(latestAuditEventTO);
         // add default diff panel
         addOrReplace(new JsonDiffPanel(toJSON(latestAuditEventTO, reference), toJSON(after, reference)));

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/batch/BatchContent.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/batch/BatchContent.java
@@ -128,7 +128,7 @@ public class BatchContent<T extends Serializable, S> extends MultilevelPanel.Sec
 
                     Map<String, String> results;
                     try {
-                        T singleItem = items.iterator().next();
+                        T singleItem = items.getFirst();
 
                         if (singleItem instanceof ExecTO) {
                             results = new HashMap<>();

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/commons/RealmsUtils.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/commons/RealmsUtils.java
@@ -45,7 +45,7 @@ public final class RealmsUtils {
         String base = SyncopeConsoleSession.get().getSearchableRealms().isEmpty()
                 || SyncopeConsoleSession.get().getSearchableRealms().contains(SyncopeConstants.ROOT_REALM)
                 ? SyncopeConstants.ROOT_REALM
-                : getFullPath(SyncopeConsoleSession.get().getSearchableRealms().get(0));
+                : getFullPath(SyncopeConsoleSession.get().getSearchableRealms().getFirst());
         return new RealmQuery.Builder().base(base).build();
     }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/commons/SortableAnyProviderComparator.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/commons/SortableAnyProviderComparator.java
@@ -102,7 +102,7 @@ public class SortableAnyProviderComparator<T extends AnyTO> extends SortableData
 
             List<String> values = Optional.ofNullable(attr).map(Attr::getValues).orElse(null);
             if (values != null && !values.isEmpty()) {
-                result = values.iterator().next();
+                result = values.getFirst();
             }
 
             return result;

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/notifications/NotificationWrapper.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/notifications/NotificationWrapper.java
@@ -72,7 +72,7 @@ public class NotificationWrapper extends EntityWrapper<NotificationTO> {
     }
 
     public Map<String, String> getAboutFIQLs() {
-        if (CollectionUtils.isEmpty(this.aboutClauses) || this.aboutClauses.get(0).getValue().isEmpty()) {
+        if (CollectionUtils.isEmpty(this.aboutClauses) || this.aboutClauses.getFirst().getValue().isEmpty()) {
             return getInnerObject().getAbouts();
         } else {
             Map<String, String> res = new HashMap<>();

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/ActionDataTablePanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/ActionDataTablePanel.java
@@ -80,7 +80,7 @@ public class ActionDataTablePanel<T extends Serializable, S> extends DataTablePa
         });
         batchForm.add(group);
 
-        columns.add(0, new CheckGroupColumn<>(group));
+        columns.addFirst(new CheckGroupColumn<>(group));
         dataTable = new AjaxFallbackDataTable<>("dataTable", columns, dataProvider, rowsPerPage, this);
         group.add(dataTable);
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/AjaxDataTablePanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/AjaxDataTablePanel.java
@@ -211,7 +211,7 @@ public final class AjaxDataTablePanel<T extends Serializable, S> extends DataTab
         groupForm.add(group);
 
         if (builder.checkBoxEnabled) {
-            builder.columns.add(0, new CheckGroupColumn<>(group));
+            builder.columns.addFirst(new CheckGroupColumn<>(group));
         }
 
         dataTable = new AjaxFallbackDataTable<>(

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/ConfParam.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/ConfParam.java
@@ -51,7 +51,7 @@ public class ConfParam implements Serializable {
                 ? values
                 : values.isEmpty()
                 ? null
-                : values.get(0);
+                : values.getFirst();
     }
 
     public void setValues(final Object value) {
@@ -77,7 +77,7 @@ public class ConfParam implements Serializable {
     }
 
     public boolean isInstance(final Class<?> clazz) {
-        return !values.isEmpty() && clazz.isInstance(values.get(0));
+        return !values.isEmpty() && clazz.isInstance(values.getFirst());
     }
 
     @Override

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/ParametersModalPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/ParametersModalPanel.java
@@ -115,12 +115,12 @@ public class ParametersModalPanel extends AbstractModalPanel<ConfParam> {
             } else // attempt to guess type from content: otherwise, it's bare String
             if (!param.getValues().isEmpty()) {
                 // 1. is it Date?
-                if (isDate(param.getValues().get(0).toString())) {
+                if (isDate(param.getValues().getFirst().toString())) {
                     schema.setType(AttrSchemaType.Date);
                 } else // 2. does it look like Base64?
-                if (isBase64(param.getValues().get(0).toString())) {
+                if (isBase64(param.getValues().getFirst().toString())) {
                     schema.setType(AttrSchemaType.Binary);
-                    String value = new String(Base64.getDecoder().decode(param.getValues().get(0).toString()));
+                    String value = new String(Base64.getDecoder().decode(param.getValues().getFirst().toString()));
 
                     // 3. is it JSON?
                     if (isJSON(value)) {

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/Realm.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/Realm.java
@@ -176,7 +176,7 @@ public abstract class Realm extends WizardMgtPanel<RealmTO> {
                 if ("afterObj".equalsIgnoreCase(key)) {
                     String remoteId = Optional.ofNullable(bean.getAfterObj()).
                             flatMap(afterObj -> afterObj.getAttr(ConnIdSpecialName.NAME).
-                            filter(s -> !s.getValues().isEmpty()).map(s -> s.getValues().get(0))).
+                            filter(s -> !s.getValues().isEmpty()).map(s -> s.getValues().getFirst())).
                             orElse(StringUtils.EMPTY);
 
                     return new Label("field", remoteId);

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/rest/LoggerConfRestClient.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/rest/LoggerConfRestClient.java
@@ -72,7 +72,7 @@ public class LoggerConfRestClient implements RestClient, LoggerConfOp {
         List<LoggerConf> loggerConfs = new ArrayList<>();
 
         try {
-            Response response = WebClientBuilder.build(getActuatorEndpoint(instances.get(0)),
+            Response response = WebClientBuilder.build(getActuatorEndpoint(instances.getFirst()),
                     SyncopeWebApplication.get().getAnonymousUser(),
                     SyncopeWebApplication.get().getAnonymousKey(),
                     List.of()).accept(MediaType.APPLICATION_JSON_TYPE).get();
@@ -95,10 +95,10 @@ public class LoggerConfRestClient implements RestClient, LoggerConfOp {
                 }
             } else {
                 LOG.error("Unexpected response for loggers from {}: {}",
-                        getActuatorEndpoint(instances.get(0)), response.getStatus());
+                        getActuatorEndpoint(instances.getFirst()), response.getStatus());
             }
         } catch (Exception e) {
-            LOG.error("Could not fetch loggers from {}", getActuatorEndpoint(instances.get(0)), e);
+            LOG.error("Could not fetch loggers from {}", getActuatorEndpoint(instances.getFirst()), e);
         }
 
         loggerConfs.sort(Comparator.comparing(LoggerConf::getKey));

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wicket/extensions/markup/html/repeater/data/table/AjaxFallbackDataTable.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wicket/extensions/markup/html/repeater/data/table/AjaxFallbackDataTable.java
@@ -117,7 +117,7 @@ public class AjaxFallbackDataTable<T extends Serializable, S> extends DataTable<
 
     protected void onDoubleClick(final AjaxRequestTarget target, final IModel<T> model) {
         togglePanel.close(target);
-        getActions(model).getActions().get(0).getLink().onClick(target, model.getObject());
+        getActions(model).getActions().getFirst().getLink().onClick(target, model.getObject());
     }
 
     @Override

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wicket/extensions/markup/html/repeater/data/table/AttrColumn.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wicket/extensions/markup/html/repeater/data/table/AttrColumn.java
@@ -70,7 +70,7 @@ public class AttrColumn<T extends Attributable> extends AbstractColumn<T, String
         if (values.isEmpty()) {
             cellItem.add(new Label(componentId, ""));
         } else if (values.size() == 1) {
-            cellItem.add(new Label(componentId, values.get(0)));
+            cellItem.add(new Label(componentId, values.getFirst()));
         } else {
             cellItem.add(new Label(componentId, values.toString()));
         }

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wicket/extensions/markup/html/repeater/data/table/ConnObjectAttrColumn.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wicket/extensions/markup/html/repeater/data/table/ConnObjectAttrColumn.java
@@ -55,7 +55,7 @@ public class ConnObjectAttrColumn extends AbstractColumn<ConnObject, String> {
         if (values == null || values.isEmpty()) {
             cellItem.add(new Label(componentId, ""));
         } else if (values.size() == 1) {
-            cellItem.add(new Label(componentId, values.get(0)));
+            cellItem.add(new Label(componentId, values.getFirst()));
         } else {
             cellItem.add(new Label(componentId, values.toString()));
         }

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/ConnObjectPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/ConnObjectPanel.java
@@ -150,7 +150,7 @@ public class ConnObjectPanel extends Panel {
         } else if (ConnIdSpecialName.PASSWORD.equals(schemaName)) {
             field = new AjaxTextFieldPanel(id, schemaName, new Model<>("********"));
         } else if (attrTO.getValues().size() == 1) {
-            field = new AjaxTextFieldPanel(id, schemaName, new Model<>(attrTO.getValues().get(0)));
+            field = new AjaxTextFieldPanel(id, schemaName, new Model<>(attrTO.getValues().getFirst()));
         } else {
             field = new MultiFieldPanel.Builder<>(new ListModel<>(attrTO.getValues())).build(
                     id,

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/DerAttrs.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/DerAttrs.java
@@ -183,7 +183,7 @@ public class DerAttrs extends AbstractAttrs<DerSchemaTO> {
                     if (values == null || values.isEmpty()) {
                         model = new ResourceModel("derived.emptyvalue.message", StringUtils.EMPTY);
                     } else {
-                        model = new Model<>(values.get(0));
+                        model = new Model<>(values.getFirst());
                     }
 
                     AjaxTextFieldPanel panel = new AjaxTextFieldPanel(

--- a/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/PreferenceManager.java
+++ b/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/PreferenceManager.java
@@ -102,7 +102,7 @@ public final class PreferenceManager implements Serializable {
     }
 
     public Integer getPaginatorRows(final String key) {
-        Integer result = getPaginatorChoices().get(0);
+        Integer result = getPaginatorChoices().getFirst();
 
         String value = get(key);
         if (value != null) {

--- a/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/panels/any/DerAttrs.java
+++ b/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/panels/any/DerAttrs.java
@@ -172,7 +172,7 @@ public class DerAttrs extends AbstractAttrs<DerSchemaTO> {
                     if (values == null || values.isEmpty()) {
                         model = new ResourceModel("derived.emptyvalue.message", StringUtils.EMPTY);
                     } else {
-                        model = new Model<>(values.get(0));
+                        model = new Model<>(values.getFirst());
                     }
 
                     AjaxTextFieldPanel panel = new AjaxTextFieldPanel(

--- a/client/idrepo/lib/src/main/java/org/apache/syncope/client/lib/SyncopeClient.java
+++ b/client/idrepo/lib/src/main/java/org/apache/syncope/client/lib/SyncopeClient.java
@@ -256,7 +256,7 @@ public class SyncopeClient {
         List<String> headerValues = restClientFactory.getHeaders().get(HttpHeaders.AUTHORIZATION);
         String header = headerValues == null || headerValues.isEmpty()
                 ? null
-                : headerValues.get(0);
+                : headerValues.getFirst();
         if (header != null && header.startsWith("Bearer ")) {
             return header.substring("Bearer ".length());
 
@@ -273,7 +273,7 @@ public class SyncopeClient {
         List<String> headerValues = restClientFactory.getHeaders().get(RESTHeaders.DOMAIN);
         return headerValues == null || headerValues.isEmpty()
                 ? SyncopeConstants.MASTER_DOMAIN
-                : headerValues.get(0);
+                : headerValues.getFirst();
     }
 
     /**

--- a/common/idrepo/rest-api/src/main/java/org/apache/syncope/common/rest/api/batch/BatchPayloadParser.java
+++ b/common/idrepo/rest-api/src/main/java/org/apache/syncope/common/rest/api/batch/BatchPayloadParser.java
@@ -64,7 +64,7 @@ public final class BatchPayloadParser {
 
     private static void removeEndingCRLFFromList(final List<BatchPayloadLine> lines) {
         if (!lines.isEmpty()) {
-            BatchPayloadLine lastLine = lines.remove(lines.size() - 1);
+            BatchPayloadLine lastLine = lines.removeLast();
             lines.add(removeEndingCRLF(lastLine));
         }
     }
@@ -98,11 +98,11 @@ public final class BatchPayloadParser {
 
         // Remove preamble
         if (!messageParts.isEmpty()) {
-            messageParts.remove(0);
+            messageParts.removeFirst();
         }
 
         if (!isEndReached) {
-            int lineNumber = lines.isEmpty() ? 0 : lines.get(0).getLineNumber();
+            int lineNumber = lines.isEmpty() ? 0 : lines.getFirst().getLineNumber();
             throw new IllegalArgumentException("Missing close boundary delimiter around line " + lineNumber);
         }
 
@@ -177,8 +177,8 @@ public final class BatchPayloadParser {
     }
 
     private static void consumeBlankLine(final List<BatchPayloadLine> bodyPart) {
-        if (!bodyPart.isEmpty() && PATTERN_BLANK_LINE.matcher(bodyPart.get(0).toString()).matches()) {
-            bodyPart.remove(0);
+        if (!bodyPart.isEmpty() && PATTERN_BLANK_LINE.matcher(bodyPart.getFirst().toString()).matches()) {
+            bodyPart.removeFirst();
         }
     }
 

--- a/common/keymaster/client-zookeeper/src/main/java/org/apache/syncope/common/keymaster/client/zookeeper/ZookeeperServiceOps.java
+++ b/common/keymaster/client-zookeeper/src/main/java/org/apache/syncope/common/keymaster/client/zookeeper/ZookeeperServiceOps.java
@@ -132,6 +132,6 @@ public class ZookeeperServiceOps implements ServiceOps {
         }
 
         // always returns first instance, can be improved
-        return list.get(0);
+        return list.getFirst();
     }
 }

--- a/common/keymaster/client-zookeeper/src/test/java/org/apache/syncope/common/keymaster/client/zookeeper/ZookeeperDomainOpsITCase.java
+++ b/common/keymaster/client-zookeeper/src/test/java/org/apache/syncope/common/keymaster/client/zookeeper/ZookeeperDomainOpsITCase.java
@@ -66,7 +66,7 @@ public class ZookeeperDomainOpsITCase {
 
         List<Domain> list = domainOps.list();
         assertNotNull(list);
-        assertEquals(domain, list.get(0));
+        assertEquals(domain, list.getFirst());
 
         try {
             domainOps.create(new JPADomain.Builder(domain.getKey()).build());

--- a/common/keymaster/client-zookeeper/src/test/java/org/apache/syncope/common/keymaster/client/zookeeper/ZookeeperServiceOpsITCase.java
+++ b/common/keymaster/client-zookeeper/src/test/java/org/apache/syncope/common/keymaster/client/zookeeper/ZookeeperServiceOpsITCase.java
@@ -51,7 +51,7 @@ public class ZookeeperServiceOpsITCase {
         list = serviceOps.list(NetworkService.Type.CORE);
         assertFalse(list.isEmpty());
         assertEquals(1, list.size());
-        assertEquals(core1, list.get(0));
+        assertEquals(core1, list.getFirst());
 
         assertEquals(core1, serviceOps.get(NetworkService.Type.CORE));
 
@@ -64,7 +64,7 @@ public class ZookeeperServiceOpsITCase {
         list = serviceOps.list(NetworkService.Type.CORE);
         assertFalse(list.isEmpty());
         assertEquals(1, list.size());
-        assertEquals(core1, list.get(0));
+        assertEquals(core1, list.getFirst());
 
         assertEquals(core1, serviceOps.get(NetworkService.Type.CORE));
 

--- a/core/idm/logic/src/main/java/org/apache/syncope/core/logic/ReconciliationLogic.java
+++ b/core/idm/logic/src/main/java/org/apache/syncope/core/logic/ReconciliationLogic.java
@@ -287,13 +287,13 @@ public class ReconciliationLogic extends AbstractTransactionalLogic<EntityTO> {
                 Optional.of(moreAttrsToGet.toArray(String[]::new)));
         if (!connObjs.isEmpty()) {
             status.setOnResource(ConnObjectUtils.getConnObjectTO(
-                    outboundMatcher.getFIQL(connObjs.get(0), triple.getMiddle(), triple.getRight()),
-                    connObjs.get(0).getAttributes()));
+                    outboundMatcher.getFIQL(connObjs.getFirst(), triple.getMiddle(), triple.getRight()),
+                    connObjs.getFirst().getAttributes()));
 
             if (connObjs.size() > 1) {
                 LOG.warn("Expected single match, found {}", connObjs);
             } else {
-                virAttrHandler.setValues(any, connObjs.get(0));
+                virAttrHandler.setValues(any, connObjs.getFirst());
             }
         }
 
@@ -412,8 +412,8 @@ public class ReconciliationLogic extends AbstractTransactionalLogic<EntityTO> {
                     getAny(triple.getRight(), triple.getLeft().getKind(), anyKey),
                     pushTask,
                     AuthContextUtils.getWho()));
-            if (!results.isEmpty() && results.get(0).getStatus() == ProvisioningReport.Status.FAILURE) {
-                sce.getElements().add(results.get(0).getMessage());
+            if (!results.isEmpty() && results.getFirst().getStatus() == ProvisioningReport.Status.FAILURE) {
+                sce.getElements().add(results.getFirst().getMessage());
             }
         } catch (JobExecutionException e) {
             sce.getElements().add(e.getMessage());
@@ -457,9 +457,9 @@ public class ReconciliationLogic extends AbstractTransactionalLogic<EntityTO> {
                                         pushTask,
                                         AuthContextUtils.getWho()));
                                 if (!results.isEmpty()
-                                        && results.get(0).getStatus() == ProvisioningReport.Status.FAILURE) {
+                                        && results.getFirst().getStatus() == ProvisioningReport.Status.FAILURE) {
 
-                                    sce.getElements().add(results.get(0).getMessage());
+                                    sce.getElements().add(results.getFirst().getMessage());
                                 }
                             } else {
                                 ProvisioningReport result = singlePushExecutor().push(
@@ -514,8 +514,8 @@ public class ReconciliationLogic extends AbstractTransactionalLogic<EntityTO> {
                     moreAttrsToGet,
                     pullTask,
                     AuthContextUtils.getWho()));
-            if (!results.isEmpty() && results.get(0).getStatus() == ProvisioningReport.Status.FAILURE) {
-                sce.getElements().add(results.get(0).getMessage());
+            if (!results.isEmpty() && results.getFirst().getStatus() == ProvisioningReport.Status.FAILURE) {
+                sce.getElements().add(results.getFirst().getMessage());
             }
         } catch (JobExecutionException e) {
             sce.getElements().add(e.getMessage());

--- a/core/idm/logic/src/main/java/org/apache/syncope/core/logic/ResourceLogic.java
+++ b/core/idm/logic/src/main/java/org/apache/syncope/core/logic/ResourceLogic.java
@@ -345,12 +345,12 @@ public class ResourceLogic extends AbstractTransactionalLogic<ResourceTO> {
         if (connObjs.size() > 1) {
             LOG.warn("Expected single match, found {}", connObjs);
         } else {
-            virAttrHandler.setValues(any, connObjs.get(0));
+            virAttrHandler.setValues(any, connObjs.getFirst());
         }
 
         return ConnObjectUtils.getConnObjectTO(
-                outboundMatcher.getFIQL(connObjs.get(0), triple.getMiddle(), triple.getRight()),
-                connObjs.get(0).getAttributes());
+                outboundMatcher.getFIQL(connObjs.getFirst(), triple.getMiddle(), triple.getRight()),
+                connObjs.getFirst().getAttributes());
     }
 
     @PreAuthorize("hasRole('" + IdMEntitlement.RESOURCE_GET_CONNOBJECT + "')")

--- a/core/idm/logic/src/test/java/org/apache/syncope/core/logic/ReconciliationLogicTest.java
+++ b/core/idm/logic/src/test/java/org/apache/syncope/core/logic/ReconciliationLogicTest.java
@@ -64,22 +64,22 @@ public class ReconciliationLogicTest extends AbstractTest {
                 SyncopeConstants.MASTER_DOMAIN, () -> reconciliationLogic.pull(spec, csv));
         assertEquals(2, results.size());
 
-        assertEquals(AnyTypeKind.USER.name(), results.get(0).getAnyType());
-        assertNotNull(results.get(0).getKey());
-        assertEquals("donizetti", results.get(0).getName());
-        assertEquals("donizetti", results.get(0).getUidValue());
+        assertEquals(AnyTypeKind.USER.name(), results.getFirst().getAnyType());
+        assertNotNull(results.getFirst().getKey());
+        assertEquals("donizetti", results.getFirst().getName());
+        assertEquals("donizetti", results.getFirst().getUidValue());
         assertEquals(ResourceOperation.CREATE, results.get(0).getOperation());
         assertEquals(ProvisioningReport.Status.SUCCESS, results.get(0).getStatus());
 
         AuthContextUtils.runAsAdmin(SyncopeConstants.MASTER_DOMAIN, () -> {
-            UserTO donizetti = userLogic.read(results.get(0).getKey());
+            UserTO donizetti = userLogic.read(results.getFirst().getKey());
             assertNotNull(donizetti);
-            assertEquals("Gaetano", donizetti.getPlainAttr("firstname").get().getValues().get(0));
+            assertEquals("Gaetano", donizetti.getPlainAttr("firstname").get().getValues().getFirst());
             assertEquals(1, donizetti.getPlainAttr("loginDate").get().getValues().size());
 
             UserTO cimarosa = userLogic.read(results.get(1).getKey());
             assertNotNull(cimarosa);
-            assertEquals("Domenico Cimarosa", cimarosa.getPlainAttr("fullname").get().getValues().get(0));
+            assertEquals("Domenico Cimarosa", cimarosa.getPlainAttr("fullname").get().getValues().getFirst());
             assertEquals(2, cimarosa.getPlainAttr("loginDate").get().getValues().size());
         });
     }

--- a/core/idrepo/logic/src/main/java/org/apache/syncope/core/logic/NotificationLogic.java
+++ b/core/idrepo/logic/src/main/java/org/apache/syncope/core/logic/NotificationLogic.java
@@ -108,7 +108,7 @@ public class NotificationLogic extends AbstractJobLogic<NotificationTO> {
     @PreAuthorize("hasRole('" + IdRepoEntitlement.NOTIFICATION_LIST + "')")
     public JobTO getJob() {
         List<JobTO> jobs = super.doListJobs(false);
-        return jobs.isEmpty() ? null : jobs.get(0);
+        return jobs.isEmpty() ? null : jobs.getFirst();
     }
 
     @PreAuthorize("hasRole('" + IdRepoEntitlement.NOTIFICATION_EXECUTE + "')")

--- a/core/idrepo/logic/src/test/java/org/apache/syncope/core/logic/ReportLogicTest.java
+++ b/core/idrepo/logic/src/test/java/org/apache/syncope/core/logic/ReportLogicTest.java
@@ -122,7 +122,7 @@ public class ReportLogicTest extends AbstractTest {
         report = logic.read(report.getKey());
         assertFalse(report.getExecutions().isEmpty());
 
-        String execKey = report.getExecutions().get(0).getKey();
+        String execKey = report.getExecutions().getFirst().getKey();
 
         checkExport(execKey);
     }

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/batch/BatchItemRequest.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/batch/BatchItemRequest.java
@@ -170,7 +170,7 @@ public class BatchItemRequest extends HttpServletRequestWrapper {
     @Override
     public String getContentType() {
         return batchItem.getHeaders().containsKey(HttpHeaders.CONTENT_TYPE)
-                ? batchItem.getHeaders().get(HttpHeaders.CONTENT_TYPE).get(0).toString()
+                ? batchItem.getHeaders().get(HttpHeaders.CONTENT_TYPE).getFirst().toString()
                 : MediaType.ALL_VALUE;
     }
 
@@ -180,7 +180,7 @@ public class BatchItemRequest extends HttpServletRequestWrapper {
         if (batchItem.getHeaders().containsKey(HttpHeaders.CONTENT_LENGTH)) {
             try {
                 contentLength = Integer.parseInt(
-                        batchItem.getHeaders().get(HttpHeaders.CONTENT_LENGTH).get(0).toString());
+                        batchItem.getHeaders().get(HttpHeaders.CONTENT_LENGTH).getFirst().toString());
             } catch (NumberFormatException e) {
                 LOG.error("Invalid value found for {}: {}",
                         HttpHeaders.CONTENT_LENGTH, batchItem.getHeaders().get(HttpHeaders.CONTENT_LENGTH), e);
@@ -197,7 +197,7 @@ public class BatchItemRequest extends HttpServletRequestWrapper {
     @Override
     public String getHeader(final String name) {
         return batchItem.getHeaders().containsKey(name)
-                ? batchItem.getHeaders().get(name).get(0).toString()
+                ? batchItem.getHeaders().get(name).getFirst().toString()
                 : HttpHeaders.CONTENT_TYPE.equals(name) || HttpHeaders.ACCEPT.equals(name)
                 ? MediaType.ALL_VALUE
                 : null;

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/batch/BatchItemResponse.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/batch/BatchItemResponse.java
@@ -152,7 +152,7 @@ public class BatchItemResponse implements HttpServletResponse {
 
     @Override
     public String getHeader(final String name) {
-        return headers.containsKey(name) ? headers.get(name).get(0).toString() : null;
+        return headers.containsKey(name) ? headers.get(name).getFirst().toString() : null;
     }
 
     @Override

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AbstractService.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AbstractService.java
@@ -104,7 +104,7 @@ public abstract class AbstractService implements JAXRSService {
     protected String findActualKey(final AnyDAO<?> dao, final String pretendingKey) {
         String actualKey = pretendingKey;
         if (uriInfo.getPathParameters(true).containsKey("key")) {
-            String keyInPath = uriInfo.getPathParameters(true).get("key").get(0);
+            String keyInPath = uriInfo.getPathParameters(true).get("key").getFirst();
             if (actualKey == null) {
                 actualKey = keyInPath;
             } else if (!actualKey.equals(keyInPath)) {

--- a/core/idrepo/rest-cxf/src/test/java/org/apache/syncope/core/rest/cxf/service/AnyObjectServiceTest.java
+++ b/core/idrepo/rest-cxf/src/test/java/org/apache/syncope/core/rest/cxf/service/AnyObjectServiceTest.java
@@ -229,7 +229,7 @@ public class AnyObjectServiceTest {
 
         Attr location = list.getResult().get(1).getPlainAttr("location").orElse(null);
         assertNotNull(location);
-        assertEquals("there", location.getValues().get(0));
+        assertEquals("there", location.getValues().getFirst());
     }
 
     @Test

--- a/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/dao/search/SearchCond.java
+++ b/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/dao/search/SearchCond.java
@@ -80,9 +80,9 @@ public class SearchCond extends AbstractSearchCond {
 
     public static SearchCond and(final List<SearchCond> conditions) {
         if (conditions.size() == 1) {
-            return conditions.get(0);
+            return conditions.getFirst();
         } else if (conditions.size() > 2) {
-            return and(conditions.get(0), and(conditions.subList(1, conditions.size())));
+            return and(conditions.getFirst(), and(conditions.subList(1, conditions.size())));
         } else {
             return and(conditions.get(0), conditions.get(1));
         }
@@ -104,9 +104,9 @@ public class SearchCond extends AbstractSearchCond {
 
     public static SearchCond or(final List<SearchCond> conditions) {
         if (conditions.size() == 1) {
-            return conditions.get(0);
+            return conditions.getFirst();
         } else if (conditions.size() > 2) {
-            return or(conditions.get(0), or(conditions.subList(1, conditions.size())));
+            return or(conditions.getFirst(), or(conditions.subList(1, conditions.size())));
         } else {
             return or(conditions.get(0), conditions.get(1));
         }

--- a/core/persistence-common/src/main/java/org/apache/syncope/core/persistence/common/dao/AbstractAnyMatchDAO.java
+++ b/core/persistence-common/src/main/java/org/apache/syncope/core/persistence/common/dao/AbstractAnyMatchDAO.java
@@ -476,17 +476,17 @@ public abstract class AbstractAnyMatchDAO implements AnyMatchDAO {
                 anyAttrValues.add(new PlainAttrValue());
                 switch (anyAttrValue) {
                     case String aString ->
-                        anyAttrValues.get(0).setStringValue(aString);
+                        anyAttrValues.getFirst().setStringValue(aString);
                     case Long aLong ->
-                        anyAttrValues.get(0).setLongValue(aLong);
+                        anyAttrValues.getFirst().setLongValue(aLong);
                     case Double aDouble ->
-                        anyAttrValues.get(0).setDoubleValue(aDouble);
+                        anyAttrValues.getFirst().setDoubleValue(aDouble);
                     case Boolean aBoolean ->
-                        anyAttrValues.get(0).setBooleanValue(aBoolean);
+                        anyAttrValues.getFirst().setBooleanValue(aBoolean);
                     case OffsetDateTime offsetDateTime ->
-                        anyAttrValues.get(0).setDateValue(offsetDateTime);
+                        anyAttrValues.getFirst().setDateValue(offsetDateTime);
                     case byte[] bytea ->
-                        anyAttrValues.get(0).setBinaryValue(bytea);
+                        anyAttrValues.getFirst().setBinaryValue(bytea);
                     default -> {
                     }
                 }

--- a/core/persistence-common/src/main/java/org/apache/syncope/core/persistence/common/dao/AnyFinder.java
+++ b/core/persistence-common/src/main/java/org/apache/syncope/core/persistence/common/dao/AnyFinder.java
@@ -73,7 +73,7 @@ public class AnyFinder {
         if (literals.isEmpty()) {
             attrValues.add(attrValue);
         } else {
-            for (String token : attrValue.split(Pattern.quote(literals.get(0)))) {
+            for (String token : attrValue.split(Pattern.quote(literals.getFirst()))) {
                 if (!token.isEmpty()) {
                     attrValues.addAll(split(token, literals.subList(1, literals.size())));
                 }

--- a/core/persistence-jpa-upgrader/src/main/java/org/apache/syncope/core/persistence/jpa/upgrade/GenerateUpgradeSQL.java
+++ b/core/persistence-jpa-upgrader/src/main/java/org/apache/syncope/core/persistence/jpa/upgrade/GenerateUpgradeSQL.java
@@ -184,11 +184,11 @@ public class GenerateUpgradeSQL {
                     String leftEndAnyType = jdbcTemplate.queryForObject(
                             "SELECT type_id from AnyObject WHERE id=?",
                             String.class,
-                            anyObjects.get(0).get("left_anyobject_id"));
+                            anyObjects.getFirst().get("left_anyobject_id"));
                     String rightEndAnyType = jdbcTemplate.queryForObject(
                             "SELECT type_id from AnyObject WHERE id=?",
                             String.class,
-                            anyObjects.get(0).get("right_anyobject_id"));
+                            anyObjects.getFirst().get("right_anyobject_id"));
 
                     result.append("UPDATE RelationshipType ").
                             append("SET leftEndAnyType_id='").append(leftEndAnyType).append("', ").
@@ -199,7 +199,7 @@ public class GenerateUpgradeSQL {
                 String rightEndAnyType = jdbcTemplate.queryForObject(
                         "SELECT type_id from AnyObject WHERE id=?",
                         String.class,
-                        anyObjects.get(0).get("anyobject_id"));
+                        anyObjects.getFirst().get("anyobject_id"));
 
                 result.append("UPDATE RelationshipType ").
                         append("SET leftEndAnyType_id='USER', ").

--- a/core/persistence-jpa-upgrader/src/test/java/org/apache/syncope/core/persistence/jpa/upgrade/VerifySyncope4Test.java
+++ b/core/persistence-jpa-upgrader/src/test/java/org/apache/syncope/core/persistence/jpa/upgrade/VerifySyncope4Test.java
@@ -203,6 +203,6 @@ class VerifySyncope4Test {
                 "Antonio",
                 userDAO.findByUsername("vivaldi").orElseThrow().
                         getPlainAttr("firstname").orElseThrow().
-                        getValuesAsStrings().get(0));
+                        getValuesAsStrings().getFirst());
     }
 }

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/MasterDomain.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/MasterDomain.java
@@ -37,13 +37,13 @@ public class MasterDomain {
     @Bean(name = "MasterDataSource")
     public JndiObjectFactoryBean masterDataSource(final PersistenceProperties props) {
         HikariConfig hikariConfig = new HikariConfig();
-        hikariConfig.setDriverClassName(props.getDomain().get(0).getJdbcDriver());
-        hikariConfig.setJdbcUrl(props.getDomain().get(0).getJdbcURL());
-        hikariConfig.setUsername(props.getDomain().get(0).getDbUsername());
-        hikariConfig.setPassword(props.getDomain().get(0).getDbPassword());
-        hikariConfig.setTransactionIsolation(props.getDomain().get(0).getTransactionIsolation().name());
-        hikariConfig.setMaximumPoolSize(props.getDomain().get(0).getPoolMaxActive());
-        hikariConfig.setMinimumIdle(props.getDomain().get(0).getPoolMinIdle());
+        hikariConfig.setDriverClassName(props.getDomain().getFirst().getJdbcDriver());
+        hikariConfig.setJdbcUrl(props.getDomain().getFirst().getJdbcURL());
+        hikariConfig.setUsername(props.getDomain().getFirst().getDbUsername());
+        hikariConfig.setPassword(props.getDomain().getFirst().getDbPassword());
+        hikariConfig.setTransactionIsolation(props.getDomain().getFirst().getTransactionIsolation().name());
+        hikariConfig.setMaximumPoolSize(props.getDomain().getFirst().getPoolMaxActive());
+        hikariConfig.setMinimumIdle(props.getDomain().getFirst().getPoolMinIdle());
 
         JndiObjectFactoryBean masterDataSource = new JndiObjectFactoryBean();
         masterDataSource.setJndiName("java:comp/env/jdbc/syncopeMasterDataSource");
@@ -56,7 +56,7 @@ public class MasterDomain {
             final ResourceLoader resourceLoader,
             final PersistenceProperties props) throws IOException {
 
-        return resourceLoader.getResource(props.getDomain().get(0).getContent()).getInputStream();
+        return resourceLoader.getResource(props.getDomain().getFirst().getContent()).getInputStream();
     }
 
     @Bean(name = "MasterKeymasterConfParamsJSON")
@@ -64,11 +64,11 @@ public class MasterDomain {
             final ResourceLoader resourceLoader,
             final PersistenceProperties props) throws IOException {
 
-        return resourceLoader.getResource(props.getDomain().get(0).getKeymasterConfParams()).getInputStream();
+        return resourceLoader.getResource(props.getDomain().getFirst().getKeymasterConfParams()).getInputStream();
     }
 
     @Bean(name = "MasterDatabaseSchema")
     public String masterDatabaseSchema(final PersistenceProperties props) {
-        return props.getDomain().get(0).getDbSchema();
+        return props.getDomain().getFirst().getDbSchema();
     }
 }

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/AbstractJPAAnySearchDAO.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/AbstractJPAAnySearchDAO.java
@@ -847,13 +847,13 @@ abstract class AbstractJPAAnySearchDAO extends AbstractAnySearchDAO {
             fromString = sv.name() + " " + sv.alias();
         } else {
             List<SearchSupport.SearchView> joins = new ArrayList<>(from);
-            StringBuilder join = new StringBuilder(joins.get(0).name() + " " + joins.get(0).alias());
+            StringBuilder join = new StringBuilder(joins.getFirst().name() + " " + joins.getFirst().alias());
             for (int i = 1; i < joins.size(); i++) {
                 SearchSupport.SearchView sv = joins.get(i);
                 join.append(" LEFT JOIN ").
                         append(sv.name()).append(" ").append(sv.alias()).
                         append(" ON ").
-                        append(joins.get(0).alias()).append(".any_id=").append(sv.alias()).append(".any_id");
+                        append(joins.getFirst().alias()).append(".any_id=").append(sv.alias()).append(".any_id");
             }
             fromString = join.toString();
         }

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/JPATaskExecDAO.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/JPATaskExecDAO.java
@@ -128,7 +128,7 @@ public class JPATaskExecDAO implements TaskExecDAO {
         List<Object> result = query.getResultList();
         return CollectionUtils.isEmpty(result)
                 ? Optional.empty()
-                : Optional.of((TaskExec<?>) result.get(0));
+                : Optional.of((TaskExec<?>) result.getFirst());
     }
 
     @Override

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/repo/ReportExecRepoExtImpl.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/repo/ReportExecRepoExtImpl.java
@@ -60,7 +60,7 @@ public class ReportExecRepoExtImpl implements ReportExecRepoExt {
         List<ReportExec> result = query.getResultList();
         return result == null || result.isEmpty()
                 ? null
-                : result.iterator().next();
+                : result.getFirst();
     }
 
     @Override

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/spring/DomainRoutingEntityManagerFactory.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/spring/DomainRoutingEntityManagerFactory.java
@@ -77,11 +77,11 @@ public class DomainRoutingEntityManagerFactory implements EntityManagerFactory, 
         OpenJpaVendorAdapter vendorAdapter = new OpenJpaVendorAdapter();
         vendorAdapter.setShowSql(false);
         vendorAdapter.setGenerateDdl(true);
-        vendorAdapter.setDatabasePlatform(props.getDomain().get(0).getDatabasePlatform());
+        vendorAdapter.setDatabasePlatform(props.getDomain().getFirst().getDatabasePlatform());
 
         DomainEntityManagerFactoryBean emf = new DomainEntityManagerFactoryBean();
         emf.setPersistenceUnitName(SyncopeConstants.MASTER_DOMAIN);
-        emf.setMappingResources(props.getDomain().get(0).getOrm());
+        emf.setMappingResources(props.getDomain().getFirst().getOrm());
         emf.setDataSource(Objects.requireNonNull((DataSource) dataSource.getObject()));
         emf.setJpaVendorAdapter(vendorAdapter);
         emf.setCommonEntityManagerFactoryConf(commonEMFConf);
@@ -91,8 +91,8 @@ public class DomainRoutingEntityManagerFactory implements EntityManagerFactory, 
         addToJpaPropertyMap(
                 emf,
                 vendorAdapter,
-                props.getDomain().get(0).getDbSchema(),
-                props.getDomain().get(0).getOrm(),
+                props.getDomain().getFirst().getDbSchema(),
+                props.getDomain().getFirst().getOrm(),
                 props.getMetaDataFactory());
 
         emf.afterPropertiesSet();

--- a/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/AccessTokenTest.java
+++ b/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/AccessTokenTest.java
@@ -85,7 +85,7 @@ public class AccessTokenTest extends AbstractTest {
 
         list = page.get().toList();
         assertEquals(1, list.size());
-        assertEquals("2", list.get(0).getKey());
+        assertEquals("2", list.getFirst().getKey());
     }
 
     @Test

--- a/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/AnySearchTest.java
+++ b/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/AnySearchTest.java
@@ -110,7 +110,7 @@ public class AnySearchTest extends AbstractTest {
         User rossini = userDAO.findByUsername("rossini").orElseThrow();
 
         PlainAttr loginDate = rossini.getPlainAttr("loginDate").orElseThrow();
-        loginDate.getValues().get(0).setDateValue(FormatUtils.parseDate(LOGIN_DATE_VALUE, "yyyy-MM-dd"));
+        loginDate.getValues().getFirst().setDateValue(FormatUtils.parseDate(LOGIN_DATE_VALUE, "yyyy-MM-dd"));
 
         userDAO.save(rossini);
     }
@@ -289,7 +289,7 @@ public class AnySearchTest extends AbstractTest {
         assertNotNull(users);
         assertEquals(1, users.size());
 
-        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", users.get(0).getKey());
+        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", users.getFirst().getKey());
     }
 
     @Test
@@ -301,13 +301,13 @@ public class AnySearchTest extends AbstractTest {
         List<User> users = searchDAO.search(SearchCond.of(anyCond), AnyTypeKind.USER);
         assertNotNull(users);
         assertEquals(1, users.size());
-        assertEquals("rossini", users.get(0).getUsername());
+        assertEquals("rossini", users.getFirst().getUsername());
 
         anyCond.setExpression("/even");
         users = searchDAO.search(SearchCond.of(anyCond), AnyTypeKind.USER);
         assertNotNull(users);
         assertEquals(1, users.size());
-        assertEquals("rossini", users.get(0).getUsername());
+        assertEquals("rossini", users.getFirst().getUsername());
     }
 
     @Test
@@ -465,8 +465,8 @@ public class AnySearchTest extends AbstractTest {
         List<User> matching = searchDAO.search(searchCondition, AnyTypeKind.USER);
         assertNotNull(matching);
         assertEquals(1, matching.size());
-        assertEquals("rossini", matching.iterator().next().getUsername());
-        assertEquals("1417acbe-cbf6-4277-9372-e75e04f97000", matching.iterator().next().getKey());
+        assertEquals("rossini", matching.getFirst().getUsername());
+        assertEquals("1417acbe-cbf6-4277-9372-e75e04f97000", matching.getFirst().getKey());
     }
 
     @Test
@@ -488,8 +488,8 @@ public class AnySearchTest extends AbstractTest {
         List<Group> matching = searchDAO.search(searchCondition, AnyTypeKind.GROUP);
         assertNotNull(matching);
         assertEquals(1, matching.size());
-        assertEquals("root", matching.iterator().next().getName());
-        assertEquals("37d15e4c-cdc1-460b-a591-8505c8133806", matching.iterator().next().getKey());
+        assertEquals("root", matching.getFirst().getName());
+        assertEquals("37d15e4c-cdc1-460b-a591-8505c8133806", matching.getFirst().getKey());
     }
 
     @Test
@@ -542,7 +542,7 @@ public class AnySearchTest extends AbstractTest {
         List<User> users = searchDAO.search(searchCondition, AnyTypeKind.USER);
         assertNotNull(users);
         assertEquals(1, users.size());
-        assertEquals("74cd8ece-715a-44a4-a736-e17b46c4e7e6", users.iterator().next().getKey());
+        assertEquals("74cd8ece-715a-44a4-a736-e17b46c4e7e6", users.getFirst().getKey());
     }
 
     @Test
@@ -587,7 +587,7 @@ public class AnySearchTest extends AbstractTest {
         List<User> users = searchDAO.search(cond, AnyTypeKind.USER);
         assertNotNull(users);
         assertEquals(1, users.size());
-        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", users.get(0).getKey());
+        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", users.getFirst().getKey());
     }
 
     @Test
@@ -602,7 +602,7 @@ public class AnySearchTest extends AbstractTest {
         List<AnyObject> anyObjects = searchDAO.search(searchCondition, AnyTypeKind.ANY_OBJECT);
         assertNotNull(anyObjects);
         assertEquals(1, anyObjects.size());
-        assertEquals("9e1d130c-d6a3-48b1-98b3-182477ed0688", anyObjects.iterator().next().getKey());
+        assertEquals("9e1d130c-d6a3-48b1-98b3-182477ed0688", anyObjects.getFirst().getKey());
     }
 
     @Test
@@ -617,7 +617,7 @@ public class AnySearchTest extends AbstractTest {
         List<User> users = searchDAO.search(searchCondition, AnyTypeKind.USER);
         assertNotNull(users);
         assertEquals(1, users.size());
-        assertEquals("1417acbe-cbf6-4277-9372-e75e04f97000", users.iterator().next().getKey());
+        assertEquals("1417acbe-cbf6-4277-9372-e75e04f97000", users.getFirst().getKey());
     }
 
     @Test
@@ -722,7 +722,7 @@ public class AnySearchTest extends AbstractTest {
                     PageRequest.of(0, 10),
                     AnyTypeKind.GROUP);
             assertEquals(1, groups.size());
-            assertEquals("37d15e4c-cdc1-460b-a591-8505c8133806", groups.get(0).getKey());
+            assertEquals("37d15e4c-cdc1-460b-a591-8505c8133806", groups.getFirst().getKey());
         } finally {
             SecurityContextHolder.getContext().setAuthentication(null);
         }

--- a/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/AuthProfileTest.java
+++ b/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/AuthProfileTest.java
@@ -130,12 +130,12 @@ public class AuthProfileTest extends AbstractTest {
         String secret = SecureRandomUtils.generateRandomUUID().toString();
         List<GoogleMfaAuthAccount> googleMfaAuthAccounts = authProfile.getGoogleMfaAuthAccounts();
         assertFalse(googleMfaAuthAccounts.isEmpty());
-        GoogleMfaAuthAccount googleMfaAuthAccount = googleMfaAuthAccounts.get(0);
+        GoogleMfaAuthAccount googleMfaAuthAccount = googleMfaAuthAccounts.getFirst();
         googleMfaAuthAccount.setSecretKey(secret);
 
         authProfile.setGoogleMfaAuthAccounts(googleMfaAuthAccounts);
         authProfile = authProfileDAO.save(authProfile);
-        assertEquals(secret, authProfile.getGoogleMfaAuthAccounts().get(0).getSecretKey());
+        assertEquals(secret, authProfile.getGoogleMfaAuthAccounts().getFirst().getSecretKey());
     }
 
     @Test

--- a/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/MultitenancyTest.java
+++ b/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/MultitenancyTest.java
@@ -77,7 +77,7 @@ public class MultitenancyTest extends AbstractTest {
                 realmSearchDAO.findDescendants(realmDAO.getRoot().getFullPath(), null, Pageable.unpaged()).size());
         assertEquals(
                 realmDAO.getRoot(),
-                realmSearchDAO.findDescendants(realmDAO.getRoot().getFullPath(), null, Pageable.unpaged()).get(0));
+                realmSearchDAO.findDescendants(realmDAO.getRoot().getFullPath(), null, Pageable.unpaged()).getFirst());
     }
 
     @Test

--- a/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/PlainAttrTest.java
+++ b/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/PlainAttrTest.java
@@ -133,7 +133,7 @@ public class PlainAttrTest extends AbstractTest {
         assertNotNull(obscure);
         assertEquals(1, obscure.getValues().size());
         assertEquals(encryptorManager.getInstance(obscureSchema.getSecretKey()).
-                encode("testvalue", obscureSchema.getCipherAlgorithm()), obscure.getValues().get(0).getStringValue());
+                encode("testvalue", obscureSchema.getCipherAlgorithm()), obscure.getValues().getFirst().getStringValue());
     }
 
     @Test
@@ -156,7 +156,7 @@ public class PlainAttrTest extends AbstractTest {
         attr.add(validator, "testvalue");
 
         assertEquals(encryptorManager.getInstance(obscureSchema.getSecretKey()).
-                encode("testvalue", obscureSchema.getCipherAlgorithm()), attr.getValues().get(0).getStringValue());
+                encode("testvalue", obscureSchema.getCipherAlgorithm()), attr.getValues().getFirst().getStringValue());
     }
 
     @Test
@@ -176,13 +176,13 @@ public class PlainAttrTest extends AbstractTest {
 
         assertEquals(encryptorManager.getInstance(obscureWithDecodeConversionPattern.getSecretKey()).
                 encode("testvalue", obscureWithDecodeConversionPattern.getCipherAlgorithm()),
-                attr.getValues().get(0).getStringValue());
+                attr.getValues().getFirst().getStringValue());
 
         obscureWithDecodeConversionPattern.setConversionPattern(SyncopeConstants.ENCRYPTED_DECODE_CONVERSION_PATTERN);
         plainSchemaDAO.save(obscureWithDecodeConversionPattern);
 
-        assertNotEquals("testvalue", attr.getValues().get(0).getStringValue());
-        assertEquals("testvalue", attr.getValuesAsStrings().get(0));
+        assertNotEquals("testvalue", attr.getValues().getFirst().getStringValue());
+        assertEquals("testvalue", attr.getValuesAsStrings().getFirst());
     }
 
     @Test
@@ -206,6 +206,6 @@ public class PlainAttrTest extends AbstractTest {
         PlainAttr photo = user.getPlainAttr("photo").orElseThrow();
         assertNotNull(photo);
         assertEquals(1, photo.getValues().size());
-        assertTrue(Arrays.equals(bytes, photo.getValues().get(0).getBinaryValue()));
+        assertTrue(Arrays.equals(bytes, photo.getValues().getFirst().getBinaryValue()));
     }
 }

--- a/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/PlainAttrTest.java
+++ b/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/PlainAttrTest.java
@@ -133,7 +133,8 @@ public class PlainAttrTest extends AbstractTest {
         assertNotNull(obscure);
         assertEquals(1, obscure.getValues().size());
         assertEquals(encryptorManager.getInstance(obscureSchema.getSecretKey()).
-                encode("testvalue", obscureSchema.getCipherAlgorithm()), obscure.getValues().getFirst().getStringValue());
+                encode("testvalue", obscureSchema.getCipherAlgorithm()),
+            obscure.getValues().getFirst().getStringValue());
     }
 
     @Test

--- a/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/PlainSchemaTest.java
+++ b/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/PlainSchemaTest.java
@@ -61,7 +61,7 @@ public class PlainSchemaTest extends AbstractTest {
     public void findByIdLike() {
         List<? extends PlainSchema> schemas = plainSchemaDAO.findByIdLike("fullna%");
         assertEquals(1, schemas.size());
-        assertEquals(0, schemas.get(0).getLabels().size());
+        assertEquals(0, schemas.getFirst().getLabels().size());
     }
 
     @Test

--- a/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/TaskTest.java
+++ b/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/TaskTest.java
@@ -215,10 +215,10 @@ public class TaskTest extends AbstractTest {
         task = taskDAO.save(task);
         assertNotNull(task);
         assertEquals(1, task.getCommands().size());
-        assertEquals(command, task.getCommands().get(0).getCommand());
+        assertEquals(command, task.getCommands().getFirst().getCommand());
         assertEquals(1, task.getFormPropertyDefs().size());
-        assertNotNull(task.getFormPropertyDefs().get(0).getKey());
-        assertEquals(formPropertyDef, task.getFormPropertyDefs().get(0));
+        assertNotNull(task.getFormPropertyDefs().getFirst().getKey());
+        assertEquals(formPropertyDef, task.getFormPropertyDefs().getFirst());
 
         MacroTask actual = (MacroTask) taskDAO.findById(TaskType.MACRO, task.getKey()).orElseThrow();
         assertEquals(task, actual);

--- a/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/UserTest.java
+++ b/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/inner/UserTest.java
@@ -82,8 +82,8 @@ public class UserTest extends AbstractTest {
         assertNull(user.getSecurityQuestion());
         assertNull(user.getSecurityAnswer());
         assertEquals("admin", user.getCreator());
-        assertEquals("Giacomo", user.getPlainAttr("firstname").orElseThrow().getValuesAsStrings().get(0));
-        assertEquals("Puccini", user.getPlainAttr("surname").orElseThrow().getValuesAsStrings().get(0));
+        assertEquals("Giacomo", user.getPlainAttr("firstname").orElseThrow().getValuesAsStrings().getFirst());
+        assertEquals("Puccini", user.getPlainAttr("surname").orElseThrow().getValuesAsStrings().getFirst());
     }
 
     @Test

--- a/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/outer/AnySearchTest.java
+++ b/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/outer/AnySearchTest.java
@@ -108,7 +108,7 @@ public class AnySearchTest extends AbstractTest {
         List<User> users = searchDAO.search(SearchCond.of(roleCond), AnyTypeKind.USER);
         assertNotNull(users);
         assertEquals(1, users.size());
-        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", users.get(0).getKey());
+        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", users.getFirst().getKey());
     }
 
     @Test
@@ -146,7 +146,7 @@ public class AnySearchTest extends AbstractTest {
                 SearchCond.of(anyCond), PageRequest.of(0, 100), AnyTypeKind.USER);
         assertNotNull(users);
         assertEquals(1, users.size());
-        assertEquals(rossini.getKey(), users.get(0).getKey());
+        assertEquals(rossini.getKey(), users.getFirst().getKey());
     }
 
     @Test
@@ -170,7 +170,7 @@ public class AnySearchTest extends AbstractTest {
         PlainAttr attr = new PlainAttr();
         attr.setSchema("ctype");
         attr.add(validator, "otherchildctype");
-        attr.setMembership(anyObject.getMemberships().get(0).getKey());
+        attr.setMembership(anyObject.getMemberships().getFirst().getKey());
         anyObject.add(attr);
         anyObjectDAO.save(anyObject);
 
@@ -196,7 +196,7 @@ public class AnySearchTest extends AbstractTest {
         assertNotNull(users);
         assertEquals(1, users.size());
 
-        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", users.get(0).getKey());
+        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", users.getFirst().getKey());
     }
 
     @Test
@@ -248,7 +248,7 @@ public class AnySearchTest extends AbstractTest {
 
         List<Group> matching = searchDAO.search(SearchCond.of(titleCond), AnyTypeKind.GROUP);
         assertEquals(1, matching.size());
-        assertEquals(group.getKey(), matching.get(0).getKey());
+        assertEquals(group.getKey(), matching.getFirst().getKey());
 
         AttrCond originalNameCond = new AttrCond(AttrCond.Type.EQ);
         originalNameCond.setSchema("originalName");
@@ -256,7 +256,7 @@ public class AnySearchTest extends AbstractTest {
 
         matching = searchDAO.search(SearchCond.of(originalNameCond), AnyTypeKind.GROUP);
         assertEquals(1, matching.size());
-        assertEquals(group.getKey(), matching.get(0).getKey());
+        assertEquals(group.getKey(), matching.getFirst().getKey());
     }
 
     @Test
@@ -272,7 +272,7 @@ public class AnySearchTest extends AbstractTest {
         List<User> users = searchDAO.search(cond, AnyTypeKind.USER);
         assertNotNull(users);
         assertEquals(1, users.size());
-        assertEquals("verdi", users.get(0).getUsername());
+        assertEquals("verdi", users.getFirst().getUsername());
 
         // 1. set rossini's email address for conditions as per SYNCOPE-1790
         User rossini = userDAO.findByUsername("rossini").orElseThrow();
@@ -288,12 +288,12 @@ public class AnySearchTest extends AbstractTest {
         rossini = userDAO.findByUsername("rossini").orElseThrow();
         assertEquals(
                 "bisverdi@syncope.org",
-                rossini.getPlainAttr("email").map(a -> a.getValuesAsStrings().get(0)).orElseThrow());
+                rossini.getPlainAttr("email").map(a -> a.getValuesAsStrings().getFirst()).orElseThrow());
 
         // 2. search again
         users = searchDAO.search(cond, AnyTypeKind.USER);
         assertNotNull(users);
         assertEquals(1, users.size());
-        assertEquals("verdi", users.get(0).getUsername());
+        assertEquals("verdi", users.getFirst().getUsername());
     }
 }

--- a/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/outer/AnyTypeClassTest.java
+++ b/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/outer/AnyTypeClassTest.java
@@ -64,8 +64,8 @@ public class AnyTypeClassTest extends AbstractTest {
         newClass = anyTypeClassDAO.findById(newClass.getKey()).orElseThrow();
         assertNotNull(newClass);
         assertEquals(1, newClass.getPlainSchemas().size());
-        assertEquals(newSchema, newClass.getPlainSchemas().get(0));
-        assertEquals(newClass, newClass.getPlainSchemas().get(0).getAnyTypeClass());
+        assertEquals(newSchema, newClass.getPlainSchemas().getFirst());
+        assertEquals(newClass, newClass.getPlainSchemas().getFirst().getAnyTypeClass());
 
         assertTrue(plainSchemaDAO.findById(newSchema.getKey()).isPresent());
     }

--- a/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/outer/DynRealmTest.java
+++ b/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/outer/DynRealmTest.java
@@ -99,7 +99,7 @@ public class DynRealmTest extends AbstractTest {
         List<User> matching = searchDAO.search(SearchCond.of(dynRealmCond), AnyTypeKind.USER);
         assertNotNull(matching);
         assertFalse(matching.isEmpty());
-        User user = matching.get(0);
+        User user = matching.getFirst();
         assertTrue(anyMatchDAO.matches(user, SearchCond.of(dynRealmCond)));
 
         assertTrue(userDAO.findDynRealms(user.getKey()).contains(actual.getKey()));

--- a/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/outer/GroupTest.java
+++ b/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/outer/GroupTest.java
@@ -305,7 +305,7 @@ public class GroupTest extends AbstractTest {
         actual = groupDAO.findById(actual.getKey()).orElseThrow();
         members = groupDAO.findUDynMembers(actual);
         assertEquals(1, members.size());
-        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", members.get(0));
+        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", members.getFirst());
 
         // 5. delete group and verify that dynamic membership was also removed
         String dynMembershipKey = actual.getUDynMembership().getKey();
@@ -404,7 +404,7 @@ public class GroupTest extends AbstractTest {
                 object -> "PRINTER".equals(anyObjectDAO.findById(object).
                         orElseThrow().getType().getKey())).toList();
         assertEquals(1, members.size());
-        assertEquals("fc6dbc3a-6c07-4965-8781-921e7401a4a5", members.get(0));
+        assertEquals("fc6dbc3a-6c07-4965-8781-921e7401a4a5", members.getFirst());
 
         // 5. delete group and verify that dynamic membership was also removed
         String dynMembershipKey = actual.getADynMembership(anyTypeDAO.findById("PRINTER").orElseThrow()).get().getKey();
@@ -444,7 +444,7 @@ public class GroupTest extends AbstractTest {
 
         group = groupDAO.findByName("root").orElseThrow();
         assertEquals(1, group.getRelationships().size());
-        assertEquals("8559d14d-58c2-46eb-a2d4-a7d35161e8f8", group.getRelationships().get(0).getRightEnd().getKey());
+        assertEquals("8559d14d-58c2-46eb-a2d4-a7d35161e8f8", group.getRelationships().getFirst().getRightEnd().getKey());
     }
 
     @Test
@@ -468,7 +468,7 @@ public class GroupTest extends AbstractTest {
         entityManager.flush();
 
         group = groupDAO.findById(group.getKey()).orElseThrow();
-        assertEquals("syncope's group", group.getPlainAttr("title").get().getValuesAsStrings().get(0));
-        assertEquals("syncope's group", group.getPlainAttr("originalName").get().getValuesAsStrings().get(0));
+        assertEquals("syncope's group", group.getPlainAttr("title").get().getValuesAsStrings().getFirst());
+        assertEquals("syncope's group", group.getPlainAttr("originalName").get().getValuesAsStrings().getFirst());
     }
 }

--- a/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/outer/GroupTest.java
+++ b/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/outer/GroupTest.java
@@ -444,7 +444,8 @@ public class GroupTest extends AbstractTest {
 
         group = groupDAO.findByName("root").orElseThrow();
         assertEquals(1, group.getRelationships().size());
-        assertEquals("8559d14d-58c2-46eb-a2d4-a7d35161e8f8", group.getRelationships().getFirst().getRightEnd().getKey());
+        assertEquals("8559d14d-58c2-46eb-a2d4-a7d35161e8f8",
+            group.getRelationships().getFirst().getRightEnd().getKey());
     }
 
     @Test

--- a/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/outer/RoleTest.java
+++ b/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/outer/RoleTest.java
@@ -145,7 +145,7 @@ public class RoleTest extends AbstractTest {
         actual = roleDAO.findById(actual.getKey()).orElseThrow();
         members = roleDAO.findDynMembers(actual);
         assertEquals(1, members.size());
-        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", members.get(0));
+        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", members.getFirst());
 
         // 5. delete role and verify that dynamic membership was also removed
         roleDAO.delete(actual);

--- a/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/outer/UserTest.java
+++ b/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/outer/UserTest.java
@@ -109,9 +109,9 @@ public class UserTest extends AbstractTest {
     public void ships() {
         User user = userDAO.findByUsername("bellini").orElseThrow();
         assertEquals(1, user.getMemberships().size());
-        assertEquals("bf825fe1-7320-4a54-bd64-143b5c18ab97", user.getMemberships().get(0).getRightEnd().getKey());
+        assertEquals("bf825fe1-7320-4a54-bd64-143b5c18ab97", user.getMemberships().getFirst().getRightEnd().getKey());
 
-        user.remove(user.getMemberships().get(0));
+        user.remove(user.getMemberships().getFirst());
 
         UMembership newM = entityFactory.newEntity(UMembership.class);
         newM.setLeftEnd(user);
@@ -126,13 +126,13 @@ public class UserTest extends AbstractTest {
         assertEquals(1, user.getMemberships().size());
         assertEquals(
                 "ba9ed509-b1f5-48ab-a334-c8530a6422dc",
-                user.getMemberships().get(0).getRightEnd().getKey());
+                user.getMemberships().getFirst().getRightEnd().getKey());
         assertEquals(1, user.getRelationships().size());
         assertEquals(
                 "fc6dbc3a-6c07-4965-8781-921e7401a4a5",
-                user.getRelationships().get(0).getRightEnd().getKey());
+                user.getRelationships().getFirst().getRightEnd().getKey());
 
-        user.getRelationships().remove(0);
+        user.getRelationships().removeFirst();
 
         URelationship newR = entityFactory.newEntity(URelationship.class);
         newR.setType(relationshipTypeDAO.findById("neighborhood").orElseThrow());
@@ -146,7 +146,7 @@ public class UserTest extends AbstractTest {
 
         user = userDAO.findByUsername("bellini").orElseThrow();
         assertEquals(1, user.getRelationships().size());
-        assertEquals("8559d14d-58c2-46eb-a2d4-a7d35161e8f8", user.getRelationships().get(0).getRightEnd().getKey());
+        assertEquals("8559d14d-58c2-46eb-a2d4-a7d35161e8f8", user.getRelationships().getFirst().getRightEnd().getKey());
     }
 
     private LinkedAccount newLinkedAccount(final String connObjectKeyValue) {
@@ -176,7 +176,7 @@ public class UserTest extends AbstractTest {
 
         assertEquals(1, user.getLinkedAccounts().size());
 
-        return user.getLinkedAccounts().get(0);
+        return user.getLinkedAccounts().getFirst();
     }
 
     @Test
@@ -196,7 +196,7 @@ public class UserTest extends AbstractTest {
         List<LinkedAccount> accounts = userDAO.findLinkedAccountsByResource(
                 resourceDAO.findById("resource-ldap").orElseThrow());
         assertEquals(1, accounts.size());
-        assertEquals(account, accounts.get(0));
+        assertEquals(account, accounts.getFirst());
     }
 
     @Test
@@ -265,7 +265,7 @@ public class UserTest extends AbstractTest {
         // add derived attributes to user
         User owner = userDAO.findByUsername("vivaldi").orElseThrow();
 
-        String firstname = owner.getPlainAttr("firstname").get().getValuesAsStrings().iterator().next();
+        String firstname = owner.getPlainAttr("firstname").get().getValuesAsStrings().getFirst();
         assertNotNull(firstname);
 
         // search by ksuffix derived attribute

--- a/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/MasterDomain.java
+++ b/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/MasterDomain.java
@@ -40,7 +40,8 @@ public class MasterDomain {
     public Driver masterDriver(final PersistenceProperties props) {
         return GraphDatabase.driver(
                 props.getDomain().getFirst().getUri(),
-                AuthTokens.basic(props.getDomain().getFirst().getUsername(), props.getDomain().getFirst().getPassword()),
+                AuthTokens.basic(props.getDomain().getFirst().getUsername(),
+                    props.getDomain().getFirst().getPassword()),
                 Config.builder().
                         withMaxConnectionPoolSize(props.getDomain().getFirst().getMaxConnectionPoolSize()).
                         withDriverMetrics().

--- a/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/MasterDomain.java
+++ b/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/MasterDomain.java
@@ -39,10 +39,10 @@ public class MasterDomain {
     @Bean(name = "MasterDriver")
     public Driver masterDriver(final PersistenceProperties props) {
         return GraphDatabase.driver(
-                props.getDomain().get(0).getUri(),
-                AuthTokens.basic(props.getDomain().get(0).getUsername(), props.getDomain().get(0).getPassword()),
+                props.getDomain().getFirst().getUri(),
+                AuthTokens.basic(props.getDomain().getFirst().getUsername(), props.getDomain().getFirst().getPassword()),
                 Config.builder().
-                        withMaxConnectionPoolSize(props.getDomain().get(0).getMaxConnectionPoolSize()).
+                        withMaxConnectionPoolSize(props.getDomain().getFirst().getMaxConnectionPoolSize()).
                         withDriverMetrics().
                         withLogging(Logging.slf4j()).build());
     }
@@ -52,7 +52,7 @@ public class MasterDomain {
             final ResourceLoader resourceLoader,
             final PersistenceProperties props) throws IOException {
 
-        return resourceLoader.getResource(props.getDomain().get(0).getContent()).getInputStream();
+        return resourceLoader.getResource(props.getDomain().getFirst().getContent()).getInputStream();
     }
 
     @Bean(name = "MasterKeymasterConfParamsJSON")
@@ -60,6 +60,6 @@ public class MasterDomain {
             final ResourceLoader resouceLoader,
             final PersistenceProperties props) throws IOException {
 
-        return resouceLoader.getResource(props.getDomain().get(0).getKeymasterConfParams()).getInputStream();
+        return resouceLoader.getResource(props.getDomain().getFirst().getKeymasterConfParams()).getInputStream();
     }
 }

--- a/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/dao/repo/AbstractAnyRepoExt.java
+++ b/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/dao/repo/AbstractAnyRepoExt.java
@@ -79,7 +79,7 @@ public abstract class AbstractAnyRepoExt<A extends Any, N extends AbstractAny>
         if (literals.isEmpty()) {
             attrValues.add(attrValue);
         } else {
-            for (String token : attrValue.split(Pattern.quote(literals.get(0)))) {
+            for (String token : attrValue.split(Pattern.quote(literals.getFirst()))) {
                 if (!token.isEmpty()) {
                     attrValues.addAll(split(token, literals.subList(1, literals.size())));
                 }

--- a/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/inner/AccessTokenTest.java
+++ b/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/inner/AccessTokenTest.java
@@ -86,7 +86,7 @@ public class AccessTokenTest extends AbstractTest {
 
         list = page.get().toList();
         assertEquals(1, list.size());
-        assertEquals("2", list.get(0).getKey());
+        assertEquals("2", list.getFirst().getKey());
     }
 
     @Test

--- a/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/inner/AnyObjectTest.java
+++ b/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/inner/AnyObjectTest.java
@@ -63,10 +63,10 @@ public class AnyObjectTest extends AbstractTest {
         assertFalse(anyObject.getType().getClasses().isEmpty());
 
         PlainAttr model = anyObject.getPlainAttr("model").orElseThrow();
-        assertEquals("HP Laserjet 1300n", model.getValuesAsStrings().get(0));
+        assertEquals("HP Laserjet 1300n", model.getValuesAsStrings().getFirst());
 
         PlainAttr location = anyObject.getPlainAttr("location").orElseThrow();
-        assertEquals("2nd floor", location.getValuesAsStrings().get(0));
+        assertEquals("2nd floor", location.getValuesAsStrings().getFirst());
     }
 
     @Test

--- a/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/inner/AnySearchTest.java
+++ b/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/inner/AnySearchTest.java
@@ -110,7 +110,7 @@ public class AnySearchTest extends AbstractTest {
         User rossini = userDAO.findByUsername("rossini").orElseThrow();
 
         PlainAttr loginDate = rossini.getPlainAttr("loginDate").get();
-        loginDate.getValues().get(0).setDateValue(FormatUtils.parseDate(LOGIN_DATE_VALUE, "yyyy-MM-dd"));
+        loginDate.getValues().getFirst().setDateValue(FormatUtils.parseDate(LOGIN_DATE_VALUE, "yyyy-MM-dd"));
 
         userDAO.save(rossini);
     }
@@ -314,7 +314,7 @@ public class AnySearchTest extends AbstractTest {
         assertNotNull(users);
         assertEquals(1, users.size());
 
-        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", users.get(0).getKey());
+        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", users.getFirst().getKey());
     }
 
     @Test
@@ -326,13 +326,13 @@ public class AnySearchTest extends AbstractTest {
         List<User> users = searchDAO.search(SearchCond.of(anyCond), AnyTypeKind.USER);
         assertNotNull(users);
         assertEquals(1, users.size());
-        assertEquals("rossini", users.get(0).getUsername());
+        assertEquals("rossini", users.getFirst().getUsername());
 
         anyCond.setExpression("/even");
         users = searchDAO.search(SearchCond.of(anyCond), AnyTypeKind.USER);
         assertNotNull(users);
         assertEquals(1, users.size());
-        assertEquals("rossini", users.get(0).getUsername());
+        assertEquals("rossini", users.getFirst().getUsername());
     }
 
     @Test
@@ -490,8 +490,8 @@ public class AnySearchTest extends AbstractTest {
         List<User> matching = searchDAO.search(searchCondition, AnyTypeKind.USER);
         assertNotNull(matching);
         assertEquals(1, matching.size());
-        assertEquals("rossini", matching.iterator().next().getUsername());
-        assertEquals("1417acbe-cbf6-4277-9372-e75e04f97000", matching.iterator().next().getKey());
+        assertEquals("rossini", matching.getFirst().getUsername());
+        assertEquals("1417acbe-cbf6-4277-9372-e75e04f97000", matching.getFirst().getKey());
     }
 
     @Test
@@ -513,8 +513,8 @@ public class AnySearchTest extends AbstractTest {
         List<Group> matching = searchDAO.search(searchCondition, AnyTypeKind.GROUP);
         assertNotNull(matching);
         assertEquals(1, matching.size());
-        assertEquals("root", matching.iterator().next().getName());
-        assertEquals("37d15e4c-cdc1-460b-a591-8505c8133806", matching.iterator().next().getKey());
+        assertEquals("root", matching.getFirst().getName());
+        assertEquals("37d15e4c-cdc1-460b-a591-8505c8133806", matching.getFirst().getKey());
     }
 
     @Test
@@ -567,7 +567,7 @@ public class AnySearchTest extends AbstractTest {
         List<User> users = searchDAO.search(searchCondition, AnyTypeKind.USER);
         assertNotNull(users);
         assertEquals(1, users.size());
-        assertEquals("74cd8ece-715a-44a4-a736-e17b46c4e7e6", users.iterator().next().getKey());
+        assertEquals("74cd8ece-715a-44a4-a736-e17b46c4e7e6", users.getFirst().getKey());
     }
 
     @Test
@@ -612,7 +612,7 @@ public class AnySearchTest extends AbstractTest {
         List<User> users = searchDAO.search(cond, AnyTypeKind.USER);
         assertNotNull(users);
         assertEquals(1, users.size());
-        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", users.get(0).getKey());
+        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", users.getFirst().getKey());
     }
 
     @Test
@@ -627,7 +627,7 @@ public class AnySearchTest extends AbstractTest {
         List<AnyObject> anyObjects = searchDAO.search(searchCondition, AnyTypeKind.ANY_OBJECT);
         assertNotNull(anyObjects);
         assertEquals(1, anyObjects.size());
-        assertEquals("9e1d130c-d6a3-48b1-98b3-182477ed0688", anyObjects.iterator().next().getKey());
+        assertEquals("9e1d130c-d6a3-48b1-98b3-182477ed0688", anyObjects.getFirst().getKey());
     }
 
     @Test
@@ -642,7 +642,7 @@ public class AnySearchTest extends AbstractTest {
         List<User> users = searchDAO.search(searchCondition, AnyTypeKind.USER);
         assertNotNull(users);
         assertEquals(1, users.size());
-        assertEquals("1417acbe-cbf6-4277-9372-e75e04f97000", users.iterator().next().getKey());
+        assertEquals("1417acbe-cbf6-4277-9372-e75e04f97000", users.getFirst().getKey());
     }
 
     @Test
@@ -749,7 +749,7 @@ public class AnySearchTest extends AbstractTest {
                     PageRequest.of(0, 10),
                     AnyTypeKind.GROUP);
             assertEquals(1, groups.size());
-            assertEquals("37d15e4c-cdc1-460b-a591-8505c8133806", groups.get(0).getKey());
+            assertEquals("37d15e4c-cdc1-460b-a591-8505c8133806", groups.getFirst().getKey());
         } finally {
             SecurityContextHolder.getContext().setAuthentication(null);
         }

--- a/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/inner/AuthProfileTest.java
+++ b/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/inner/AuthProfileTest.java
@@ -134,12 +134,12 @@ public class AuthProfileTest extends AbstractTest {
         String secret = SecureRandomUtils.generateRandomUUID().toString();
         List<GoogleMfaAuthAccount> googleMfaAuthAccounts = authProfile.getGoogleMfaAuthAccounts();
         assertFalse(googleMfaAuthAccounts.isEmpty());
-        GoogleMfaAuthAccount googleMfaAuthAccount = googleMfaAuthAccounts.get(0);
+        GoogleMfaAuthAccount googleMfaAuthAccount = googleMfaAuthAccounts.getFirst();
         googleMfaAuthAccount.setSecretKey(secret);
 
         authProfile.setGoogleMfaAuthAccounts(googleMfaAuthAccounts);
         authProfile = authProfileDAO.save(authProfile);
-        assertEquals(secret, authProfile.getGoogleMfaAuthAccounts().get(0).getSecretKey());
+        assertEquals(secret, authProfile.getGoogleMfaAuthAccounts().getFirst().getSecretKey());
     }
 
     @Test

--- a/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/inner/MultitenancyTest.java
+++ b/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/inner/MultitenancyTest.java
@@ -73,7 +73,7 @@ public class MultitenancyTest extends AbstractTest {
                 realmSearchDAO.findDescendants(realmDAO.getRoot().getFullPath(), null, Pageable.unpaged()).size());
         assertEquals(
                 realmDAO.getRoot(),
-                realmSearchDAO.findDescendants(realmDAO.getRoot().getFullPath(), null, Pageable.unpaged()).get(0));
+                realmSearchDAO.findDescendants(realmDAO.getRoot().getFullPath(), null, Pageable.unpaged()).getFirst());
     }
 
     @Test

--- a/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/inner/PlainAttrTest.java
+++ b/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/inner/PlainAttrTest.java
@@ -145,7 +145,7 @@ public class PlainAttrTest extends AbstractTest {
         assertEquals(
                 encryptorManager.getInstance(obscureSchema.getSecretKey()).
                         encode("testvalue", obscureSchema.getCipherAlgorithm()),
-                obscure.getValues().get(0).getStringValue());
+                obscure.getValues().getFirst().getStringValue());
     }
 
     @Test
@@ -170,7 +170,7 @@ public class PlainAttrTest extends AbstractTest {
         assertEquals(
                 encryptorManager.getInstance(obscureSchema.getSecretKey()).
                         encode("testvalue", obscureSchema.getCipherAlgorithm()),
-                attr.getValues().get(0).getStringValue());
+                attr.getValues().getFirst().getStringValue());
     }
 
     @Test
@@ -191,13 +191,13 @@ public class PlainAttrTest extends AbstractTest {
         assertEquals(
                 encryptorManager.getInstance(obscureWithDecodeConversionPattern.getSecretKey()).
                         encode("testvalue", obscureWithDecodeConversionPattern.getCipherAlgorithm()),
-                attr.getValues().get(0).getStringValue());
+                attr.getValues().getFirst().getStringValue());
 
         obscureWithDecodeConversionPattern.setConversionPattern(SyncopeConstants.ENCRYPTED_DECODE_CONVERSION_PATTERN);
         plainSchemaDAO.save(obscureWithDecodeConversionPattern);
 
-        assertNotEquals("testvalue", attr.getValues().get(0).getStringValue());
-        assertEquals("testvalue", attr.getValuesAsStrings().get(0));
+        assertNotEquals("testvalue", attr.getValues().getFirst().getStringValue());
+        assertEquals("testvalue", attr.getValuesAsStrings().getFirst());
     }
 
     @Test
@@ -221,6 +221,6 @@ public class PlainAttrTest extends AbstractTest {
         PlainAttr photo = user.getPlainAttr("photo").orElseThrow();
         assertNotNull(photo);
         assertEquals(1, photo.getValues().size());
-        assertTrue(Arrays.equals(bytes, photo.getValues().get(0).getBinaryValue()));
+        assertTrue(Arrays.equals(bytes, photo.getValues().getFirst().getBinaryValue()));
     }
 }

--- a/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/inner/PlainSchemaTest.java
+++ b/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/inner/PlainSchemaTest.java
@@ -61,7 +61,7 @@ public class PlainSchemaTest extends AbstractTest {
     public void findByIdLike() {
         List<? extends PlainSchema> schemas = plainSchemaDAO.findByIdLike("fullna%");
         assertEquals(1, schemas.size());
-        assertEquals(0, schemas.get(0).getLabels().size());
+        assertEquals(0, schemas.getFirst().getLabels().size());
     }
 
     @Test

--- a/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/inner/TaskTest.java
+++ b/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/inner/TaskTest.java
@@ -215,10 +215,10 @@ public class TaskTest extends AbstractTest {
         task = taskDAO.save(task);
         assertNotNull(task);
         assertEquals(1, task.getCommands().size());
-        assertEquals(command, task.getCommands().get(0).getCommand());
+        assertEquals(command, task.getCommands().getFirst().getCommand());
         assertEquals(1, task.getFormPropertyDefs().size());
-        assertNotNull(task.getFormPropertyDefs().get(0).getKey());
-        assertEquals(formPropertyDef, task.getFormPropertyDefs().get(0));
+        assertNotNull(task.getFormPropertyDefs().getFirst().getKey());
+        assertEquals(formPropertyDef, task.getFormPropertyDefs().getFirst());
 
         MacroTask actual = (MacroTask) taskDAO.findById(TaskType.MACRO, task.getKey()).orElseThrow();
         assertEquals(task, actual);

--- a/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/inner/UserTest.java
+++ b/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/inner/UserTest.java
@@ -82,8 +82,8 @@ public class UserTest extends AbstractTest {
         assertNull(user.getSecurityQuestion());
         assertNull(user.getSecurityAnswer());
         assertEquals("admin", user.getCreator());
-        assertEquals("Giacomo", user.getPlainAttr("firstname").get().getValuesAsStrings().get(0));
-        assertEquals("Puccini", user.getPlainAttr("surname").get().getValuesAsStrings().get(0));
+        assertEquals("Giacomo", user.getPlainAttr("firstname").get().getValuesAsStrings().getFirst());
+        assertEquals("Puccini", user.getPlainAttr("surname").get().getValuesAsStrings().getFirst());
     }
 
     @Test

--- a/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/AnySearchTest.java
+++ b/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/AnySearchTest.java
@@ -107,7 +107,7 @@ public class AnySearchTest extends AbstractTest {
         List<User> users = searchDAO.search(SearchCond.of(roleCond), AnyTypeKind.USER);
         assertNotNull(users);
         assertEquals(1, users.size());
-        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", users.get(0).getKey());
+        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", users.getFirst().getKey());
     }
 
     @Test
@@ -143,7 +143,7 @@ public class AnySearchTest extends AbstractTest {
                 SearchCond.of(anyCond), PageRequest.of(0, 100), AnyTypeKind.USER);
         assertNotNull(users);
         assertEquals(1, users.size());
-        assertEquals(rossini.getKey(), users.get(0).getKey());
+        assertEquals(rossini.getKey(), users.getFirst().getKey());
     }
 
     @Test
@@ -177,7 +177,7 @@ public class AnySearchTest extends AbstractTest {
         PlainAttr attr = new PlainAttr();
         attr.setSchema("ctype");
         attr.add(validator, "otherchildctype");
-        attr.setMembership(anyObject.getMemberships().get(0).getKey());
+        attr.setMembership(anyObject.getMemberships().getFirst().getKey());
         anyObject.add(attr);
         anyObjectDAO.save(anyObject);
 
@@ -209,7 +209,7 @@ public class AnySearchTest extends AbstractTest {
         assertNotNull(users);
         assertEquals(1, users.size());
 
-        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", users.get(0).getKey());
+        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", users.getFirst().getKey());
     }
 
     @Test
@@ -259,7 +259,7 @@ public class AnySearchTest extends AbstractTest {
 
         List<Group> matching = searchDAO.search(SearchCond.of(titleCond), AnyTypeKind.GROUP);
         assertEquals(1, matching.size());
-        assertEquals(group.getKey(), matching.get(0).getKey());
+        assertEquals(group.getKey(), matching.getFirst().getKey());
 
         AttrCond originalNameCond = new AttrCond(AttrCond.Type.EQ);
         originalNameCond.setSchema("originalName");
@@ -267,7 +267,7 @@ public class AnySearchTest extends AbstractTest {
 
         matching = searchDAO.search(SearchCond.of(originalNameCond), AnyTypeKind.GROUP);
         assertEquals(1, matching.size());
-        assertEquals(group.getKey(), matching.get(0).getKey());
+        assertEquals(group.getKey(), matching.getFirst().getKey());
     }
 
     @Test
@@ -283,7 +283,7 @@ public class AnySearchTest extends AbstractTest {
         List<User> users = searchDAO.search(cond, AnyTypeKind.USER);
         assertNotNull(users);
         assertEquals(1, users.size());
-        assertEquals("verdi", users.get(0).getUsername());
+        assertEquals("verdi", users.getFirst().getUsername());
 
         // 1. set rossini's email address for conditions as per SYNCOPE-1790
         User rossini = userDAO.findByUsername("rossini").orElseThrow();
@@ -298,12 +298,12 @@ public class AnySearchTest extends AbstractTest {
         rossini = userDAO.findByUsername("rossini").orElseThrow();
         assertEquals(
                 "bisverdi@syncope.org",
-                rossini.getPlainAttr("email").map(a -> a.getValuesAsStrings().get(0)).orElseThrow());
+                rossini.getPlainAttr("email").map(a -> a.getValuesAsStrings().getFirst()).orElseThrow());
 
         // 2. search again
         users = searchDAO.search(cond, AnyTypeKind.USER);
         assertNotNull(users);
         assertEquals(1, users.size());
-        assertEquals("verdi", users.get(0).getUsername());
+        assertEquals("verdi", users.getFirst().getUsername());
     }
 }

--- a/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/AnyTypeClassTest.java
+++ b/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/AnyTypeClassTest.java
@@ -60,8 +60,8 @@ public class AnyTypeClassTest extends AbstractTest {
         newClass = anyTypeClassDAO.findById(newClass.getKey()).orElseThrow();
         assertNotNull(newClass);
         assertEquals(1, newClass.getPlainSchemas().size());
-        assertEquals(newSchema, newClass.getPlainSchemas().get(0));
-        assertEquals(newClass, newClass.getPlainSchemas().get(0).getAnyTypeClass());
+        assertEquals(newSchema, newClass.getPlainSchemas().getFirst());
+        assertEquals(newClass, newClass.getPlainSchemas().getFirst().getAnyTypeClass());
 
         assertTrue(plainSchemaDAO.findById(newSchema.getKey()).isPresent());
     }

--- a/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/DynRealmTest.java
+++ b/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/DynRealmTest.java
@@ -97,7 +97,7 @@ public class DynRealmTest extends AbstractTest {
         List<User> matching = searchDAO.search(SearchCond.of(dynRealmCond), AnyTypeKind.USER);
         assertNotNull(matching);
         assertFalse(matching.isEmpty());
-        User user = matching.get(0);
+        User user = matching.getFirst();
         assertTrue(anyMatchDAO.matches(user, SearchCond.of(dynRealmCond)));
 
         assertTrue(userDAO.findDynRealms(user.getKey()).contains(actual.getKey()));

--- a/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/GroupTest.java
+++ b/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/GroupTest.java
@@ -382,7 +382,8 @@ public class GroupTest extends AbstractTest {
 
         group = groupDAO.findByName("root").orElseThrow();
         assertEquals(1, group.getRelationships().size());
-        assertEquals("8559d14d-58c2-46eb-a2d4-a7d35161e8f8", group.getRelationships().getFirst().getRightEnd().getKey());
+        assertEquals("8559d14d-58c2-46eb-a2d4-a7d35161e8f8",
+            group.getRelationships().getFirst().getRightEnd().getKey());
     }
 
     @Test

--- a/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/GroupTest.java
+++ b/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/GroupTest.java
@@ -274,7 +274,7 @@ public class GroupTest extends AbstractTest {
         actual = groupDAO.findById(actual.getKey()).orElseThrow();
         members = groupDAO.findUDynMembers(actual);
         assertEquals(1, members.size());
-        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", members.get(0));
+        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", members.getFirst());
 
         // 5. delete group and verify that dynamic membership was also removed
         String dynMembershipKey = actual.getUDynMembership().getKey();
@@ -348,7 +348,7 @@ public class GroupTest extends AbstractTest {
                 object -> "PRINTER".equals(anyObjectDAO.findById(object).
                         orElseThrow().getType().getKey())).toList();
         assertEquals(1, members.size());
-        assertEquals("fc6dbc3a-6c07-4965-8781-921e7401a4a5", members.get(0));
+        assertEquals("fc6dbc3a-6c07-4965-8781-921e7401a4a5", members.getFirst());
 
         // 5. delete group and verify that dynamic membership was also removed
         String dynMembershipKey = actual.getADynMembership(anyTypeDAO.findById("PRINTER").orElseThrow()).get().getKey();
@@ -382,7 +382,7 @@ public class GroupTest extends AbstractTest {
 
         group = groupDAO.findByName("root").orElseThrow();
         assertEquals(1, group.getRelationships().size());
-        assertEquals("8559d14d-58c2-46eb-a2d4-a7d35161e8f8", group.getRelationships().get(0).getRightEnd().getKey());
+        assertEquals("8559d14d-58c2-46eb-a2d4-a7d35161e8f8", group.getRelationships().getFirst().getRightEnd().getKey());
     }
 
     @Test
@@ -404,7 +404,7 @@ public class GroupTest extends AbstractTest {
         groupDAO.save(group);
 
         group = groupDAO.findById(group.getKey()).orElseThrow();
-        assertEquals("syncope's group", group.getPlainAttr("title").get().getValuesAsStrings().get(0));
-        assertEquals("syncope's group", group.getPlainAttr("originalName").get().getValuesAsStrings().get(0));
+        assertEquals("syncope's group", group.getPlainAttr("title").get().getValuesAsStrings().getFirst());
+        assertEquals("syncope's group", group.getPlainAttr("originalName").get().getValuesAsStrings().getFirst());
     }
 }

--- a/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/RealmTest.java
+++ b/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/RealmTest.java
@@ -97,7 +97,7 @@ public class RealmTest extends AbstractTest {
 
         realm = realmDAO.findById("722f3d84-9c2b-4525-8f6e-e4b82c55a36c").orElseThrow();
         assertEquals(1, realm.getActions().size());
-        assertEquals(implementation, realm.getActions().get(0));
+        assertEquals(implementation, realm.getActions().getFirst());
 
         realm.getActions().clear();
         realm = realmDAO.save(realm);

--- a/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/ResourceTest.java
+++ b/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/ResourceTest.java
@@ -280,7 +280,7 @@ public class ResourceTest extends AbstractTest {
 
         resource = resourceDAO.findById("ws-target-resource-2").orElseThrow();
         assertEquals(1, resource.getPropagationActions().size());
-        assertEquals(implementation, resource.getPropagationActions().get(0));
+        assertEquals(implementation, resource.getPropagationActions().getFirst());
 
         resource.getPropagationActions().clear();
         resource = resourceDAO.save(resource);

--- a/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/RoleTest.java
+++ b/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/RoleTest.java
@@ -117,7 +117,7 @@ public class RoleTest extends AbstractTest {
         actual = roleDAO.findById(actual.getKey()).orElseThrow();
         members = roleDAO.findDynMembers(actual);
         assertEquals(1, members.size());
-        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", members.get(0));
+        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", members.getFirst());
 
         // 5. delete role and verify that dynamic membership was also removed
         roleDAO.delete(actual);

--- a/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/TaskTest.java
+++ b/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/TaskTest.java
@@ -319,7 +319,7 @@ public class TaskTest extends AbstractTest {
 
         task = (PullTask) taskDAO.findById(TaskType.PULL, "c41b9b71-9bfa-4f90-89f2-84787def4c5c").orElseThrow();
         assertEquals(1, task.getActions().size());
-        assertEquals(implementation, task.getActions().get(0));
+        assertEquals(implementation, task.getActions().getFirst());
 
         task.getActions().clear();
         task = taskDAO.save(task);

--- a/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/UserTest.java
+++ b/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/UserTest.java
@@ -107,9 +107,9 @@ public class UserTest extends AbstractTest {
     public void ships() {
         User user = userDAO.findByUsername("bellini").orElseThrow();
         assertEquals(1, user.getMemberships().size());
-        assertEquals("bf825fe1-7320-4a54-bd64-143b5c18ab97", user.getMemberships().get(0).getRightEnd().getKey());
+        assertEquals("bf825fe1-7320-4a54-bd64-143b5c18ab97", user.getMemberships().getFirst().getRightEnd().getKey());
 
-        user.remove(user.getMemberships().get(0));
+        user.remove(user.getMemberships().getFirst());
 
         UMembership newM = entityFactory.newEntity(UMembership.class);
         newM.setLeftEnd(user);
@@ -120,11 +120,11 @@ public class UserTest extends AbstractTest {
 
         user = userDAO.findByUsername("bellini").orElseThrow();
         assertEquals(1, user.getMemberships().size());
-        assertEquals("ba9ed509-b1f5-48ab-a334-c8530a6422dc", user.getMemberships().get(0).getRightEnd().getKey());
+        assertEquals("ba9ed509-b1f5-48ab-a334-c8530a6422dc", user.getMemberships().getFirst().getRightEnd().getKey());
         assertEquals(1, user.getRelationships().size());
-        assertEquals("fc6dbc3a-6c07-4965-8781-921e7401a4a5", user.getRelationships().get(0).getRightEnd().getKey());
+        assertEquals("fc6dbc3a-6c07-4965-8781-921e7401a4a5", user.getRelationships().getFirst().getRightEnd().getKey());
 
-        user.getRelationships().remove(0);
+        user.getRelationships().removeFirst();
 
         URelationship newR = entityFactory.newEntity(URelationship.class);
         newR.setType(relationshipTypeDAO.findById("neighborhood").orElseThrow());
@@ -136,7 +136,7 @@ public class UserTest extends AbstractTest {
 
         user = userDAO.findByUsername("bellini").orElseThrow();
         assertEquals(1, user.getRelationships().size());
-        assertEquals("8559d14d-58c2-46eb-a2d4-a7d35161e8f8", user.getRelationships().get(0).getRightEnd().getKey());
+        assertEquals("8559d14d-58c2-46eb-a2d4-a7d35161e8f8", user.getRelationships().getFirst().getRightEnd().getKey());
     }
 
     private LinkedAccount newLinkedAccount(final String connObjectKeyValue) {
@@ -163,7 +163,7 @@ public class UserTest extends AbstractTest {
 
         assertEquals(1, user.getLinkedAccounts().size());
 
-        return user.getLinkedAccounts().get(0);
+        return user.getLinkedAccounts().getFirst();
     }
 
     @Test
@@ -183,7 +183,7 @@ public class UserTest extends AbstractTest {
         List<LinkedAccount> accounts = userDAO.findLinkedAccountsByResource(
                 resourceDAO.findById("resource-ldap").orElseThrow());
         assertEquals(1, accounts.size());
-        assertEquals(account, accounts.get(0));
+        assertEquals(account, accounts.getFirst());
     }
 
     @Test
@@ -245,7 +245,7 @@ public class UserTest extends AbstractTest {
         // add derived attributes to user
         User owner = userDAO.findByUsername("vivaldi").orElseThrow();
 
-        String firstname = owner.getPlainAttr("firstname").get().getValuesAsStrings().iterator().next();
+        String firstname = owner.getPlainAttr("firstname").get().getValuesAsStrings().getFirst();
         assertNotNull(firstname);
 
         // search by ksuffix derived attribute

--- a/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/jexl/JexlUtils.java
+++ b/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/jexl/JexlUtils.java
@@ -235,7 +235,7 @@ public final class JexlUtils {
                 value = StringUtils.EMPTY;
             } else {
                 value = attr.getValues().size() == 1
-                        ? attr.getValues().get(0)
+                        ? attr.getValues().getFirst()
                         : attr.getValues();
             }
 
@@ -253,7 +253,7 @@ public final class JexlUtils {
                 value = StringUtils.EMPTY;
             } else {
                 value = attrValues.size() == 1
-                        ? attrValues.get(0)
+                        ? attrValues.getFirst()
                         : attrValues;
             }
 

--- a/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/serialization/AttributeDeserializer.java
+++ b/core/provisioning-api/src/main/java/org/apache/syncope/core/provisioning/api/serialization/AttributeDeserializer.java
@@ -40,10 +40,10 @@ class AttributeDeserializer extends AbstractValueDeserializer<Attribute> {
         List<Object> values = doDeserialize(tree.get("value"), jp);
 
         if (Uid.NAME.equals(name)) {
-            return new Uid(values.isEmpty() || values.get(0) == null ? null : values.get(0).toString());
+            return new Uid(values.isEmpty() || values.getFirst() == null ? null : values.getFirst().toString());
         } else {
             if (Name.NAME.equals(name)) {
-                return new Name(values.isEmpty() || values.get(0) == null ? null : values.get(0).toString());
+                return new Name(values.isEmpty() || values.getFirst() == null ? null : values.getFirst().toString());
             }
 
             return AttributeBuilder.build(name, values);

--- a/core/provisioning-api/src/test/java/org/apache/syncope/core/provisioning/api/serialization/AttributeDeserializerTest.java
+++ b/core/provisioning-api/src/test/java/org/apache/syncope/core/provisioning/api/serialization/AttributeDeserializerTest.java
@@ -81,7 +81,7 @@ public class AttributeDeserializerTest extends AbstractTest {
         when(node.asBoolean()).thenReturn(Boolean.TRUE);
         Attribute attr = deserializer.deserialize(jp, ct);
         assertEquals(name, attr.getName());
-        assertEquals(List.of(Boolean.TRUE.toString()).get(0), attr.getValue().get(0));
+        assertEquals(List.of(Boolean.TRUE.toString()).getFirst(), attr.getValue().getFirst());
     }
 
     @Test
@@ -93,7 +93,7 @@ public class AttributeDeserializerTest extends AbstractTest {
         when(node.asDouble()).thenReturn(number);
         Attribute attr = deserializer.deserialize(jp, ct);
         assertEquals(name, attr.getName());
-        assertEquals(List.of(number).get(0), attr.getValue().get(0));
+        assertEquals(List.of(number).getFirst(), attr.getValue().getFirst());
     }
 
     @Test
@@ -105,7 +105,7 @@ public class AttributeDeserializerTest extends AbstractTest {
         when(node.asLong()).thenReturn(number);
         Attribute attr = deserializer.deserialize(jp, ct);
         assertEquals(name, attr.getName());
-        assertEquals(List.of(number.toString()).get(0), attr.getValue().get(0));
+        assertEquals(List.of(number.toString()).getFirst(), attr.getValue().getFirst());
     }
 
     @Test
@@ -116,7 +116,7 @@ public class AttributeDeserializerTest extends AbstractTest {
         when(node.asInt()).thenReturn(number);
         Attribute attr = deserializer.deserialize(jp, ct);
         assertEquals(attr.getName(), name);
-        assertEquals(List.of(number.toString()).get(0), attr.getValue().get(0));
+        assertEquals(List.of(number.toString()).getFirst(), attr.getValue().getFirst());
     }
 
     @Test
@@ -126,6 +126,6 @@ public class AttributeDeserializerTest extends AbstractTest {
         when(node.asText()).thenReturn(text);
         Attribute attr = deserializer.deserialize(jp, ct);
         assertEquals(attr.getName(), name);
-        assertEquals(List.of(text).get(0), attr.getValue().get(0));
+        assertEquals(List.of(text).getFirst(), attr.getValue().getFirst());
     }
 }

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/ConnectorFacadeProxy.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/ConnectorFacadeProxy.java
@@ -521,30 +521,30 @@ public class ConnectorFacadeProxy implements Connector {
             Class<?> propertySchemaClass = ClassUtils.forName(propType, ClassUtils.getDefaultClassLoader());
 
             if (GuardedString.class.equals(propertySchemaClass)) {
-                value = new GuardedString(values.get(0).toString().toCharArray());
+                value = new GuardedString(values.getFirst().toString().toCharArray());
             } else if (GuardedByteArray.class.equals(propertySchemaClass)) {
-                value = new GuardedByteArray((byte[]) values.get(0));
+                value = new GuardedByteArray((byte[]) values.getFirst());
             } else if (Character.class.equals(propertySchemaClass) || Character.TYPE.equals(propertySchemaClass)) {
-                value = values.get(0) == null || values.get(0).toString().isEmpty()
-                        ? null : values.get(0).toString().charAt(0);
+                value = values.getFirst() == null || values.getFirst().toString().isEmpty()
+                        ? null : values.getFirst().toString().charAt(0);
             } else if (Integer.class.equals(propertySchemaClass) || Integer.TYPE.equals(propertySchemaClass)) {
-                value = Integer.valueOf(values.get(0).toString());
+                value = Integer.valueOf(values.getFirst().toString());
             } else if (Long.class.equals(propertySchemaClass) || Long.TYPE.equals(propertySchemaClass)) {
-                value = Long.valueOf(values.get(0).toString());
+                value = Long.valueOf(values.getFirst().toString());
             } else if (Float.class.equals(propertySchemaClass) || Float.TYPE.equals(propertySchemaClass)) {
-                value = Float.valueOf(values.get(0).toString());
+                value = Float.valueOf(values.getFirst().toString());
             } else if (Double.class.equals(propertySchemaClass) || Double.TYPE.equals(propertySchemaClass)) {
-                value = Double.valueOf(values.get(0).toString());
+                value = Double.valueOf(values.getFirst().toString());
             } else if (Boolean.class.equals(propertySchemaClass) || Boolean.TYPE.equals(propertySchemaClass)) {
-                value = Boolean.valueOf(values.get(0).toString());
+                value = Boolean.valueOf(values.getFirst().toString());
             } else if (URI.class.equals(propertySchemaClass)) {
-                value = URI.create(values.get(0).toString());
+                value = URI.create(values.getFirst().toString());
             } else if (File.class.equals(propertySchemaClass)) {
-                value = Path.of(values.get(0).toString()).toFile();
+                value = Path.of(values.getFirst().toString()).toFile();
             } else if (String[].class.equals(propertySchemaClass)) {
                 value = values.toArray(String[]::new);
             } else {
-                value = values.get(0) == null ? null : values.get(0).toString();
+                value = values.getFirst() == null ? null : values.getFirst().toString();
             }
         } catch (Exception e) {
             LOG.error("Invalid ConnConfProperty specified: {} {}", propType, values, e);

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/DefaultGroupProvisioningManager.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/DefaultGroupProvisioningManager.java
@@ -107,7 +107,7 @@ public class DefaultGroupProvisioningManager implements GroupProvisioningManager
 
         // see ConnObjectUtils#getAnyTOFromConnObject for GroupOwnerSchema
         groupCR.getPlainAttr(StringUtils.EMPTY).
-                ifPresent(groupOwner -> groupOwnerMap.put(created.getResult(), groupOwner.getValues().get(0)));
+                ifPresent(groupOwner -> groupOwnerMap.put(created.getResult(), groupOwner.getValues().getFirst()));
 
         List<PropagationTaskInfo> tasks = propagationManager.getCreateTasks(
                 AnyTypeKind.GROUP,

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/DefaultMappingManager.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/DefaultMappingManager.java
@@ -587,7 +587,7 @@ public class DefaultMappingManager implements MappingManager {
             }
 
             if (item.isConnObjectKey()) {
-                result = Pair.of(objValues.isEmpty() ? null : objValues.iterator().next().toString(), null);
+                result = Pair.of(objValues.isEmpty() ? null : objValues.getFirst().toString(), null);
             } else if (item.isPassword() && any instanceof User) {
                 result = getPasswordAttrValue(passwordAccountGetter.apply((User) any), password).
                         map(passwordAttrValue -> Pair.of(
@@ -898,7 +898,7 @@ public class DefaultMappingManager implements MappingManager {
         }
         return Optional.ofNullable(intValues.getRight().isEmpty()
                 ? null
-                : intValues.getRight().get(0).getValueAsString());
+                : intValues.getRight().getFirst().getValueAsString());
     }
 
     @Transactional(readOnly = true)
@@ -936,36 +936,36 @@ public class DefaultMappingManager implements MappingManager {
             switch (intAttrName.getField()) {
                 case "password" -> {
                     if (anyTO instanceof UserTO && !values.isEmpty()) {
-                        ((UserTO) anyTO).setPassword(ConnObjectUtils.getPassword(values.get(0)));
+                        ((UserTO) anyTO).setPassword(ConnObjectUtils.getPassword(values.getFirst()));
                     }
                 }
 
                 case "username" -> {
                     if (anyTO instanceof UserTO userTO) {
-                        userTO.setUsername(values.isEmpty() || values.get(0) == null
+                        userTO.setUsername(values.isEmpty() || values.getFirst() == null
                                 ? null
-                                : values.get(0).toString());
+                                : values.getFirst().toString());
                     }
                 }
 
                 case "name" -> {
                     switch (anyTO) {
                         case GroupTO groupTO ->
-                            groupTO.setName(values.isEmpty() || values.get(0) == null
+                            groupTO.setName(values.isEmpty() || values.getFirst() == null
                                     ? null
-                                    : values.get(0).toString());
+                                    : values.getFirst().toString());
                         case AnyObjectTO anyObjectTO ->
-                            anyObjectTO.setName(values.isEmpty() || values.get(0) == null
+                            anyObjectTO.setName(values.isEmpty() || values.getFirst() == null
                                     ? null
-                                    : values.get(0).toString());
+                                    : values.getFirst().toString());
                         default -> {
                         }
                     }
                 }
 
                 case "mustChangePassword" -> {
-                    if (anyTO instanceof UserTO && !values.isEmpty() && values.get(0) != null) {
-                        ((UserTO) anyTO).setMustChangePassword(BooleanUtils.toBoolean(values.get(0).toString()));
+                    if (anyTO instanceof UserTO && !values.isEmpty() && values.getFirst() != null) {
+                        ((UserTO) anyTO).setMustChangePassword(BooleanUtils.toBoolean(values.getFirst().toString()));
                     }
                 }
 
@@ -975,10 +975,10 @@ public class DefaultMappingManager implements MappingManager {
                         // GroupOwnerSchema value
                         Attr attrTO = new Attr();
                         attrTO.setSchema(StringUtils.EMPTY);
-                        if (values.isEmpty() || values.get(0) == null) {
+                        if (values.isEmpty() || values.getFirst() == null) {
                             attrTO.getValues().add(StringUtils.EMPTY);
                         } else {
-                            attrTO.getValues().add(values.get(0).toString());
+                            attrTO.getValues().add(values.getFirst().toString());
                         }
 
                         ((GroupTO) anyTO).getPlainAttrs().add(attrTO);
@@ -1080,13 +1080,13 @@ public class DefaultMappingManager implements MappingManager {
             }
         }
 
-        if (values != null && !values.isEmpty() && values.get(0) != null) {
+        if (values != null && !values.isEmpty() && values.getFirst() != null) {
             switch (item.getIntAttrName()) {
                 case "name" ->
-                    realmTO.setName(values.get(0).toString());
+                    realmTO.setName(values.getFirst().toString());
 
                 case "fullpath" -> {
-                    String parentFullPath = StringUtils.substringBeforeLast(values.get(0).toString(), "/");
+                    String parentFullPath = StringUtils.substringBeforeLast(values.getFirst().toString(), "/");
                     realmSearchDAO.findByFullPath(parentFullPath).ifPresentOrElse(
                             parent -> realmTO.setParent(parent.getFullPath()),
                             () -> LOG.warn("Could not find Realm with path {}, ignoring", parentFullPath));

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/AbstractAnyDataBinder.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/AbstractAnyDataBinder.java
@@ -305,9 +305,9 @@ abstract class AbstractAnyDataBinder {
         // otherwise only the fist one - if provided - is considered
         List<String> valuesProvided = schema.isMultivalue()
                 ? values
-                : (values.isEmpty() || values.get(0) == null
+                : (values.isEmpty() || values.getFirst() == null
                 ? List.of()
-                : List.of(values.get(0)));
+                : List.of(values.getFirst()));
 
         valuesProvided.forEach(value -> {
             if (StringUtils.isBlank(value)) {
@@ -465,7 +465,7 @@ abstract class AbstractAnyDataBinder {
                 if (schema.isUniqueConstraint()) {
                     if (attr.getUniqueValue() != null
                             && !patch.getAttr().getValues().isEmpty()
-                            && !patch.getAttr().getValues().get(0).equals(attr.getUniqueValue().getValueAsString())) {
+                            && !patch.getAttr().getValues().getFirst().equals(attr.getUniqueValue().getValueAsString())) {
 
                         attr.setUniqueValue(null);
                     }
@@ -477,7 +477,7 @@ abstract class AbstractAnyDataBinder {
                 List<String> valuesToBeAdded = patch.getAttr().getValues();
                 if (!valuesToBeAdded.isEmpty()
                         && (!schema.isUniqueConstraint() || attr.getUniqueValue() == null
-                        || !valuesToBeAdded.get(0).equals(attr.getUniqueValue().getValueAsString()))) {
+                        || !valuesToBeAdded.getFirst().equals(attr.getUniqueValue().getValueAsString()))) {
 
                     fillAttr(anyTO, valuesToBeAdded, schema, attr, invalidValues);
                 }
@@ -587,7 +587,7 @@ abstract class AbstractAnyDataBinder {
                 if (!beforeObject.equals(connObject)) {
                     propByRes.add(ResourceOperation.UPDATE, resource);
 
-                    beforeObject.getAttr(Uid.NAME).map(attr -> attr.getValues().get(0)).
+                    beforeObject.getAttr(Uid.NAME).map(attr -> attr.getValues().getFirst()).
                             ifPresent(value -> propByRes.addOldConnObjectKey(resource, value));
                 }
             } else {

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/AbstractAnyDataBinder.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/AbstractAnyDataBinder.java
@@ -465,7 +465,8 @@ abstract class AbstractAnyDataBinder {
                 if (schema.isUniqueConstraint()) {
                     if (attr.getUniqueValue() != null
                             && !patch.getAttr().getValues().isEmpty()
-                            && !patch.getAttr().getValues().getFirst().equals(attr.getUniqueValue().getValueAsString())) {
+                            && !patch.getAttr().getValues().getFirst().equals(
+                                attr.getUniqueValue().getValueAsString())) {
 
                         attr.setUniqueValue(null);
                     }

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/notification/DefaultNotificationManager.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/notification/DefaultNotificationManager.java
@@ -407,7 +407,7 @@ public class DefaultNotificationManager implements NotificationManager {
                             : user.getPlainAttr(recipientAttrName, membership);
                     email = attr.map(a -> a.getValuesAsStrings().isEmpty()
                             ? null
-                            : a.getValuesAsStrings().get(0)).
+                            : a.getValuesAsStrings().getFirst()).
                             orElse(null);
                 }
 
@@ -425,7 +425,7 @@ public class DefaultNotificationManager implements NotificationManager {
                                 List<String> virAttrValues = membership == null
                                         ? virAttrHandler.getValues(user, virSchema)
                                         : virAttrHandler.getValues(user, membership, virSchema);
-                                return virAttrValues.isEmpty() ? null : virAttrValues.get(0);
+                                return virAttrValues.isEmpty() ? null : virAttrValues.getFirst();
                             }).
                             orElse(null);
                 }

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/propagation/AbstractPropagationTaskExecutor.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/propagation/AbstractPropagationTaskExecutor.java
@@ -846,7 +846,7 @@ public abstract class AbstractPropagationTaskExecutor implements PropagationTask
                 outboundMatcher.match(taskInfo, connector, provision, actions, connObjectKeyValue);
         LOG.debug("Found for propagation task {}: {}", taskInfo, matches);
 
-        return matches.isEmpty() ? null : matches.get(0);
+        return matches.isEmpty() ? null : matches.getFirst();
     }
 
     /**

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/propagation/AzurePropagationActions.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/propagation/AzurePropagationActions.java
@@ -59,7 +59,7 @@ public class AzurePropagationActions implements PropagationActions {
             }
 
             Optional.ofNullable(AttributeUtil.getNameFromAttributes(attrs)).ifPresent(attrs::remove);
-            attrs.add(new Name(AttributeUtil.find(getEmailAttrName(), attrs).getValue().get(0).toString()));
+            attrs.add(new Name(AttributeUtil.find(getEmailAttrName(), attrs).getValue().getFirst().toString()));
         }
     }
 

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/propagation/DBPasswordPropagationActions.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/propagation/DBPasswordPropagationActions.java
@@ -58,7 +58,7 @@ public class DBPasswordPropagationActions implements PropagationActions {
                 filter(property -> "cipherAlgorithm".equals(property.getSchema().getName())
                 && property.getValues() != null && !property.getValues().isEmpty()).findFirst();
 
-        return cipherAlgorithm.map(a -> (String) a.getValues().get(0)).orElse(CLEARTEXT);
+        return cipherAlgorithm.map(a -> (String) a.getValues().getFirst()).orElse(CLEARTEXT);
     }
 
     protected boolean cipherAlgorithmMatches(final String connectorAlgorithm, final CipherAlgorithm userAlgorithm) {
@@ -88,7 +88,7 @@ public class DBPasswordPropagationActions implements PropagationActions {
 
                 ConnInstance connInstance = taskInfo.getResource().getConnector();
                 if (missing != null && missing.getValue() != null && missing.getValue().size() == 1
-                        && missing.getValue().get(0).equals(OperationalAttributes.PASSWORD_NAME)
+                        && missing.getValue().getFirst().equals(OperationalAttributes.PASSWORD_NAME)
                         && cipherAlgorithmMatches(getCipherAlgorithm(connInstance), user.getCipherAlgorithm())) {
 
                     Attribute passwordAttribute = AttributeBuilder.buildPassword(

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/propagation/GoogleAppsPropagationActions.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/propagation/GoogleAppsPropagationActions.java
@@ -69,7 +69,7 @@ public class GoogleAppsPropagationActions implements PropagationActions {
             }
 
             Optional.ofNullable(AttributeUtil.getNameFromAttributes(attrs)).ifPresent(attrs::remove);
-            attrs.add(new Name(AttributeUtil.find(getEmailAttrName(), attrs).getValue().get(0).toString()));
+            attrs.add(new Name(AttributeUtil.find(getEmailAttrName(), attrs).getValue().getFirst().toString()));
         }
     }
 }

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/propagation/LDAPPasswordPropagationActions.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/propagation/LDAPPasswordPropagationActions.java
@@ -68,7 +68,7 @@ public class LDAPPasswordPropagationActions implements PropagationActions {
             String cipherAlgorithm = getCipherAlgorithm(taskInfo.getResource().getConnector());
             Optional.ofNullable(AttributeUtil.find(PropagationManager.MANDATORY_MISSING_ATTR_NAME, attrs)).
                     filter(missing -> !CollectionUtils.isEmpty(missing.getValue())
-                    && OperationalAttributes.PASSWORD_NAME.equals(missing.getValue().get(0))
+                    && OperationalAttributes.PASSWORD_NAME.equals(missing.getValue().getFirst())
                     && cipherAlgorithmMatches(cipherAlgorithm, user.getCipherAlgorithm())).
                     ifPresent(missing -> {
                         attrs.remove(missing);
@@ -87,7 +87,7 @@ public class LDAPPasswordPropagationActions implements PropagationActions {
         return connInstance.getConf().stream().
                 filter(property -> "passwordHashAlgorithm".equals(property.getSchema().getName())
                 && !property.getValues().isEmpty()).findFirst().
-                map(cipherAlgorithm -> cipherAlgorithm.getValues().get(0).toString()).
+                map(cipherAlgorithm -> cipherAlgorithm.getValues().getFirst().toString()).
                 orElse(CLEARTEXT);
     }
 

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/ADMembershipPullActions.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/ADMembershipPullActions.java
@@ -39,7 +39,7 @@ public class ADMembershipPullActions extends LDAPMembershipPullActions {
         return connector.getConnInstance().getConf().stream().
                 filter(property -> "groupMemberReferenceAttribute".equals(property.getSchema().getName())
                 && !property.getValues().isEmpty()).findFirst().
-                map(groupMembership -> (String) groupMembership.getValues().get(0)).
+                map(groupMembership -> (String) groupMembership.getValues().getFirst()).
                 orElse("member");
     }
 }

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/AbstractPullResultHandler.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/AbstractPullResultHandler.java
@@ -817,7 +817,8 @@ public abstract class AbstractPullResultHandler
 
             case DELETE:
                 // Skip DELETE in case of InboundCorrelationRule.NO_MATCH
-                result = matches.getFirst().getAny() == null ? OpEvent.Outcome.SUCCESS : delete(delta, matches, provision);
+                result = matches.getFirst().getAny() == null
+                    ? OpEvent.Outcome.SUCCESS : delete(delta, matches, provision);
                 break;
 
             default:

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/AbstractPullResultHandler.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/AbstractPullResultHandler.java
@@ -755,7 +755,7 @@ public abstract class AbstractPullResultHandler
             case CREATE:
             case UPDATE:
             case CREATE_OR_UPDATE:
-                if (matches.get(0).getAny() == null) {
+                if (matches.getFirst().getAny() == null) {
                     switch (profile.getTask().getUnmatchingRule()) {
                         case ASSIGN:
                         case PROVISION:
@@ -773,7 +773,7 @@ public abstract class AbstractPullResultHandler
                     // update VirAttrCache
                     virSchemaDAO.findByResourceAndAnyType(
                             profile.getTask().getResource().getKey(),
-                            matches.get(0).getAny().getType().getKey()).
+                            matches.getFirst().getAny().getType().getKey()).
                             forEach(vs -> {
                                 Attribute attr = delta.getObject().getAttributeByName(vs.getExtAttrName());
                                 matches.forEach(match -> {
@@ -817,7 +817,7 @@ public abstract class AbstractPullResultHandler
 
             case DELETE:
                 // Skip DELETE in case of InboundCorrelationRule.NO_MATCH
-                result = matches.get(0).getAny() == null ? OpEvent.Outcome.SUCCESS : delete(delta, matches, provision);
+                result = matches.getFirst().getAny() == null ? OpEvent.Outcome.SUCCESS : delete(delta, matches, provision);
                 break;
 
             default:

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/AbstractPushResultHandler.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/AbstractPushResultHandler.java
@@ -67,8 +67,8 @@ public abstract class AbstractPushResultHandler extends AbstractSyncopeResultHan
 
     protected static void reportPropagation(final ProvisioningReport result, final PropagationReporter reporter) {
         if (!reporter.getStatuses().isEmpty()) {
-            result.setStatus(toProvisioningReportStatus(reporter.getStatuses().get(0).getStatus()));
-            result.setMessage(reporter.getStatuses().get(0).getFailureReason());
+            result.setStatus(toProvisioningReportStatus(reporter.getStatuses().getFirst().getStatus()));
+            result.setMessage(reporter.getStatuses().getFirst().getFailureReason());
         }
     }
 
@@ -157,9 +157,9 @@ public abstract class AbstractPushResultHandler extends AbstractSyncopeResultHan
                 null,
                 noPropResources);
         if (!taskInfos.isEmpty()) {
-            taskInfos.get(0).setBeforeObj(Optional.of(beforeObj));
+            taskInfos.getFirst().setBeforeObj(Optional.of(beforeObj));
             PropagationReporter reporter = new DefaultPropagationReporter();
-            taskExecutor.execute(taskInfos.get(0), reporter, securityProperties.getAdminUser());
+            taskExecutor.execute(taskInfos.getFirst(), reporter, securityProperties.getAdminUser());
             reportPropagation(result, reporter);
         }
     }
@@ -181,9 +181,9 @@ public abstract class AbstractPushResultHandler extends AbstractSyncopeResultHan
                 null,
                 noPropResources);
         if (!taskInfos.isEmpty()) {
-            taskInfos.get(0).setBeforeObj(Optional.of(beforeObj));
+            taskInfos.getFirst().setBeforeObj(Optional.of(beforeObj));
             PropagationReporter reporter = new DefaultPropagationReporter();
-            taskExecutor.execute(taskInfos.get(0), reporter, securityProperties.getAdminUser());
+            taskExecutor.execute(taskInfos.getFirst(), reporter, securityProperties.getAdminUser());
             reportPropagation(result, reporter);
         }
     }
@@ -205,9 +205,9 @@ public abstract class AbstractPushResultHandler extends AbstractSyncopeResultHan
                 before.getVirAttrs(),
                 noPropResources);
         if (!taskInfos.isEmpty()) {
-            taskInfos.get(0).setBeforeObj(Optional.empty());
+            taskInfos.getFirst().setBeforeObj(Optional.empty());
             PropagationReporter reporter = new DefaultPropagationReporter();
-            taskExecutor.execute(taskInfos.get(0), reporter, securityProperties.getAdminUser());
+            taskExecutor.execute(taskInfos.getFirst(), reporter, securityProperties.getAdminUser());
             reportPropagation(result, reporter);
         }
     }
@@ -331,7 +331,7 @@ public abstract class AbstractPushResultHandler extends AbstractSyncopeResultHan
                 default:
             }
         }
-        ConnectorObject beforeObj = connObjs.isEmpty() ? null : connObjs.get(0);
+        ConnectorObject beforeObj = connObjs.isEmpty() ? null : connObjs.getFirst();
 
         if (profile.isDryRun()) {
             if (beforeObj == null) {

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/DBPasswordPullActions.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/DBPasswordPullActions.java
@@ -104,7 +104,7 @@ public class DBPasswordPullActions implements InboundActions {
         return connInstance.getConf().stream().
                 filter(property -> "cipherAlgorithm".equals(property.getSchema().getName())
                 && property.getValues() != null && !property.getValues().isEmpty()).findFirst().
-                map(cipherAlgorithm -> cipherAlgorithm.getValues().get(0).toString()).
+                map(cipherAlgorithm -> cipherAlgorithm.getValues().getFirst().toString()).
                 orElse(CLEARTEXT);
     }
 

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/DefaultGroupPullResultHandler.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/DefaultGroupPullResultHandler.java
@@ -124,7 +124,7 @@ public class DefaultGroupPullResultHandler extends AbstractPullResultHandler imp
             if (attrPatch.getOperation() == PatchOperation.ADD_REPLACE && attrPatch.getAttr() != null
                     && attrPatch.getAttr().getSchema().isEmpty() && !attrPatch.getAttr().getValues().isEmpty()) {
 
-                groupOwner = attrPatch.getAttr().getValues().get(0);
+                groupOwner = attrPatch.getAttr().getValues().getFirst();
             }
         }
         if (groupOwner != null) {

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/DefaultInboundCorrelationRule.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/DefaultInboundCorrelationRule.java
@@ -71,14 +71,14 @@ public class DefaultInboundCorrelationRule implements InboundCorrelationRule {
             String expression = null;
 
             if (attr.getValue() == null || attr.getValue().isEmpty()
-                    || (attr.getValue().size() == 1 && attr.getValue().get(0) == null)) {
+                    || (attr.getValue().size() == 1 && attr.getValue().getFirst() == null)) {
 
                 type = AttrCond.Type.ISNULL;
             } else {
                 type = AttrCond.Type.EQ;
                 expression = attr.getValue().size() > 1
                         ? attr.getValue().toString()
-                        : attr.getValue().get(0).toString();
+                        : attr.getValue().getFirst().toString();
             }
 
             AttrCond cond = "key".equalsIgnoreCase(schema)

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/DefaultPushCorrelationRule.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/DefaultPushCorrelationRule.java
@@ -135,7 +135,7 @@ public class DefaultPushCorrelationRule implements PushCorrelationRule {
 
                         if (!valueConditions.isEmpty()) {
                             conditions.add(valueConditions.size() == 1
-                                    ? valueConditions.get(0)
+                                    ? valueConditions.getFirst()
                                     : FIQL_BUILDER.and(valueConditions));
                         }
                     }

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/DefaultRealmPushResultHandler.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/DefaultRealmPushResultHandler.java
@@ -140,8 +140,8 @@ public class DefaultRealmPushResultHandler
 
     private static void reportPropagation(final ProvisioningReport result, final PropagationReporter reporter) {
         if (!reporter.getStatuses().isEmpty()) {
-            result.setStatus(toProvisioningReportStatus(reporter.getStatuses().get(0).getStatus()));
-            result.setMessage(reporter.getStatuses().get(0).getFailureReason());
+            result.setStatus(toProvisioningReportStatus(reporter.getStatuses().getFirst().getStatus()));
+            result.setMessage(reporter.getStatuses().getFirst().getFailureReason());
         }
     }
 
@@ -158,9 +158,9 @@ public class DefaultRealmPushResultHandler
                 propagationManager.createTasks(realm, propByRes, null),
                 beforeAttrs);
         if (!taskInfos.isEmpty()) {
-            taskInfos.get(0).setBeforeObj(Optional.ofNullable(beforeObj));
+            taskInfos.getFirst().setBeforeObj(Optional.ofNullable(beforeObj));
             PropagationReporter reporter = new DefaultPropagationReporter();
-            taskExecutor.execute(taskInfos.get(0), reporter, securityProperties.getAdminUser());
+            taskExecutor.execute(taskInfos.getFirst(), reporter, securityProperties.getAdminUser());
             reportPropagation(result, reporter);
         }
 
@@ -176,9 +176,9 @@ public class DefaultRealmPushResultHandler
 
         List<PropagationTaskInfo> taskInfos = propagationManager.createTasks(realm, propByRes, noPropResources);
         if (!taskInfos.isEmpty()) {
-            taskInfos.get(0).setBeforeObj(Optional.ofNullable(beforeObj));
+            taskInfos.getFirst().setBeforeObj(Optional.ofNullable(beforeObj));
             PropagationReporter reporter = new DefaultPropagationReporter();
-            taskExecutor.execute(taskInfos.get(0), reporter, securityProperties.getAdminUser());
+            taskExecutor.execute(taskInfos.getFirst(), reporter, securityProperties.getAdminUser());
             reportPropagation(result, reporter);
         }
     }

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/DefaultUserPushResultHandler.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/DefaultUserPushResultHandler.java
@@ -134,9 +134,9 @@ public class DefaultUserPushResultHandler extends AbstractPushResultHandler impl
                 null,
                 noPropResources);
         if (!taskInfos.isEmpty()) {
-            taskInfos.get(0).setBeforeObj(Optional.of(beforeObj));
+            taskInfos.getFirst().setBeforeObj(Optional.of(beforeObj));
             PropagationReporter reporter = new DefaultPropagationReporter();
-            taskExecutor.execute(taskInfos.get(0), reporter, profile.getExecutor());
+            taskExecutor.execute(taskInfos.getFirst(), reporter, profile.getExecutor());
             reportPropagation(result, reporter);
         }
     }
@@ -165,9 +165,9 @@ public class DefaultUserPushResultHandler extends AbstractPushResultHandler impl
                 propByLinkedAccount,
                 noPropResources);
         if (!taskInfos.isEmpty()) {
-            taskInfos.get(0).setBeforeObj(Optional.of(beforeObj));
+            taskInfos.getFirst().setBeforeObj(Optional.of(beforeObj));
             PropagationReporter reporter = new DefaultPropagationReporter();
-            taskExecutor.execute(taskInfos.get(0), reporter, profile.getExecutor());
+            taskExecutor.execute(taskInfos.getFirst(), reporter, profile.getExecutor());
             reportPropagation(result, reporter);
         }
     }
@@ -374,9 +374,9 @@ public class DefaultUserPushResultHandler extends AbstractPushResultHandler impl
                 null,
                 null);
         if (!taskInfos.isEmpty()) {
-            taskInfos.get(0).setBeforeObj(Optional.empty());
+            taskInfos.getFirst().setBeforeObj(Optional.empty());
             PropagationReporter reporter = new DefaultPropagationReporter();
-            taskExecutor.execute(taskInfos.get(0), reporter, profile.getExecutor());
+            taskExecutor.execute(taskInfos.getFirst(), reporter, profile.getExecutor());
             reportPropagation(result, reporter);
         }
     }
@@ -401,9 +401,9 @@ public class DefaultUserPushResultHandler extends AbstractPushResultHandler impl
                         propByLinkedAccount,
                         ""));
         if (!taskInfos.isEmpty()) {
-            taskInfos.get(0).setBeforeObj(Optional.empty());
+            taskInfos.getFirst().setBeforeObj(Optional.empty());
             PropagationReporter reporter = new DefaultPropagationReporter();
-            taskExecutor.execute(taskInfos.get(0), reporter, profile.getExecutor());
+            taskExecutor.execute(taskInfos.getFirst(), reporter, profile.getExecutor());
             reportPropagation(result, reporter);
         }
     }

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/InboundMatcher.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/InboundMatcher.java
@@ -187,7 +187,7 @@ public class InboundMatcher {
                         provision.get().getObjectClass(), resource, Name.NAME, nameValue);
             }
 
-            ConnectorObject connObj = found.iterator().next();
+            ConnectorObject connObj = found.getFirst();
             try {
                 List<InboundMatch> matches = match(
                         new SyncDeltaBuilder().
@@ -239,7 +239,7 @@ public class InboundMatcher {
                     null,
                     List.of(finalConnObjectKeyValue));
             if (!CollectionUtils.isEmpty(output)) {
-                finalConnObjectKeyValue = output.get(0).toString();
+                finalConnObjectKeyValue = output.getFirst().toString();
             }
         }
 
@@ -421,8 +421,8 @@ public class InboundMatcher {
             LOG.error("Could not match {} with any existing {}", syncDelta, provision.getAnyType(), e);
         }
 
-        if (result.size() == 1 && result.get(0).getMatchTarget() == MatchType.ANY) {
-            virAttrHandler.setValues(result.get(0).getAny(), syncDelta.getObject());
+        if (result.size() == 1 && result.getFirst().getMatchTarget() == MatchType.ANY) {
+            virAttrHandler.setValues(result.getFirst().getAny(), syncDelta.getObject());
         }
 
         return result;
@@ -459,7 +459,7 @@ public class InboundMatcher {
                     null,
                     List.of(connObjectKey));
             if (!CollectionUtils.isEmpty(output)) {
-                connObjectKey = output.get(0).toString();
+                connObjectKey = output.getFirst().toString();
             }
         }
 

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/LDAPMembershipPullActions.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/LDAPMembershipPullActions.java
@@ -94,7 +94,7 @@ public class LDAPMembershipPullActions implements InboundActions {
         return connector.getConnInstance().getConf().stream().
                 filter(property -> "groupMemberAttribute".equals(property.getSchema().getName())
                 && !property.getValues().isEmpty()).findFirst().
-                map(groupMembership -> (String) groupMembership.getValues().get(0)).
+                map(groupMembership -> (String) groupMembership.getValues().getFirst()).
                 orElse("uniquemember");
     }
 

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/OutboundMatcher.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/OutboundMatcher.java
@@ -166,7 +166,7 @@ public class OutboundMatcher {
         }
 
         if (any != null && result.size() == 1) {
-            virAttrHandler.setValues(any, result.get(0));
+            virAttrHandler.setValues(any, result.getFirst());
         }
 
         return result;
@@ -239,7 +239,7 @@ public class OutboundMatcher {
         }
 
         if (any != null && result.size() == 1) {
-            virAttrHandler.setValues(any, result.get(0));
+            virAttrHandler.setValues(any, result.getFirst());
         }
 
         return result;

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/SinglePushJobDelegate.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/SinglePushJobDelegate.java
@@ -155,7 +155,7 @@ public class SinglePushJobDelegate extends PushJobDelegate implements SyncopeSin
                 action.afterAll(profile);
             }
 
-            return profile.getResults().get(0);
+            return profile.getResults().getFirst();
         } catch (Exception e) {
             throw e instanceof JobExecutionException
                     ? (JobExecutionException) e

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/stream/CSVStreamConnector.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/stream/CSVStreamConnector.java
@@ -172,10 +172,10 @@ public class CSVStreamConnector implements Connector, AutoCloseable {
 
         Map<String, String> row = new LinkedHashMap<>();
         attrs.stream().filter(attr -> !AttributeUtil.isSpecial(attr)).forEach(attr -> {
-            if (CollectionUtils.isEmpty(attr.getValue()) || attr.getValue().get(0) == null) {
+            if (CollectionUtils.isEmpty(attr.getValue()) || attr.getValue().getFirst() == null) {
                 row.put(attr.getName(), null);
             } else if (attr.getValue().size() == 1) {
-                row.put(attr.getName(), attr.getValue().get(0).toString());
+                row.put(attr.getName(), attr.getValue().getFirst().toString());
             } else if (arrayElementsSeparator == null) {
                 row.put(attr.getName(), attr.getValue().toString());
             } else {

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/stream/StreamAnyObjectPushResultHandler.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/stream/StreamAnyObjectPushResultHandler.java
@@ -42,7 +42,7 @@ public class StreamAnyObjectPushResultHandler extends DefaultAnyObjectPushResult
 
     @Override
     protected void provision(final Any any, final Boolean enabled, final ProvisioningReport result) {
-        Provision provision = profile.getTask().getResource().getProvisions().get(0);
+        Provision provision = profile.getTask().getResource().getProvisions().getFirst();
 
         Stream<Item> items = MappingUtils.getPropagationItems(provision.getMapping().getItems().stream());
 

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/stream/StreamGroupPushResultHandler.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/stream/StreamGroupPushResultHandler.java
@@ -42,7 +42,7 @@ public class StreamGroupPushResultHandler extends DefaultGroupPushResultHandler 
 
     @Override
     protected void provision(final Any any, final Boolean enabled, final ProvisioningReport result) {
-        Provision provision = profile.getTask().getResource().getProvisions().get(0);
+        Provision provision = profile.getTask().getResource().getProvisions().getFirst();
 
         Stream<Item> items = MappingUtils.getPropagationItems(provision.getMapping().getItems().stream());
 

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/stream/StreamPullJobDelegate.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/stream/StreamPullJobDelegate.java
@@ -168,7 +168,7 @@ public class StreamPullJobDelegate extends PullJobDelegate implements SyncopeStr
         try {
             ExternalResource resource =
                     externalResource(anyType, keyColumn, columns, conflictResolutionAction, inboundCorrelationRule);
-            Provision provision = resource.getProvisions().get(0);
+            Provision provision = resource.getProvisions().getFirst();
 
             task = entityFactory.newEntity(PullTask.class);
             task.setName(pullTaskTO.getName());

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/stream/StreamUserPushResultHandler.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/stream/StreamUserPushResultHandler.java
@@ -42,7 +42,7 @@ public class StreamUserPushResultHandler extends DefaultUserPushResultHandler {
 
     @Override
     protected void provision(final Any any, final Boolean enabled, final ProvisioningReport result) {
-        Provision provision = profile.getTask().getResource().getProvisions().get(0);
+        Provision provision = profile.getTask().getResource().getProvisions().getFirst();
 
         Stream<Item> items = MappingUtils.getPropagationItems(provision.getMapping().getItems().stream());
 

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/utils/TemplateUtils.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/utils/TemplateUtils.java
@@ -48,13 +48,13 @@ public class TemplateUtils {
         templates.values().forEach(value -> {
             value.getPlainAttrs().stream().
                     filter(attrTO -> !attrTO.getValues().isEmpty()
-                    && !JexlUtils.isExpressionValid(attrTO.getValues().get(0))).
-                    forEachOrdered(attrTO -> sce.getElements().add("Invalid JEXL: " + attrTO.getValues().get(0)));
+                    && !JexlUtils.isExpressionValid(attrTO.getValues().getFirst())).
+                    forEachOrdered(attrTO -> sce.getElements().add("Invalid JEXL: " + attrTO.getValues().getFirst()));
 
             value.getVirAttrs().stream().
                     filter(attrTO -> !attrTO.getValues().isEmpty()
-                    && !JexlUtils.isExpressionValid(attrTO.getValues().get(0))).
-                    forEachOrdered((attrTO) -> sce.getElements().add("Invalid JEXL: " + attrTO.getValues().get(0)));
+                    && !JexlUtils.isExpressionValid(attrTO.getValues().getFirst())).
+                    forEachOrdered((attrTO) -> sce.getElements().add("Invalid JEXL: " + attrTO.getValues().getFirst()));
 
             switch (value) {
                 case UserTO template -> {
@@ -125,7 +125,7 @@ public class TemplateUtils {
                 Attr evaluated = evaluateAttr(templatePlainAttr, jexlContext);
                 if (!evaluated.getValues().isEmpty()) {
                     realmMember.getPlainAttrs().add(evaluated);
-                    jexlContext.set(evaluated.getSchema(), evaluated.getValues().get(0));
+                    jexlContext.set(evaluated.getSchema(), evaluated.getValues().getFirst());
                 }
             }
         }
@@ -146,7 +146,7 @@ public class TemplateUtils {
                 Attr evaluated = evaluateAttr(templateVirAttr, jexlContext);
                 if (!evaluated.getValues().isEmpty()) {
                     realmMember.getVirAttrs().add(evaluated);
-                    jexlContext.set(evaluated.getSchema(), evaluated.getValues().get(0));
+                    jexlContext.set(evaluated.getSchema(), evaluated.getValues().getFirst());
                 }
             }
         }

--- a/core/provisioning-java/src/test/java/org/apache/syncope/core/provisioning/java/pushpull/stream/StreamPullJobDelegateTest.java
+++ b/core/provisioning-java/src/test/java/org/apache/syncope/core/provisioning/java/pushpull/stream/StreamPullJobDelegateTest.java
@@ -120,16 +120,16 @@ public class StreamPullJobDelegateTest extends AbstractTest {
         });
         assertEquals(1, results.size());
 
-        assertEquals(AnyTypeKind.USER.name(), results.get(0).getAnyType());
-        assertNotNull(results.get(0).getKey());
-        assertEquals("donizetti", results.get(0).getName());
-        assertEquals("donizetti", results.get(0).getUidValue());
-        assertEquals(ResourceOperation.CREATE, results.get(0).getOperation());
-        assertEquals(ProvisioningReport.Status.SUCCESS, results.get(0).getStatus());
+        assertEquals(AnyTypeKind.USER.name(), results.getFirst().getAnyType());
+        assertNotNull(results.getFirst().getKey());
+        assertEquals("donizetti", results.getFirst().getName());
+        assertEquals("donizetti", results.getFirst().getUidValue());
+        assertEquals(ResourceOperation.CREATE, results.getFirst().getOperation());
+        assertEquals(ProvisioningReport.Status.SUCCESS, results.getFirst().getStatus());
 
-        User donizetti = userDAO.findById(results.get(0).getKey()).orElseThrow();
+        User donizetti = userDAO.findById(results.getFirst().getKey()).orElseThrow();
         assertNotNull(donizetti);
         assertEquals("donizetti", donizetti.getUsername());
-        assertEquals("Gaetano", donizetti.getPlainAttr("firstname").get().getValuesAsStrings().get(0));
+        assertEquals("Gaetano", donizetti.getPlainAttr("firstname").get().getValuesAsStrings().getFirst());
     }
 }

--- a/core/self-keymaster-starter/src/main/java/org/apache/syncope/core/logic/NetworkServiceLogic.java
+++ b/core/self-keymaster-starter/src/main/java/org/apache/syncope/core/logic/NetworkServiceLogic.java
@@ -67,7 +67,7 @@ public class NetworkServiceLogic extends AbstractTransactionalLogic<EntityTO> {
         }
 
         return list.size() == 1
-                ? list.get(0)
+                ? list.getFirst()
                 : list.get(SecureRandomUtils.generateRandomInt(0, list.size()));
     }
 

--- a/core/spring/src/main/java/org/apache/syncope/core/spring/security/AuthDataAccessor.java
+++ b/core/spring/src/main/java/org/apache/syncope/core/spring/security/AuthDataAccessor.java
@@ -205,7 +205,7 @@ public class AuthDataAccessor {
                 try {
                     List<User> users = anySearchDAO.search(SearchCond.of(attrCond), AnyTypeKind.USER);
                     if (users.size() == 1) {
-                        user = users.get(0);
+                        user = users.getFirst();
                     } else {
                         LOG.warn("Search condition {} does not uniquely match a user", attrCond);
                     }

--- a/ext/elasticsearch/client-elasticsearch/src/main/java/org/apache/syncope/ext/elasticsearch/client/ElasticsearchUtils.java
+++ b/ext/elasticsearch/client-elasticsearch/src/main/java/org/apache/syncope/ext/elasticsearch/client/ElasticsearchUtils.java
@@ -192,7 +192,7 @@ public class ElasticsearchUtils {
 
             Optional.ofNullable(plainAttr.getUniqueValue()).ifPresent(v -> values.add(v.getValue()));
 
-            builder.put(plainAttr.getSchema(), values.size() == 1 ? values.get(0) : values);
+            builder.put(plainAttr.getSchema(), values.size() == 1 ? values.getFirst() : values);
         }
 
         // add also flattened membership attributes
@@ -209,7 +209,7 @@ public class ElasticsearchUtils {
                     ((Collection<Object>) attr).addAll(values);
                 } else {
                     values.add(attr);
-                    builder.put(mAttr.getSchema(), values.size() == 1 ? values.get(0) : values);
+                    builder.put(mAttr.getSchema(), values.size() == 1 ? values.getFirst() : values);
                 }
             }));
         }

--- a/ext/elasticsearch/persistence/src/main/java/org/apache/syncope/core/persistence/elasticsearch/dao/ElasticsearchAnySearchDAO.java
+++ b/ext/elasticsearch/persistence/src/main/java/org/apache/syncope/core/persistence/elasticsearch/dao/ElasticsearchAnySearchDAO.java
@@ -442,7 +442,7 @@ public class ElasticsearchAnySearchDAO extends AbstractAnySearchDAO {
                 build()).toList();
 
         return queries.size() == 1
-                ? queries.get(0)
+                ? queries.getFirst()
                 : new Query.Builder().disMax(QueryBuilders.disMax().queries(queries).build()).build();
     }
 
@@ -453,7 +453,7 @@ public class ElasticsearchAnySearchDAO extends AbstractAnySearchDAO {
                 build()).toList();
 
         return queries.size() == 1
-                ? queries.get(0)
+                ? queries.getFirst()
                 : new Query.Builder().disMax(QueryBuilders.disMax().queries(queries).build()).build();
     }
 
@@ -476,7 +476,7 @@ public class ElasticsearchAnySearchDAO extends AbstractAnySearchDAO {
                 build()).toList();
 
         return queries.size() == 1
-                ? queries.get(0)
+                ? queries.getFirst()
                 : new Query.Builder().disMax(QueryBuilders.disMax().queries(queries).build()).build();
     }
 

--- a/ext/elasticsearch/persistence/src/test/java/org/apache/syncope/core/persistence/elasticsearch/dao/ElasticsearchAnySearchDAOTest.java
+++ b/ext/elasticsearch/persistence/src/test/java/org/apache/syncope/core/persistence/elasticsearch/dao/ElasticsearchAnySearchDAOTest.java
@@ -313,7 +313,7 @@ public class ElasticsearchAnySearchDAOTest {
                     AnyTypeKind.USER);
             assertEquals(Query.Kind.Bool, query._kind());
             assertEquals(2, ((BoolQuery) query._get()).must().size());
-            Query left = ((BoolQuery) query._get()).must().get(0);
+            Query left = ((BoolQuery) query._get()).must().getFirst();
             assertEquals(Query.Kind.DisMax, left._kind());
             assertEquals(3, ((DisMaxQuery) left._get()).queries().size());
             Query right = ((BoolQuery) query._get()).must().get(1);
@@ -352,7 +352,7 @@ public class ElasticsearchAnySearchDAOTest {
                     AnyTypeKind.USER);
             assertEquals(Query.Kind.DisMax, query._kind());
             assertEquals(2, ((DisMaxQuery) query._get()).queries().size());
-            left = ((DisMaxQuery) query._get()).queries().get(0);
+            left = ((DisMaxQuery) query._get()).queries().getFirst();
             assertEquals(Query.Kind.Bool, left._kind());
             assertEquals(3, ((BoolQuery) left._get()).must().size());
             right = ((DisMaxQuery) query._get()).queries().get(1);

--- a/ext/flowable/client-console/src/main/java/org/apache/syncope/client/console/rest/UserRequestRestClient.java
+++ b/ext/flowable/client-console/src/main/java/org/apache/syncope/client/console/rest/UserRequestRestClient.java
@@ -95,7 +95,7 @@ public class UserRequestRestClient extends BaseRestClient {
                 listForms(new UserRequestQuery.Builder().user(userKey).page(1).size(1).build());
         UserRequestForm form = forms.getResult().isEmpty()
                 ? null
-                : forms.getResult().get(0);
+                : forms.getResult().getFirst();
         return Optional.ofNullable(form);
     }
 

--- a/ext/flowable/flowable-bpmn/src/main/java/org/apache/syncope/core/flowable/impl/FlowableRuntimeUtils.java
+++ b/ext/flowable/flowable-bpmn/src/main/java/org/apache/syncope/core/flowable/impl/FlowableRuntimeUtils.java
@@ -134,7 +134,7 @@ public final class FlowableRuntimeUtils {
         if (tasks.isEmpty() || tasks.size() > 1) {
             LOG.warn("While setting user status: unexpected task number ({})", tasks.size());
         } else {
-            user.setStatus(tasks.get(0).getTaskDefinitionKey());
+            user.setStatus(tasks.getFirst().getTaskDefinitionKey());
         }
     }
 
@@ -146,7 +146,7 @@ public final class FlowableRuntimeUtils {
         if (tasks.isEmpty() || tasks.size() > 1) {
             LOG.debug("While checking if form task: unexpected task number ({})", tasks.size());
         } else {
-            result = tasks.get(0).getFormKey();
+            result = tasks.getFirst().getFormKey();
         }
 
         return result;

--- a/ext/flowable/flowable-bpmn/src/main/java/org/apache/syncope/core/flowable/impl/FlowableUserWorkflowAdapter.java
+++ b/ext/flowable/flowable-bpmn/src/main/java/org/apache/syncope/core/flowable/impl/FlowableUserWorkflowAdapter.java
@@ -218,11 +218,11 @@ public class FlowableUserWorkflowAdapter extends AbstractUserWorkflowAdapter imp
         String task = null;
         if (tasks.size() == 1) {
             try {
-                engine.getTaskService().complete(tasks.get(0).getId(), variables);
-                task = tasks.get(0).getTaskDefinitionKey();
+                engine.getTaskService().complete(tasks.getFirst().getId(), variables);
+                task = tasks.getFirst().getTaskDefinitionKey();
             } catch (FlowableException e) {
                 FlowableRuntimeUtils.throwException(
-                        e, "While completing task '" + tasks.get(0).getName() + "' for " + user);
+                        e, "While completing task '" + tasks.getFirst().getName() + "' for " + user);
             }
         } else {
             LOG.warn("Expected a single task, found {}", tasks.size());
@@ -604,7 +604,7 @@ public class FlowableUserWorkflowAdapter extends AbstractUserWorkflowAdapter imp
 
             Process process = engine.getRepositoryService().
                     getBpmnModel(FlowableRuntimeUtils.getLatestProcDefByKey(
-                            engine, FlowableRuntimeUtils.WF_PROCESS_ID).getId()).getProcesses().get(0);
+                            engine, FlowableRuntimeUtils.WF_PROCESS_ID).getId()).getProcesses().getFirst();
             process.getFlowElements().stream().
                     filter(SequenceFlow.class::isInstance).
                     map(SequenceFlow.class::cast).

--- a/ext/flowable/flowable-bpmn/src/main/java/org/apache/syncope/core/flowable/support/SyncopeTaskFormHandler.java
+++ b/ext/flowable/flowable-bpmn/src/main/java/org/apache/syncope/core/flowable/support/SyncopeTaskFormHandler.java
@@ -52,11 +52,11 @@ public class SyncopeTaskFormHandler extends DefaultTaskFormHandler {
         switch (formProperty.getType()) {
             case "dropdown":
                 if (formProperty.getFormValues().isEmpty()
-                        || !DropdownValueProvider.NAME.equals(formProperty.getFormValues().get(0).getId())) {
+                        || !DropdownValueProvider.NAME.equals(formProperty.getFormValues().getFirst().getId())) {
 
                     LOG.warn("A single value with id '" + DropdownValueProvider.NAME + "' was expected, ignoring");
                 } else {
-                    formType = new DropdownFormType(formProperty.getFormValues().get(0).getName());
+                    formType = new DropdownFormType(formProperty.getFormValues().getFirst().getName());
                 }
                 break;
 

--- a/ext/oidcc4ui/logic/src/main/java/org/apache/syncope/core/logic/OIDCC4UILogic.java
+++ b/ext/oidcc4ui/logic/src/main/java/org/apache/syncope/core/logic/OIDCC4UILogic.java
@@ -217,12 +217,12 @@ public class OIDCC4UILogic extends AbstractTransactionalLogic<EntityTO> {
             throw new IllegalArgumentException("Several users match the provided value " + keyValue);
         } else {
             if (op.isUpdateMatching()) {
-                LOG.debug("About to update {} for {}", matchingUsers.get(0), keyValue);
+                LOG.debug("About to update {} for {}", matchingUsers.getFirst(), keyValue);
 
                 username = AuthContextUtils.callAsAdmin(AuthContextUtils.getDomain(),
-                        () -> userManager.update(matchingUsers.get(0), op, loginResp));
+                        () -> userManager.update(matchingUsers.getFirst(), op, loginResp));
             } else {
-                username = matchingUsers.get(0);
+                username = matchingUsers.getFirst();
             }
         }
 

--- a/ext/oidcc4ui/logic/src/main/java/org/apache/syncope/core/logic/oidc/OIDCUserManager.java
+++ b/ext/oidcc4ui/logic/src/main/java/org/apache/syncope/core/logic/oidc/OIDCUserManager.java
@@ -164,7 +164,7 @@ public class OIDCUserManager {
                 switch (intAttrName.getField()) {
                     case "username" -> {
                         if (!values.isEmpty()) {
-                            userTO.setUsername(values.get(0));
+                            userTO.setUsername(values.getFirst());
                         }
                     }
 

--- a/ext/opensearch/client-opensearch/src/main/java/org/apache/syncope/ext/opensearch/client/OpenSearchUtils.java
+++ b/ext/opensearch/client-opensearch/src/main/java/org/apache/syncope/ext/opensearch/client/OpenSearchUtils.java
@@ -192,7 +192,7 @@ public class OpenSearchUtils {
 
             Optional.ofNullable(plainAttr.getUniqueValue()).ifPresent(v -> values.add(v.getValue()));
 
-            builder.put(plainAttr.getSchema(), values.size() == 1 ? values.get(0) : values);
+            builder.put(plainAttr.getSchema(), values.size() == 1 ? values.getFirst() : values);
         }
 
         // add also flattened membership attributes
@@ -209,7 +209,7 @@ public class OpenSearchUtils {
                     ((Collection<Object>) attr).addAll(values);
                 } else {
                     values.add(attr);
-                    builder.put(mAttr.getSchema(), values.size() == 1 ? values.get(0) : values);
+                    builder.put(mAttr.getSchema(), values.size() == 1 ? values.getFirst() : values);
                 }
             }));
         }

--- a/ext/opensearch/persistence/src/main/java/org/apache/syncope/core/persistence/opensearch/dao/OpenSearchAnySearchDAO.java
+++ b/ext/opensearch/persistence/src/main/java/org/apache/syncope/core/persistence/opensearch/dao/OpenSearchAnySearchDAO.java
@@ -440,7 +440,7 @@ public class OpenSearchAnySearchDAO extends AbstractAnySearchDAO {
                 build()).toList();
 
         return queries.size() == 1
-                ? queries.get(0)
+                ? queries.getFirst()
                 : new Query.Builder().disMax(QueryBuilders.disMax().queries(queries).build()).build();
     }
 
@@ -451,7 +451,7 @@ public class OpenSearchAnySearchDAO extends AbstractAnySearchDAO {
                 build()).toList();
 
         return queries.size() == 1
-                ? queries.get(0)
+                ? queries.getFirst()
                 : new Query.Builder().disMax(QueryBuilders.disMax().queries(queries).build()).build();
     }
 
@@ -474,7 +474,7 @@ public class OpenSearchAnySearchDAO extends AbstractAnySearchDAO {
                 build()).toList();
 
         return queries.size() == 1
-                ? queries.get(0)
+                ? queries.getFirst()
                 : new Query.Builder().disMax(QueryBuilders.disMax().queries(queries).build()).build();
     }
 

--- a/ext/opensearch/persistence/src/test/java/org/apache/syncope/core/persistence/opensearch/dao/OpenSearchAnySearchDAOTest.java
+++ b/ext/opensearch/persistence/src/test/java/org/apache/syncope/core/persistence/opensearch/dao/OpenSearchAnySearchDAOTest.java
@@ -314,7 +314,7 @@ public class OpenSearchAnySearchDAOTest {
                     AnyTypeKind.USER);
             assertEquals(Query.Kind.Bool, query._kind());
             assertEquals(2, ((BoolQuery) query._get()).must().size());
-            Query left = ((BoolQuery) query._get()).must().get(0);
+            Query left = ((BoolQuery) query._get()).must().getFirst();
             assertEquals(Query.Kind.DisMax, left._kind());
             assertEquals(3, ((DisMaxQuery) left._get()).queries().size());
             Query right = ((BoolQuery) query._get()).must().get(1);
@@ -359,7 +359,7 @@ public class OpenSearchAnySearchDAOTest {
                     AnyTypeKind.USER);
             assertEquals(Query.Kind.DisMax, query._kind());
             assertEquals(2, ((DisMaxQuery) query._get()).queries().size());
-            left = ((DisMaxQuery) query._get()).queries().get(0);
+            left = ((DisMaxQuery) query._get()).queries().getFirst();
             assertEquals(Query.Kind.Bool, left._kind());
             assertEquals(3, ((BoolQuery) left._get()).must().size());
             right = ((DisMaxQuery) query._get()).queries().get(1);

--- a/ext/saml2sp4ui/logic/src/main/java/org/apache/syncope/core/logic/SAML2SP4UILogic.java
+++ b/ext/saml2sp4ui/logic/src/main/java/org/apache/syncope/core/logic/SAML2SP4UILogic.java
@@ -176,7 +176,7 @@ public class SAML2SP4UILogic extends AbstractSAML2SP4UILogic {
                     (EntityDescriptor) new SAML2ServiceProviderMetadataResolver(cfg).getEntityDescriptorElement();
 
             AssertionConsumerService postACS = entityDescriptor.getSPSSODescriptor(SAMLConstants.SAML20P_NS).
-                    getAssertionConsumerServices().get(0);
+                    getAssertionConsumerServices().getFirst();
 
             AssertionConsumerService redirectACS = new AssertionConsumerServiceBuilder().buildObject();
             BeanUtils.copyProperties(postACS, redirectACS);
@@ -377,7 +377,7 @@ public class SAML2SP4UILogic extends AbstractSAML2SP4UILogic {
             if (!attr.getAttributeValues().isEmpty()) {
                 String attrName = Optional.ofNullable(attr.getFriendlyName()).orElse(attr.getName());
                 if (connObjectKeyItem != null && attrName.equals(connObjectKeyItem.getExtAttrName())) {
-                    keyValue = attr.getAttributeValues().get(0);
+                    keyValue = attr.getAttributeValues().getFirst();
                 }
 
                 loginResp.getAttrs().add(new Attr.Builder(attrName).values(attr.getAttributeValues()).build());
@@ -420,12 +420,12 @@ public class SAML2SP4UILogic extends AbstractSAML2SP4UILogic {
             throw new IllegalArgumentException("Several users match the provided value " + keyValue);
         } else {
             if (idp.isUpdateMatching()) {
-                LOG.debug("About to update {} for {}", matchingUsers.get(0), keyValue);
+                LOG.debug("About to update {} for {}", matchingUsers.getFirst(), keyValue);
 
                 username = AuthContextUtils.callAsAdmin(AuthContextUtils.getDomain(),
-                        () -> userManager.update(matchingUsers.get(0), idp, loginResp));
+                        () -> userManager.update(matchingUsers.getFirst(), idp, loginResp));
             } else {
-                username = matchingUsers.get(0);
+                username = matchingUsers.getFirst();
             }
         }
 

--- a/ext/saml2sp4ui/logic/src/main/java/org/apache/syncope/core/logic/saml2/SAML2SP4UIUserManager.java
+++ b/ext/saml2sp4ui/logic/src/main/java/org/apache/syncope/core/logic/saml2/SAML2SP4UIUserManager.java
@@ -180,7 +180,7 @@ public class SAML2SP4UIUserManager {
                 switch (intAttrName.getField()) {
                     case "username" -> {
                         if (!values.isEmpty()) {
-                            userTO.setUsername(values.get(0));
+                            userTO.setUsername(values.getFirst());
                         }
                     }
 

--- a/ext/scimv2/logic/src/main/java/org/apache/syncope/core/logic/SCIMDataBinder.java
+++ b/ext/scimv2/logic/src/main/java/org/apache/syncope/core/logic/SCIMDataBinder.java
@@ -142,10 +142,10 @@ public class SCIMDataBinder {
             SCIMComplexValue value = new SCIMComplexValue();
 
             if (conf.getValue() != null && attrs.containsKey(conf.getValue())) {
-                value.setValue(attrs.get(conf.getValue()).getValues().get(0));
+                value.setValue(attrs.get(conf.getValue()).getValues().getFirst());
             }
             if (conf.getDisplay() != null && attrs.containsKey(conf.getDisplay())) {
-                value.setDisplay(attrs.get(conf.getDisplay()).getValues().get(0));
+                value.setDisplay(attrs.get(conf.getDisplay()).getValues().getFirst());
             }
             if (conf.getType() != null) {
                 value.setType(conf.getType().name());
@@ -219,7 +219,7 @@ public class SCIMDataBinder {
                     && conf.getUserConf().getExternalId() != null
                     && attrs.containsKey(conf.getUserConf().getExternalId())) {
 
-                user.setExternalId(attrs.get(conf.getUserConf().getExternalId()).getValues().get(0));
+                user.setExternalId(attrs.get(conf.getUserConf().getExternalId()).getValues().getFirst());
             }
 
             if (output(attributes, excludedAttributes, "name") && conf.getUserConf().getName() != null) {
@@ -228,34 +228,34 @@ public class SCIMDataBinder {
                 if (conf.getUserConf().getName().getFamilyName() != null
                         && attrs.containsKey(conf.getUserConf().getName().getFamilyName())) {
 
-                    name.setFamilyName(attrs.get(conf.getUserConf().getName().getFamilyName()).getValues().get(0));
+                    name.setFamilyName(attrs.get(conf.getUserConf().getName().getFamilyName()).getValues().getFirst());
                 }
                 if (conf.getUserConf().getName().getFormatted() != null
                         && attrs.containsKey(conf.getUserConf().getName().getFormatted())) {
 
-                    name.setFormatted(attrs.get(conf.getUserConf().getName().getFormatted()).getValues().get(0));
+                    name.setFormatted(attrs.get(conf.getUserConf().getName().getFormatted()).getValues().getFirst());
                 }
                 if (conf.getUserConf().getName().getGivenName() != null
                         && attrs.containsKey(conf.getUserConf().getName().getGivenName())) {
 
-                    name.setGivenName(attrs.get(conf.getUserConf().getName().getGivenName()).getValues().get(0));
+                    name.setGivenName(attrs.get(conf.getUserConf().getName().getGivenName()).getValues().getFirst());
                 }
                 if (conf.getUserConf().getName().getHonorificPrefix() != null
                         && attrs.containsKey(conf.getUserConf().getName().getHonorificPrefix())) {
 
                     name.setHonorificPrefix(
-                            attrs.get(conf.getUserConf().getName().getHonorificPrefix()).getValues().get(0));
+                            attrs.get(conf.getUserConf().getName().getHonorificPrefix()).getValues().getFirst());
                 }
                 if (conf.getUserConf().getName().getHonorificSuffix() != null
                         && attrs.containsKey(conf.getUserConf().getName().getHonorificSuffix())) {
 
                     name.setHonorificSuffix(
-                            attrs.get(conf.getUserConf().getName().getHonorificSuffix()).getValues().get(0));
+                            attrs.get(conf.getUserConf().getName().getHonorificSuffix()).getValues().getFirst());
                 }
                 if (conf.getUserConf().getName().getMiddleName() != null
                         && attrs.containsKey(conf.getUserConf().getName().getMiddleName())) {
 
-                    name.setMiddleName(attrs.get(conf.getUserConf().getName().getMiddleName()).getValues().get(0));
+                    name.setMiddleName(attrs.get(conf.getUserConf().getName().getMiddleName()).getValues().getFirst());
                 }
 
                 if (!name.isEmpty()) {
@@ -267,49 +267,49 @@ public class SCIMDataBinder {
                     && conf.getUserConf().getDisplayName() != null
                     && attrs.containsKey(conf.getUserConf().getDisplayName())) {
 
-                user.setDisplayName(attrs.get(conf.getUserConf().getDisplayName()).getValues().get(0));
+                user.setDisplayName(attrs.get(conf.getUserConf().getDisplayName()).getValues().getFirst());
             }
             if (output(attributes, excludedAttributes, "nickName")
                     && conf.getUserConf().getNickName() != null
                     && attrs.containsKey(conf.getUserConf().getNickName())) {
 
-                user.setNickName(attrs.get(conf.getUserConf().getNickName()).getValues().get(0));
+                user.setNickName(attrs.get(conf.getUserConf().getNickName()).getValues().getFirst());
             }
             if (output(attributes, excludedAttributes, "profileUrl")
                     && conf.getUserConf().getProfileUrl() != null
                     && attrs.containsKey(conf.getUserConf().getProfileUrl())) {
 
-                user.setProfileUrl(attrs.get(conf.getUserConf().getProfileUrl()).getValues().get(0));
+                user.setProfileUrl(attrs.get(conf.getUserConf().getProfileUrl()).getValues().getFirst());
             }
             if (output(attributes, excludedAttributes, "title")
                     && conf.getUserConf().getTitle() != null
                     && attrs.containsKey(conf.getUserConf().getTitle())) {
 
-                user.setTitle(attrs.get(conf.getUserConf().getTitle()).getValues().get(0));
+                user.setTitle(attrs.get(conf.getUserConf().getTitle()).getValues().getFirst());
             }
             if (output(attributes, excludedAttributes, "userType")
                     && conf.getUserConf().getUserType() != null
                     && attrs.containsKey(conf.getUserConf().getUserType())) {
 
-                user.setUserType(attrs.get(conf.getUserConf().getUserType()).getValues().get(0));
+                user.setUserType(attrs.get(conf.getUserConf().getUserType()).getValues().getFirst());
             }
             if (output(attributes, excludedAttributes, "preferredLanguage")
                     && conf.getUserConf().getPreferredLanguage() != null
                     && attrs.containsKey(conf.getUserConf().getPreferredLanguage())) {
 
-                user.setPreferredLanguage(attrs.get(conf.getUserConf().getPreferredLanguage()).getValues().get(0));
+                user.setPreferredLanguage(attrs.get(conf.getUserConf().getPreferredLanguage()).getValues().getFirst());
             }
             if (output(attributes, excludedAttributes, "locale")
                     && conf.getUserConf().getLocale() != null
                     && attrs.containsKey(conf.getUserConf().getLocale())) {
 
-                user.setLocale(attrs.get(conf.getUserConf().getLocale()).getValues().get(0));
+                user.setLocale(attrs.get(conf.getUserConf().getLocale()).getValues().getFirst());
             }
             if (output(attributes, excludedAttributes, "timezone")
                     && conf.getUserConf().getTimezone() != null
                     && attrs.containsKey(conf.getUserConf().getTimezone())) {
 
-                user.setTimezone(attrs.get(conf.getUserConf().getTimezone()).getValues().get(0));
+                user.setTimezone(attrs.get(conf.getUserConf().getTimezone()).getValues().getFirst());
             }
 
             if (output(attributes, excludedAttributes, "emails")) {
@@ -329,19 +329,19 @@ public class SCIMDataBinder {
                     SCIMUserAddress address = new SCIMUserAddress();
 
                     if (addressConf.getFormatted() != null && attrs.containsKey(addressConf.getFormatted())) {
-                        address.setFormatted(attrs.get(addressConf.getFormatted()).getValues().get(0));
+                        address.setFormatted(attrs.get(addressConf.getFormatted()).getValues().getFirst());
                     }
                     if (addressConf.getStreetAddress() != null && attrs.containsKey(addressConf.getStreetAddress())) {
-                        address.setStreetAddress(attrs.get(addressConf.getStreetAddress()).getValues().get(0));
+                        address.setStreetAddress(attrs.get(addressConf.getStreetAddress()).getValues().getFirst());
                     }
                     if (addressConf.getLocality() != null && attrs.containsKey(addressConf.getLocality())) {
-                        address.setLocality(attrs.get(addressConf.getLocality()).getValues().get(0));
+                        address.setLocality(attrs.get(addressConf.getLocality()).getValues().getFirst());
                     }
                     if (addressConf.getRegion() != null && attrs.containsKey(addressConf.getRegion())) {
-                        address.setRegion(attrs.get(addressConf.getRegion()).getValues().get(0));
+                        address.setRegion(attrs.get(addressConf.getRegion()).getValues().getFirst());
                     }
                     if (addressConf.getCountry() != null && attrs.containsKey(addressConf.getCountry())) {
-                        address.setCountry(attrs.get(addressConf.getCountry()).getValues().get(0));
+                        address.setCountry(attrs.get(addressConf.getCountry()).getValues().getFirst());
                     }
                     if (addressConf.getType() != null) {
                         address.setType(addressConf.getType().name());
@@ -357,7 +357,7 @@ public class SCIMDataBinder {
             }
             if (output(attributes, excludedAttributes, "x509Certificates")) {
                 conf.getUserConf().getX509Certificates().stream().filter(attrs::containsKey).
-                        forEach(cert -> user.getX509Certificates().add(new Value(attrs.get(cert).getValues().get(0))));
+                        forEach(cert -> user.getX509Certificates().add(new Value(attrs.get(cert).getValues().getFirst())));
             }
         }
 
@@ -369,35 +369,35 @@ public class SCIMDataBinder {
                     && attrs.containsKey(conf.getEnterpriseUserConf().getEmployeeNumber())) {
 
                 enterpriseInfo.setEmployeeNumber(
-                        attrs.get(conf.getEnterpriseUserConf().getEmployeeNumber()).getValues().get(0));
+                        attrs.get(conf.getEnterpriseUserConf().getEmployeeNumber()).getValues().getFirst());
             }
             if (output(attributes, excludedAttributes, "costCenter")
                     && conf.getEnterpriseUserConf().getCostCenter() != null
                     && attrs.containsKey(conf.getEnterpriseUserConf().getCostCenter())) {
 
                 enterpriseInfo.setCostCenter(
-                        attrs.get(conf.getEnterpriseUserConf().getCostCenter()).getValues().get(0));
+                        attrs.get(conf.getEnterpriseUserConf().getCostCenter()).getValues().getFirst());
             }
             if (output(attributes, excludedAttributes, "organization")
                     && conf.getEnterpriseUserConf().getOrganization() != null
                     && attrs.containsKey(conf.getEnterpriseUserConf().getOrganization())) {
 
                 enterpriseInfo.setOrganization(
-                        attrs.get(conf.getEnterpriseUserConf().getOrganization()).getValues().get(0));
+                        attrs.get(conf.getEnterpriseUserConf().getOrganization()).getValues().getFirst());
             }
             if (output(attributes, excludedAttributes, "division")
                     && conf.getEnterpriseUserConf().getDivision() != null
                     && attrs.containsKey(conf.getEnterpriseUserConf().getDivision())) {
 
                 enterpriseInfo.setDivision(
-                        attrs.get(conf.getEnterpriseUserConf().getDivision()).getValues().get(0));
+                        attrs.get(conf.getEnterpriseUserConf().getDivision()).getValues().getFirst());
             }
             if (output(attributes, excludedAttributes, "department")
                     && conf.getEnterpriseUserConf().getDepartment() != null
                     && attrs.containsKey(conf.getEnterpriseUserConf().getDepartment())) {
 
                 enterpriseInfo.setDepartment(
-                        attrs.get(conf.getEnterpriseUserConf().getDepartment()).getValues().get(0));
+                        attrs.get(conf.getEnterpriseUserConf().getDepartment()).getValues().getFirst());
             }
             if (output(attributes, excludedAttributes, "manager")
                     && conf.getEnterpriseUserConf().getManager() != null) {
@@ -409,7 +409,7 @@ public class SCIMDataBinder {
 
                     try {
                         UserTO userManager = userLogic.read(attrs.get(
-                                conf.getEnterpriseUserConf().getManager().getKey()).getValues().get(0));
+                                conf.getEnterpriseUserConf().getManager().getKey()).getValues().getFirst());
                         manager.setValue(userManager.getKey());
                         manager.setRef(
                                 StringUtils.substringBefore(location, "/Users") + "/Users/" + userManager.getKey());
@@ -426,7 +426,7 @@ public class SCIMDataBinder {
                                         conf.getEnterpriseUserConf().getManager().getDisplayName()).orElse(null);
                             }
                             if (displayName != null) {
-                                manager.setDisplayName(displayName.getValues().get(0));
+                                manager.setDisplayName(displayName.getValues().getFirst());
                             }
                         }
                     } catch (Exception e) {
@@ -448,7 +448,7 @@ public class SCIMDataBinder {
             SCIMExtensionInfo extensionInfo = new SCIMExtensionInfo();
             conf.getExtensionUserConf().asMap().forEach((scimAttr, syncopeAttr) -> {
                 if (output(attributes, excludedAttributes, scimAttr) && attrs.containsKey(syncopeAttr)) {
-                    extensionInfo.getAttributes().put(scimAttr, attrs.get(syncopeAttr).getValues().get(0));
+                    extensionInfo.getAttributes().put(scimAttr, attrs.get(syncopeAttr).getValues().getFirst());
                 }
             });
 
@@ -725,7 +725,7 @@ public class SCIMDataBinder {
         Optional.ofNullable(schema).ifPresent(a -> {
             Attr.Builder attr = new Attr.Builder(a);
             if (!CollectionUtils.isEmpty(op.getValue())) {
-                attr.value(op.getValue().get(0).toString());
+                attr.value(op.getValue().getFirst().toString());
             }
 
             attrs.add(new AttrPatch.Builder(attr.build()).
@@ -800,7 +800,7 @@ public class SCIMDataBinder {
         StatusR statusR = null;
 
         if (op.getPath() == null && op.getOp() != PatchOp.remove
-                && !CollectionUtils.isEmpty(op.getValue()) && op.getValue().get(0) instanceof final SCIMUser after) {
+                && !CollectionUtils.isEmpty(op.getValue()) && op.getValue().getFirst() instanceof final SCIMUser after) {
 
             if (after.getActive() != null && before.isSuspended() == after.isActive()) {
                 statusR = new StatusR.Builder(
@@ -828,13 +828,13 @@ public class SCIMDataBinder {
             case "userName" -> {
                 if (op.getOp() != PatchOp.remove && !CollectionUtils.isEmpty(op.getValue())) {
                     userUR.setUsername(
-                            new StringReplacePatchItem.Builder().value(op.getValue().get(0).toString()).build());
+                            new StringReplacePatchItem.Builder().value(op.getValue().getFirst().toString()).build());
                 }
             }
 
             case "password" -> {
                 if (op.getOp() != PatchOp.remove && !CollectionUtils.isEmpty(op.getValue())) {
-                    userUR.setPassword(new PasswordPatch.Builder().value(op.getValue().get(0).toString()).resources(
+                    userUR.setPassword(new PasswordPatch.Builder().value(op.getValue().getFirst().toString()).resources(
                             resources).build());
                 }
             }
@@ -843,12 +843,12 @@ public class SCIMDataBinder {
                 if (!CollectionUtils.isEmpty(op.getValue())) {
 
                     // Workaround for Microsoft Entra being not SCIM compliant on PATCH requests
-                    if (op.getValue().get(0) instanceof String a) {
+                    if (op.getValue().getFirst() instanceof String a) {
                         op.setValue(List.of(BooleanUtils.toBoolean(a)));
                     }
 
                     statusR = new StatusR.Builder(before.getKey(),
-                            (boolean) op.getValue().get(0) ? StatusRType.REACTIVATE : StatusRType.SUSPEND).resources(
+                            (boolean) op.getValue().getFirst() ? StatusRType.REACTIVATE : StatusRType.SUSPEND).resources(
                             resources).build();
                 }
             }
@@ -894,43 +894,43 @@ public class SCIMDataBinder {
             case "timezone" -> setAttribute(userUR.getPlainAttrs(), conf.getUserConf().getTimezone(), op);
 
             case "emails" -> {
-                if (!CollectionUtils.isEmpty(op.getValue()) && op.getValue().get(0) instanceof SCIMUser) {
+                if (!CollectionUtils.isEmpty(op.getValue()) && op.getValue().getFirst() instanceof SCIMUser) {
                     setAttribute(userUR.getPlainAttrs(), conf.getUserConf().getEmails(),
-                            ((SCIMUser) op.getValue().get(0)).getEmails(), op.getOp());
+                            ((SCIMUser) op.getValue().getFirst()).getEmails(), op.getOp());
                 } else if (op.getPath().getFilter() != null) {
                     setAttribute(userUR.getPlainAttrs(), conf.getUserConf().getEmails(), op);
                 }
             }
 
             case "phoneNumbers" -> {
-                if (!CollectionUtils.isEmpty(op.getValue()) && op.getValue().get(0) instanceof SCIMUser) {
+                if (!CollectionUtils.isEmpty(op.getValue()) && op.getValue().getFirst() instanceof SCIMUser) {
                     setAttribute(userUR.getPlainAttrs(), conf.getUserConf().getPhoneNumbers(),
-                            ((SCIMUser) op.getValue().get(0)).getPhoneNumbers(), op.getOp());
+                            ((SCIMUser) op.getValue().getFirst()).getPhoneNumbers(), op.getOp());
                 } else if (op.getPath().getFilter() != null) {
                     setAttribute(userUR.getPlainAttrs(), conf.getUserConf().getPhoneNumbers(), op);
                 }
             }
 
             case "ims" -> {
-                if (!CollectionUtils.isEmpty(op.getValue()) && op.getValue().get(0) instanceof SCIMUser) {
+                if (!CollectionUtils.isEmpty(op.getValue()) && op.getValue().getFirst() instanceof SCIMUser) {
                     setAttribute(userUR.getPlainAttrs(), conf.getUserConf().getIms(),
-                            ((SCIMUser) op.getValue().get(0)).getIms(), op.getOp());
+                            ((SCIMUser) op.getValue().getFirst()).getIms(), op.getOp());
                 } else if (op.getPath().getFilter() != null) {
                     setAttribute(userUR.getPlainAttrs(), conf.getUserConf().getIms(), op);
                 }
             }
 
             case "photos" -> {
-                if (!CollectionUtils.isEmpty(op.getValue()) && op.getValue().get(0) instanceof SCIMUser) {
+                if (!CollectionUtils.isEmpty(op.getValue()) && op.getValue().getFirst() instanceof SCIMUser) {
                     setAttribute(userUR.getPlainAttrs(), conf.getUserConf().getPhotos(),
-                            ((SCIMUser) op.getValue().get(0)).getPhotos(), op.getOp());
+                            ((SCIMUser) op.getValue().getFirst()).getPhotos(), op.getOp());
                 } else if (op.getPath().getFilter() != null) {
                     setAttribute(userUR.getPlainAttrs(), conf.getUserConf().getPhotos(), op);
                 }
             }
 
             case "addresses" -> {
-                if (!CollectionUtils.isEmpty(op.getValue()) && op.getValue().get(0) instanceof final SCIMUser after) {
+                if (!CollectionUtils.isEmpty(op.getValue()) && op.getValue().getFirst() instanceof final SCIMUser after) {
                     after.getAddresses().stream().filter(address -> address.getType() != null).forEach(
                             address -> conf.getUserConf().getAddresses().stream()
                                     .filter(object -> address.getType().equals(object.getType().name())).findFirst()
@@ -1006,7 +1006,7 @@ public class SCIMDataBinder {
                 && conf.getGroupConf().getExternalId() != null
                 && attrs.containsKey(conf.getGroupConf().getExternalId())) {
 
-            group.setExternalId(attrs.get(conf.getGroupConf().getExternalId()).getValues().get(0));
+            group.setExternalId(attrs.get(conf.getGroupConf().getExternalId()).getValues().getFirst());
         }
 
         MembershipCond membCond = new MembershipCond();
@@ -1075,7 +1075,7 @@ public class SCIMDataBinder {
             StringReplacePatchItem.Builder name = new StringReplacePatchItem.Builder().
                     operation(op.getOp() == PatchOp.remove ? PatchOperation.DELETE : PatchOperation.ADD_REPLACE);
             if (!CollectionUtils.isEmpty(op.getValue())) {
-                name.value(op.getValue().get(0).toString());
+                name.value(op.getValue().getFirst().toString());
             }
             groupUR.setName(name.build());
         } else {

--- a/ext/scimv2/logic/src/main/java/org/apache/syncope/core/logic/SCIMDataBinder.java
+++ b/ext/scimv2/logic/src/main/java/org/apache/syncope/core/logic/SCIMDataBinder.java
@@ -357,7 +357,8 @@ public class SCIMDataBinder {
             }
             if (output(attributes, excludedAttributes, "x509Certificates")) {
                 conf.getUserConf().getX509Certificates().stream().filter(attrs::containsKey).
-                        forEach(cert -> user.getX509Certificates().add(new Value(attrs.get(cert).getValues().getFirst())));
+                        forEach(cert -> user.getX509Certificates().add(
+                            new Value(attrs.get(cert).getValues().getFirst())));
             }
         }
 
@@ -800,7 +801,8 @@ public class SCIMDataBinder {
         StatusR statusR = null;
 
         if (op.getPath() == null && op.getOp() != PatchOp.remove
-                && !CollectionUtils.isEmpty(op.getValue()) && op.getValue().getFirst() instanceof final SCIMUser after) {
+                && !CollectionUtils.isEmpty(op.getValue())
+                && op.getValue().getFirst() instanceof final SCIMUser after) {
 
             if (after.getActive() != null && before.isSuspended() == after.isActive()) {
                 statusR = new StatusR.Builder(
@@ -848,8 +850,9 @@ public class SCIMDataBinder {
                     }
 
                     statusR = new StatusR.Builder(before.getKey(),
-                            (boolean) op.getValue().getFirst() ? StatusRType.REACTIVATE : StatusRType.SUSPEND).resources(
-                            resources).build();
+                            (boolean) op.getValue().getFirst()
+                                ? StatusRType.REACTIVATE
+                                : StatusRType.SUSPEND).resources(resources).build();
                 }
             }
 
@@ -930,7 +933,8 @@ public class SCIMDataBinder {
             }
 
             case "addresses" -> {
-                if (!CollectionUtils.isEmpty(op.getValue()) && op.getValue().getFirst() instanceof final SCIMUser after) {
+                if (!CollectionUtils.isEmpty(op.getValue())
+                    && op.getValue().getFirst() instanceof final SCIMUser after) {
                     after.getAddresses().stream().filter(address -> address.getType() != null).forEach(
                             address -> conf.getUserConf().getAddresses().stream()
                                     .filter(object -> address.getType().equals(object.getType().name())).findFirst()

--- a/ext/scimv2/scim-rest-api/src/test/java/org/apache/syncope/ext/scimv2/api/data/SCIMPatchOperationDeserializerTest.java
+++ b/ext/scimv2/scim-rest-api/src/test/java/org/apache/syncope/ext/scimv2/api/data/SCIMPatchOperationDeserializerTest.java
@@ -61,14 +61,14 @@ public class SCIMPatchOperationDeserializerTest {
         assertEquals(List.of(Resource.PatchOp.schema()), scimPatchOp.getSchemas());
         assertEquals(1, scimPatchOp.getOperations().size());
 
-        SCIMPatchOperation op = scimPatchOp.getOperations().get(0);
+        SCIMPatchOperation op = scimPatchOp.getOperations().getFirst();
         assertNotNull(op);
         assertEquals(PatchOp.add, op.getOp());
         assertEquals("members", op.getPath().getAttribute());
 
         assertEquals(1, op.getValue().size());
 
-        Member member = (Member) op.getValue().get(0);
+        Member member = (Member) op.getValue().getFirst();
         assertEquals("Babs Jensen", member.getDisplay());
         assertEquals("https://example.com/v2/Users/2819c223...413861904646", member.getRef());
         assertEquals("2819c223-7f76-453a-919d-413861904646", member.getValue());
@@ -90,7 +90,7 @@ public class SCIMPatchOperationDeserializerTest {
         assertEquals(List.of(Resource.PatchOp.schema()), scimPatchOp.getSchemas());
         assertEquals(1, scimPatchOp.getOperations().size());
 
-        SCIMPatchOperation op = scimPatchOp.getOperations().get(0);
+        SCIMPatchOperation op = scimPatchOp.getOperations().getFirst();
         assertNotNull(op);
         assertEquals(PatchOp.remove, op.getOp());
         assertEquals("members", op.getPath().getAttribute());
@@ -131,7 +131,7 @@ public class SCIMPatchOperationDeserializerTest {
         assertEquals(List.of(Resource.PatchOp.schema()), scimPatchOp.getSchemas());
         assertEquals(2, scimPatchOp.getOperations().size());
 
-        SCIMPatchOperation op = scimPatchOp.getOperations().get(0);
+        SCIMPatchOperation op = scimPatchOp.getOperations().getFirst();
         assertNotNull(op);
         assertEquals(PatchOp.remove, op.getOp());
         assertEquals("members", op.getPath().getAttribute());
@@ -144,7 +144,7 @@ public class SCIMPatchOperationDeserializerTest {
 
         assertEquals(2, op.getValue().size());
 
-        Member member = (Member) op.getValue().get(0);
+        Member member = (Member) op.getValue().getFirst();
         assertEquals("Babs Jensen", member.getDisplay());
         assertEquals("https://example.com/v2/Users/2819c223...413861904646", member.getRef());
         assertEquals("2819c223-7f76-453a-919d-413861904646", member.getValue());
@@ -181,19 +181,19 @@ public class SCIMPatchOperationDeserializerTest {
         assertEquals(List.of(Resource.PatchOp.schema()), scimPatchOp.getSchemas());
         assertEquals(1, scimPatchOp.getOperations().size());
 
-        SCIMPatchOperation op = scimPatchOp.getOperations().get(0);
+        SCIMPatchOperation op = scimPatchOp.getOperations().getFirst();
         assertNotNull(op);
         assertEquals(PatchOp.add, op.getOp());
         assertNull(op.getPath());
 
         assertEquals(1, op.getValue().size());
 
-        SCIMUser user = (SCIMUser) op.getValue().get(0);
+        SCIMUser user = (SCIMUser) op.getValue().getFirst();
         assertEquals("Babs", user.getNickName());
 
         assertEquals(1, user.getEmails().size());
 
-        SCIMComplexValue email = user.getEmails().get(0);
+        SCIMComplexValue email = user.getEmails().getFirst();
         assertEquals("home", email.getType());
         assertEquals("babs@jensen.org", email.getValue());
     }
@@ -226,14 +226,14 @@ public class SCIMPatchOperationDeserializerTest {
         assertEquals(List.of(Resource.PatchOp.schema()), scimPatchOp.getSchemas());
         assertEquals(1, scimPatchOp.getOperations().size());
 
-        SCIMPatchOperation op = scimPatchOp.getOperations().get(0);
+        SCIMPatchOperation op = scimPatchOp.getOperations().getFirst();
         assertNotNull(op);
         assertEquals(PatchOp.replace, op.getOp());
         assertEquals("members", op.getPath().getAttribute());
 
         assertEquals(2, op.getValue().size());
 
-        Member member = (Member) op.getValue().get(0);
+        Member member = (Member) op.getValue().getFirst();
         assertEquals("Babs Jensen", member.getDisplay());
         assertEquals("https://example.com/v2/Users/2819c223...413861904646", member.getRef());
         assertEquals("2819c223...413861904646", member.getValue());
@@ -271,7 +271,7 @@ public class SCIMPatchOperationDeserializerTest {
         assertEquals(List.of(Resource.PatchOp.schema()), scimPatchOp.getSchemas());
         assertEquals(1, scimPatchOp.getOperations().size());
 
-        SCIMPatchOperation op = scimPatchOp.getOperations().get(0);
+        SCIMPatchOperation op = scimPatchOp.getOperations().getFirst();
         assertNotNull(op);
         assertEquals(PatchOp.replace, op.getOp());
         assertEquals("addresses", op.getPath().getAttribute());
@@ -279,11 +279,11 @@ public class SCIMPatchOperationDeserializerTest {
 
         assertEquals(1, op.getValue().size());
 
-        SCIMUser user = (SCIMUser) op.getValue().get(0);
+        SCIMUser user = (SCIMUser) op.getValue().getFirst();
 
         assertEquals(1, user.getAddresses().size());
 
-        SCIMUserAddress address = user.getAddresses().get(0);
+        SCIMUserAddress address = user.getAddresses().getFirst();
         assertEquals("work", address.getType());
         assertTrue(address.isPrimary());
     }
@@ -305,7 +305,7 @@ public class SCIMPatchOperationDeserializerTest {
         assertEquals(List.of(Resource.PatchOp.schema()), scimPatchOp.getSchemas());
         assertEquals(1, scimPatchOp.getOperations().size());
 
-        SCIMPatchOperation op = scimPatchOp.getOperations().get(0);
+        SCIMPatchOperation op = scimPatchOp.getOperations().getFirst();
         assertNotNull(op);
         assertEquals(PatchOp.replace, op.getOp());
         assertEquals("addresses", op.getPath().getAttribute());
@@ -314,7 +314,7 @@ public class SCIMPatchOperationDeserializerTest {
 
         assertEquals(1, op.getValue().size());
 
-        String value = (String) op.getValue().get(0);
+        String value = (String) op.getValue().getFirst();
         assertEquals("1010 Broadway Ave", value);
     }
 
@@ -336,14 +336,14 @@ public class SCIMPatchOperationDeserializerTest {
         assertEquals(List.of(Resource.PatchOp.schema()), scimPatchOp.getSchemas());
         assertEquals(1, scimPatchOp.getOperations().size());
 
-        SCIMPatchOperation op = scimPatchOp.getOperations().get(0);
+        SCIMPatchOperation op = scimPatchOp.getOperations().getFirst();
         assertNotNull(op);
         assertEquals(PatchOp.add, op.getOp());
         assertEquals("externalId", op.getPath().getAttribute());
 
         assertEquals(1, op.getValue().size());
 
-        String value = (String) op.getValue().get(0);
+        String value = (String) op.getValue().getFirst();
         assertEquals("da91cb5d-addb-424f-aa41-799fda8658c3", value);
     }
 }

--- a/fit/build-tools/src/main/java/org/apache/syncope/fit/buildtools/cxf/ProvisioningImpl.java
+++ b/fit/build-tools/src/main/java/org/apache/syncope/fit/buildtools/cxf/ProvisioningImpl.java
@@ -123,7 +123,7 @@ public class ProvisioningImpl implements Provisioning {
                     if (attr.getValues() == null || attr.getValues().isEmpty()) {
                         value = null;
                     } else if (attr.getValues().size() == 1) {
-                        value = attr.getValues().get(0).toString();
+                        value = attr.getValues().getFirst().toString();
                     } else {
                         value = attr.getValues().toString();
                     }
@@ -256,7 +256,7 @@ public class ProvisioningImpl implements Provisioning {
                         if (attr.getValues() == null || attr.getValues().isEmpty()) {
                             value = null;
                         } else if (attr.getValues().size() == 1) {
-                            value = attr.getValues().get(0).toString();
+                            value = attr.getValues().getFirst().toString();
                         } else {
                             value = attr.getValues().toString();
                         }
@@ -285,7 +285,7 @@ public class ProvisioningImpl implements Provisioning {
                         values.append(Optional.ofNullable(value).map(s -> '\'' + s + '\'').orElse(null));
 
                         if (attr.isKey() && !attr.getValues().isEmpty()) {
-                            accountid = attr.getValues().get(0).toString();
+                            accountid = attr.getValues().getFirst().toString();
                         }
                     }
                 }

--- a/fit/core-reference/src/main/java/org/apache/syncope/fit/core/reference/CustomJWTSSOProvider.java
+++ b/fit/core-reference/src/main/java/org/apache/syncope/fit/core/reference/CustomJWTSSOProvider.java
@@ -103,7 +103,7 @@ public class CustomJWTSSOProvider implements JWTSSOProvider {
 
         List<User> matching = anySearchDAO.search(SearchCond.of(userIdCond), AnyTypeKind.USER);
         if (matching.size() == 1) {
-            User user = matching.get(0);
+            User user = matching.getFirst();
             Set<SyncopeGrantedAuthority> authorities = authDataAccessor.getAuthorities(user.getUsername(), null);
 
             return Pair.of(user, authorities);

--- a/fit/core-reference/src/main/java/org/apache/syncope/fit/core/reference/DateToDateItemTransformer.java
+++ b/fit/core-reference/src/main/java/org/apache/syncope/fit/core/reference/DateToDateItemTransformer.java
@@ -38,11 +38,11 @@ public class DateToDateItemTransformer implements ItemTransformer {
             final AttrSchemaType schemaType,
             final List<PlainAttrValue> values) {
 
-        if (values == null || values.isEmpty() || values.get(0).getDateValue() == null) {
+        if (values == null || values.isEmpty() || values.getFirst().getDateValue() == null) {
             return ItemTransformer.super.beforePropagation(item, any, schemaType, values);
         }
 
-        values.get(0).setDateValue(values.get(0).getDateValue().plusDays(1));
+        values.getFirst().setDateValue(values.getFirst().getDateValue().plusDays(1));
         return Pair.of(schemaType, values);
     }
 }

--- a/fit/core-reference/src/main/java/org/apache/syncope/fit/core/reference/DateToLongItemTransformer.java
+++ b/fit/core-reference/src/main/java/org/apache/syncope/fit/core/reference/DateToLongItemTransformer.java
@@ -38,16 +38,16 @@ public class DateToLongItemTransformer implements ItemTransformer {
             final AttrSchemaType schemaType,
             final List<PlainAttrValue> values) {
 
-        if (values == null || values.isEmpty() || values.get(0).getDateValue() == null) {
+        if (values == null || values.isEmpty() || values.getFirst().getDateValue() == null) {
             return ItemTransformer.super.beforePropagation(item, any, schemaType, values);
         }
 
-        values.get(0).setLongValue(values.get(0).getDateValue().toInstant().toEpochMilli());
-        values.get(0).setBinaryValue(null);
-        values.get(0).setBooleanValue(null);
-        values.get(0).setDateValue(null);
-        values.get(0).setDoubleValue(null);
-        values.get(0).setStringValue(null);
+        values.getFirst().setLongValue(values.getFirst().getDateValue().toInstant().toEpochMilli());
+        values.getFirst().setBinaryValue(null);
+        values.getFirst().setBooleanValue(null);
+        values.getFirst().setDateValue(null);
+        values.getFirst().setDoubleValue(null);
+        values.getFirst().setStringValue(null);
 
         return Pair.of(AttrSchemaType.Long, values);
     }

--- a/fit/core-reference/src/main/java/org/apache/syncope/fit/core/reference/LinkedAccountSampleInboundCorrelationRule.java
+++ b/fit/core-reference/src/main/java/org/apache/syncope/fit/core/reference/LinkedAccountSampleInboundCorrelationRule.java
@@ -50,7 +50,7 @@ public class LinkedAccountSampleInboundCorrelationRule implements InboundCorrela
         if (email != null && !CollectionUtils.isEmpty(email.getValue())) {
             cond.setSchema("email");
             cond.setType(AttrCond.Type.EQ);
-            cond.setExpression(email.getValue().get(0).toString());
+            cond.setExpression(email.getValue().getFirst().toString());
         } else {
             cond.setSchema("");
         }
@@ -66,7 +66,7 @@ public class LinkedAccountSampleInboundCorrelationRule implements InboundCorrela
         Attribute firstName = syncDelta.getObject().getAttributeByName("firstName");
         if (VIVALDI_KEY.equals(any.getKey())
                 && firstName != null && !CollectionUtils.isEmpty(firstName.getValue())
-                && !"Antonio".equals(firstName.getValue().get(0).toString())) {
+                && !"Antonio".equals(firstName.getValue().getFirst().toString())) {
 
             return new InboundMatch(MatchType.LINKED_ACCOUNT, any);
         }

--- a/fit/core-reference/src/main/java/org/apache/syncope/fit/core/reference/TestLiveSyncDeltaMapper.java
+++ b/fit/core-reference/src/main/java/org/apache/syncope/fit/core/reference/TestLiveSyncDeltaMapper.java
@@ -58,11 +58,11 @@ public class TestLiveSyncDeltaMapper implements LiveSyncDeltaMapper {
 
         long timestamp = Optional.ofNullable(liveSyncDelta.getObject().getAttributeByName("record.timestamp")).
                 filter(attr -> !CollectionUtils.isEmpty(attr.getValue())).
-                map(attr -> (Long) attr.getValue().get(0)).
+                map(attr -> (Long) attr.getValue().getFirst()).
                 orElseThrow(() -> new IllegalArgumentException("No record.timestamp attribute found"));
         String value = Optional.ofNullable(liveSyncDelta.getObject().getAttributeByName("record.value")).
                 filter(attr -> !CollectionUtils.isEmpty(attr.getValue())).
-                map(attr -> attr.getValue().get(0).toString()).
+                map(attr -> attr.getValue().getFirst().toString()).
                 orElseThrow(() -> new IllegalArgumentException("No record.value attribute found"));
         LOG.debug("Received: timestamp {} / value {}", timestamp, value);
 

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/AbstractITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/AbstractITCase.java
@@ -494,10 +494,10 @@ public abstract class AbstractITCase {
         }, Objects::nonNull);
         JsonNode beans = JSON_MAPPER.readTree(beansJSON);
 
-        JsonNode uwfAdapter = beans.findValues("uwfAdapter").get(0);
+        JsonNode uwfAdapter = beans.findValues("uwfAdapter").getFirst();
         IS_FLOWABLE_ENABLED = uwfAdapter.get("resource").asText().contains("Flowable");
 
-        JsonNode anySearchDAO = beans.findValues("anySearchDAO").get(0);
+        JsonNode anySearchDAO = beans.findValues("anySearchDAO").getFirst();
         IS_ELASTICSEARCH_ENABLED = anySearchDAO.get("type").asText().contains("Elasticsearch");
         IS_OPENSEARCH_ENABLED = anySearchDAO.get("type").asText().contains("OpenSearch");
         IS_EXT_SEARCH_ENABLED = IS_ELASTICSEARCH_ENABLED || IS_OPENSEARCH_ENABLED;
@@ -794,13 +794,13 @@ public abstract class AbstractITCase {
 
         Properties env = new Properties();
         env.put(Context.INITIAL_CONTEXT_FACTORY, "com.sun.jndi.ldap.LdapCtxFactory");
-        env.put(Context.PROVIDER_URL, "ldap://" + ldapConn.getConf("host").get().getValues().get(0)
-                + ':' + ldapConn.getConf("port").get().getValues().get(0) + '/');
+        env.put(Context.PROVIDER_URL, "ldap://" + ldapConn.getConf("host").get().getValues().getFirst()
+                + ':' + ldapConn.getConf("port").get().getValues().getFirst() + '/');
         env.put(Context.SECURITY_AUTHENTICATION, "simple");
         env.put(Context.SECURITY_PRINCIPAL,
-                bindDn == null ? ldapConn.getConf("principal").get().getValues().get(0) : bindDn);
+                bindDn == null ? ldapConn.getConf("principal").get().getValues().getFirst() : bindDn);
         env.put(Context.SECURITY_CREDENTIALS,
-                bindPwd == null ? ldapConn.getConf("credentials").get().getValues().get(0) : bindPwd);
+                bindPwd == null ? ldapConn.getConf("credentials").get().getValues().getFirst() : bindPwd);
 
         return new InitialDirContext(env);
     }

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/AbstractUIITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/AbstractUIITCase.java
@@ -107,10 +107,10 @@ public abstract class AbstractUIITCase {
         }, Objects::nonNull);
         JsonNode beans = JSON_MAPPER.readTree(beansJSON);
 
-        JsonNode uwfAdapter = beans.findValues("uwfAdapter").get(0);
+        JsonNode uwfAdapter = beans.findValues("uwfAdapter").getFirst();
         IS_FLOWABLE_ENABLED = uwfAdapter.get("resource").asText().contains("Flowable");
 
-        JsonNode anySearchDAO = beans.findValues("anySearchDAO").get(0);
+        JsonNode anySearchDAO = beans.findValues("anySearchDAO").getFirst();
         IS_EXT_SEARCH_ENABLED = anySearchDAO.get("type").asText().contains("Elasticsearch")
                 || anySearchDAO.get("type").asText().contains("OpenSearch");
     }

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/console/LinkedAccountsITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/console/LinkedAccountsITCase.java
@@ -95,7 +95,7 @@ public class LinkedAccountsITCase extends AbstractConsoleITCase {
         USER = response.readEntity(new GenericType<ProvisioningResult<UserTO>>() {
         }).getEntity();
         assertNotNull(USER.getKey());
-        assertEquals(account.getConnObjectKeyValue(), USER.getLinkedAccounts().get(0).getConnObjectKeyValue());
+        assertEquals(account.getConnObjectKeyValue(), USER.getLinkedAccounts().getFirst().getConnObjectKeyValue());
     }
 
     @AfterEach

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AbstractTaskITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AbstractTaskITCase.java
@@ -161,7 +161,7 @@ public abstract class AbstractTaskITCase extends AbstractITCase {
                 PagedResult<NotificationTaskTO> tasks = TASK_SERVICE.search(
                         new TaskQuery.Builder(TaskType.NOTIFICATION).notification(notification).build());
                 if (!tasks.getResult().isEmpty()) {
-                    notificationTask.set(tasks.getResult().get(0));
+                    notificationTask.set(tasks.getResult().getFirst());
                 }
             } catch (Exception e) {
                 // ignore

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AnyObjectITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AnyObjectITCase.java
@@ -139,7 +139,7 @@ public class AnyObjectITCase extends AbstractITCase {
 
         anyObjectTO = updateAnyObject(anyObjectUR).getEntity();
 
-        assertEquals(newLocation, anyObjectTO.getPlainAttr("location").get().getValues().get(0));
+        assertEquals(newLocation, anyObjectTO.getPlainAttr("location").get().getValues().getFirst());
     }
 
     @Test
@@ -200,7 +200,7 @@ public class AnyObjectITCase extends AbstractITCase {
         AnyObjectTO right = createAnyObject(anyObjectCR).getEntity();
 
         assertEquals(1, right.getRelationships().size());
-        assertEquals(left.getKey(), right.getRelationships().get(0).getOtherEndKey());
+        assertEquals(left.getKey(), right.getRelationships().getFirst().getOtherEndKey());
 
         AnyObjectUR anyObjectUR = new AnyObjectUR.Builder(left.getKey()).
                 relationship(new RelationshipUR.Builder(new RelationshipTO.Builder("inclusion").
@@ -290,7 +290,7 @@ public class AnyObjectITCase extends AbstractITCase {
 
         // Verify relationships for printer1
         assertEquals(1, printer1.getRelationships().size());
-        RelationshipTO rel1 = printer1.getRelationships().get(0);
+        RelationshipTO rel1 = printer1.getRelationships().getFirst();
         assertEquals(RelationshipTO.End.LEFT, rel1.getEnd());
         assertEquals(printer2.getKey(), rel1.getOtherEndKey());
         assertEquals(printer2.getType(), rel1.getOtherEndType());
@@ -311,7 +311,7 @@ public class AnyObjectITCase extends AbstractITCase {
 
         // Verify relationships for printer3
         assertEquals(1, printer3.getRelationships().size());
-        RelationshipTO rel3 = printer3.getRelationships().get(0);
+        RelationshipTO rel3 = printer3.getRelationships().getFirst();
         assertEquals(RelationshipTO.End.RIGHT, rel3.getEnd());
         assertEquals(printer2.getKey(), rel3.getOtherEndKey());
         assertEquals(printer2.getType(), rel3.getOtherEndType());

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AuditITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AuditITCase.java
@@ -102,7 +102,7 @@ public class AuditITCase extends AbstractITCase {
             fail("Timeout when executing query for key " + query.getEntityKey());
             return null;
         }
-        return results.get(0);
+        return results.getFirst();
     }
 
     @Test
@@ -244,7 +244,7 @@ public class AuditITCase extends AbstractITCase {
         ConnConfProperty originalConfProp = SerializationUtils.clone(
                 ldapConn.getConf("maintainPosixGroupMembership").get());
         assertEquals(1, originalConfProp.getValues().size());
-        assertEquals("false", originalConfProp.getValues().get(0));
+        assertEquals("false", originalConfProp.getValues().getFirst());
 
         ldapConn.setDisplayName(originalDisplayName + " modified");
         ldapConn.getCapabilities().clear();
@@ -259,7 +259,7 @@ public class AuditITCase extends AbstractITCase {
         entries = query(query, MAX_WAIT_SECONDS);
         assertEquals(pre + 1, entries.size());
 
-        ConnInstanceTO restore = JSON_MAPPER.readValue(entries.get(0).getBefore(), ConnInstanceTO.class);
+        ConnInstanceTO restore = JSON_MAPPER.readValue(entries.getFirst().getBefore(), ConnInstanceTO.class);
         CONNECTOR_SERVICE.update(restore);
 
         ldapConn = CONNECTOR_SERVICE.read(connectorKey, null);

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AuthenticationITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AuthenticationITCase.java
@@ -255,7 +255,7 @@ public class AuthenticationITCase extends AbstractITCase {
             UserTO user = response.readEntity(new GenericType<ProvisioningResult<UserTO>>() {
             }).getEntity();
             assertEquals("/even/two", user.getRealm());
-            assertEquals("surname", user.getPlainAttr("surname").get().getValues().get(0));
+            assertEquals("surname", user.getPlainAttr("surname").get().getValues().getFirst());
 
             // 5. as delegated, update user attempting to move under realm /odd -> fail
             UserUR userUR = new UserUR();
@@ -279,7 +279,7 @@ public class AuthenticationITCase extends AbstractITCase {
             user = response.readEntity(new GenericType<ProvisioningResult<UserTO>>() {
             }).getEntity();
             assertEquals("/even/two", user.getRealm());
-            assertEquals("surname2", user.getPlainAttr("surname").get().getValues().get(0));
+            assertEquals("surname2", user.getPlainAttr("surname").get().getValues().getFirst());
 
             // 7. as delegated, delete user
             delegatedUserService.delete(user.getKey());
@@ -589,7 +589,7 @@ public class AuthenticationITCase extends AbstractITCase {
 
         // 3. approve user
         UserRequestForm form = USER_REQUEST_SERVICE.listForms(
-                new UserRequestQuery.Builder().user(userTO.getKey()).build()).getResult().get(0);
+                new UserRequestQuery.Builder().user(userTO.getKey()).build()).getResult().getFirst();
         form = USER_REQUEST_SERVICE.claimForm(form.getTaskId());
         form.getProperty("approveCreate").get().setValue(Boolean.TRUE.toString());
         userTO = USER_REQUEST_SERVICE.submitForm(form).readEntity(new GenericType<ProvisioningResult<UserTO>>() {

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/BatchITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/BatchITCase.java
@@ -140,12 +140,12 @@ public class BatchITCase extends AbstractITCase {
     private static void check(final List<BatchResponseItem> resItems) throws IOException {
         assertEquals(6, resItems.size());
 
-        assertEquals(Response.Status.CREATED.getStatusCode(), resItems.get(0).getStatus());
-        assertNotNull(resItems.get(0).getHeaders().get(HttpHeaders.LOCATION));
-        assertNotNull(resItems.get(0).getHeaders().get(HttpHeaders.ETAG));
-        assertNotNull(resItems.get(0).getHeaders().get(RESTHeaders.DOMAIN));
-        assertNotNull(resItems.get(0).getHeaders().get(RESTHeaders.RESOURCE_KEY));
-        assertEquals(RESTHeaders.APPLICATION_YAML, resItems.get(0).getHeaders().get(HttpHeaders.CONTENT_TYPE).get(0));
+        assertEquals(Response.Status.CREATED.getStatusCode(), resItems.getFirst().getStatus());
+        assertNotNull(resItems.getFirst().getHeaders().get(HttpHeaders.LOCATION));
+        assertNotNull(resItems.getFirst().getHeaders().get(HttpHeaders.ETAG));
+        assertNotNull(resItems.getFirst().getHeaders().get(RESTHeaders.DOMAIN));
+        assertNotNull(resItems.getFirst().getHeaders().get(RESTHeaders.RESOURCE_KEY));
+        assertEquals(RESTHeaders.APPLICATION_YAML, resItems.getFirst().getHeaders().get(HttpHeaders.CONTENT_TYPE).getFirst());
         ProvisioningResult<UserTO> user = YAML_MAPPER.readValue(
                 resItems.get(0).getContent(), new TypeReference<>() {
         });
@@ -156,7 +156,7 @@ public class BatchITCase extends AbstractITCase {
         assertNotNull(resItems.get(1).getHeaders().get(HttpHeaders.ETAG));
         assertNotNull(resItems.get(1).getHeaders().get(RESTHeaders.DOMAIN));
         assertNotNull(resItems.get(1).getHeaders().get(RESTHeaders.RESOURCE_KEY));
-        assertEquals(MediaType.APPLICATION_XML, resItems.get(1).getHeaders().get(HttpHeaders.CONTENT_TYPE).get(0));
+        assertEquals(MediaType.APPLICATION_XML, resItems.get(1).getHeaders().get(HttpHeaders.CONTENT_TYPE).getFirst());
 
         ProvisioningResult<GroupTO> group = XML_MAPPER.readValue(
                 resItems.get(1).getContent(), new TypeReference<>() {
@@ -167,7 +167,7 @@ public class BatchITCase extends AbstractITCase {
         assertNotNull(resItems.get(2).getHeaders().get(RESTHeaders.DOMAIN));
         assertEquals(
                 Preference.RETURN_NO_CONTENT.toString(),
-                resItems.get(2).getHeaders().get(RESTHeaders.PREFERENCE_APPLIED).get(0));
+                resItems.get(2).getHeaders().get(RESTHeaders.PREFERENCE_APPLIED).getFirst());
 
         assertEquals(Response.Status.NOT_FOUND.getStatusCode(), resItems.get(3).getStatus());
 
@@ -175,11 +175,11 @@ public class BatchITCase extends AbstractITCase {
         assertNotNull(resItems.get(4).getHeaders().get(RESTHeaders.DOMAIN));
         assertNotNull(resItems.get(4).getHeaders().get(RESTHeaders.ERROR_CODE));
         assertNotNull(resItems.get(4).getHeaders().get(RESTHeaders.ERROR_INFO));
-        assertEquals(MediaType.APPLICATION_JSON, resItems.get(4).getHeaders().get(HttpHeaders.CONTENT_TYPE).get(0));
+        assertEquals(MediaType.APPLICATION_JSON, resItems.get(4).getHeaders().get(HttpHeaders.CONTENT_TYPE).getFirst());
 
         assertEquals(Response.Status.OK.getStatusCode(), resItems.get(5).getStatus());
         assertNotNull(resItems.get(5).getHeaders().get(RESTHeaders.DOMAIN));
-        assertEquals(MediaType.APPLICATION_JSON, resItems.get(5).getHeaders().get(HttpHeaders.CONTENT_TYPE).get(0));
+        assertEquals(MediaType.APPLICATION_JSON, resItems.get(5).getHeaders().get(HttpHeaders.CONTENT_TYPE).getFirst());
         group = JSON_MAPPER.readValue(
                 resItems.get(5).getContent(), new TypeReference<>() {
         });

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/BatchITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/BatchITCase.java
@@ -145,7 +145,8 @@ public class BatchITCase extends AbstractITCase {
         assertNotNull(resItems.getFirst().getHeaders().get(HttpHeaders.ETAG));
         assertNotNull(resItems.getFirst().getHeaders().get(RESTHeaders.DOMAIN));
         assertNotNull(resItems.getFirst().getHeaders().get(RESTHeaders.RESOURCE_KEY));
-        assertEquals(RESTHeaders.APPLICATION_YAML, resItems.getFirst().getHeaders().get(HttpHeaders.CONTENT_TYPE).getFirst());
+        assertEquals(RESTHeaders.APPLICATION_YAML, resItems.getFirst().
+            getHeaders().get(HttpHeaders.CONTENT_TYPE).getFirst());
         ProvisioningResult<UserTO> user = YAML_MAPPER.readValue(
                 resItems.get(0).getContent(), new TypeReference<>() {
         });

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/CommandITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/CommandITCase.java
@@ -73,7 +73,7 @@ public class CommandITCase extends AbstractITCase {
         assertEquals(1, commands.getTotalCount());
         assertEquals(1, commands.getResult().size());
 
-        CommandTO command = commands.getResult().get(0);
+        CommandTO command = commands.getResult().getFirst();
         assertNotNull(command);
         assertEquals(TestCommand.class.getSimpleName(), command.getKey());
         assertTrue(command.getArgs() instanceof TestCommandArgs);
@@ -82,7 +82,7 @@ public class CommandITCase extends AbstractITCase {
     @Test
     public void argsValidationFailure() {
         CommandTO command = COMMAND_SERVICE.search(new CommandQuery.Builder().
-                keyword(TestCommand.class.getSimpleName()).page(1).size(1).build()).getResult().get(0);
+                keyword(TestCommand.class.getSimpleName()).page(1).size(1).build()).getResult().getFirst();
 
         try {
             COMMAND_SERVICE.run(command);
@@ -95,7 +95,7 @@ public class CommandITCase extends AbstractITCase {
     @Test
     public void runCommand() {
         CommandTO command = COMMAND_SERVICE.search(
-                new CommandQuery.Builder().page(1).size(1).build()).getResult().get(0);
+                new CommandQuery.Builder().page(1).size(1).build()).getResult().getFirst();
         TestCommandArgs args = ((TestCommandArgs) command.getArgs());
         args.setParentRealm("/even/two");
         args.setRealmName("realm123");

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/ConnectorITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/ConnectorITCase.java
@@ -469,8 +469,8 @@ public class ConnectorITCase extends AbstractITCase {
         List<ConnIdObjectClass> objectClassInfo = CONNECTOR_SERVICE.buildObjectClassInfo(db, true);
         assertNotNull(objectClassInfo);
         assertEquals(1, objectClassInfo.size());
-        assertEquals(ObjectClass.ACCOUNT_NAME, objectClassInfo.get(0).getType());
-        assertTrue(objectClassInfo.get(0).getAttributes().stream().anyMatch(schema -> "ID".equals(schema.getKey())));
+        assertEquals(ObjectClass.ACCOUNT_NAME, objectClassInfo.getFirst().getType());
+        assertTrue(objectClassInfo.getFirst().getAttributes().stream().anyMatch(schema -> "ID".equals(schema.getKey())));
 
         ConnInstanceTO ldap = CONNECTOR_SERVICE.read(
                 "74141a3b-0762-4720-a4aa-fc3e374ef3ef", Locale.ENGLISH.getLanguage());
@@ -510,14 +510,14 @@ public class ConnectorITCase extends AbstractITCase {
         try {
             ConnInstanceTO scriptedsql = pcs.read("a6d017fd-a705-4507-bb7c-6ab6a6745997", null);
             ConnConfProperty reloadScriptOnExecution = scriptedsql.getConf("reloadScriptOnExecution").get();
-            assertEquals("true", reloadScriptOnExecution.getValues().get(0).toString());
+            assertEquals("true", reloadScriptOnExecution.getValues().getFirst().toString());
 
             reloadScriptOnExecution.getValues().set(0, "false");
             pcs.update(scriptedsql);
 
             scriptedsql = pcs.read(scriptedsql.getKey(), null);
             reloadScriptOnExecution = scriptedsql.getConf("reloadScriptOnExecution").get();
-            assertEquals("false", reloadScriptOnExecution.getValues().get(0).toString());
+            assertEquals("false", reloadScriptOnExecution.getValues().getFirst().toString());
         } finally {
             ConnInstanceTO scriptedsql = CONNECTOR_SERVICE.read("a6d017fd-a705-4507-bb7c-6ab6a6745997", null);
             ConnConfProperty reloadScriptOnExecution = scriptedsql.getConf("reloadScriptOnExecution").get();
@@ -543,7 +543,7 @@ public class ConnectorITCase extends AbstractITCase {
         assertEquals(4, resources.size());
 
         // Retrieve a resource TO template.
-        ResourceTO resourceTO = resources.get(0);
+        ResourceTO resourceTO = resources.getFirst();
 
         // Make it new.
         resourceTO.setKey("newAbout103" + getUUIDString());

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/ConnectorITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/ConnectorITCase.java
@@ -470,7 +470,8 @@ public class ConnectorITCase extends AbstractITCase {
         assertNotNull(objectClassInfo);
         assertEquals(1, objectClassInfo.size());
         assertEquals(ObjectClass.ACCOUNT_NAME, objectClassInfo.getFirst().getType());
-        assertTrue(objectClassInfo.getFirst().getAttributes().stream().anyMatch(schema -> "ID".equals(schema.getKey())));
+        assertTrue(objectClassInfo.getFirst().getAttributes().stream().
+            anyMatch(schema -> "ID".equals(schema.getKey())));
 
         ConnInstanceTO ldap = CONNECTOR_SERVICE.read(
                 "74141a3b-0762-4720-a4aa-fc3e374ef3ef", Locale.ENGLISH.getLanguage());

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/DynRealmITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/DynRealmITCase.java
@@ -110,7 +110,7 @@ public class DynRealmITCase extends AbstractITCase {
             assertNotNull(matching);
             assertNotEquals(0, matching.getSize());
 
-            UserTO user = matching.getResult().get(0);
+            UserTO user = matching.getResult().getFirst();
 
             assertTrue(user.getDynRealms().contains(dynRealm.getKey()));
         } finally {
@@ -232,7 +232,7 @@ public class DynRealmITCase extends AbstractITCase {
             group = delegatedGroupService.update(groupUR).readEntity(new GenericType<ProvisioningResult<GroupTO>>() {
             }).getEntity();
             assertNotNull(group);
-            assertEquals("modified", group.getPlainAttr("icon").get().getValues().get(0));
+            assertEquals("modified", group.getPlainAttr("icon").get().getValues().getFirst());
         } finally {
             if (role != null) {
                 ROLE_SERVICE.delete(role.getKey());

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/ExceptionMapperITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/ExceptionMapperITCase.java
@@ -191,9 +191,9 @@ public class ExceptionMapperITCase extends AbstractITCase {
         }
 
         ResourceTO ldap = RESOURCE_SERVICE.read(RESOURCE_NAME_LDAP);
-        assertTrue(ldap.getProvisions().get(0).getMapping().getConnObjectKeyItem().isPresent());
+        assertTrue(ldap.getProvisions().getFirst().getMapping().getConnObjectKeyItem().isPresent());
         try {
-            Item mapping = ldap.getProvisions().get(0).getMapping().getItems().get(0);
+            Item mapping = ldap.getProvisions().getFirst().getMapping().getItems().getFirst();
             mapping.setIntAttrName("memberships.cn");
             RESOURCE_SERVICE.update(ldap);
             fail("This should not happen");
@@ -201,6 +201,6 @@ public class ExceptionMapperITCase extends AbstractITCase {
             assertEquals(ClientExceptionType.InvalidMapping, e.getType());
         }
         ldap = RESOURCE_SERVICE.read(RESOURCE_NAME_LDAP);
-        assertTrue(ldap.getProvisions().get(0).getMapping().getConnObjectKeyItem().isPresent());
+        assertTrue(ldap.getProvisions().getFirst().getMapping().getConnObjectKeyItem().isPresent());
     }
 }

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/GroupITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/GroupITCase.java
@@ -128,7 +128,7 @@ public class GroupITCase extends AbstractITCase {
 
         assertNotNull(groupTO.getVirAttr("rvirtualdata").orElseThrow().getValues());
         assertFalse(groupTO.getVirAttr("rvirtualdata").orElseThrow().getValues().isEmpty());
-        assertEquals("rvirtualvalue", groupTO.getVirAttr("rvirtualdata").orElseThrow().getValues().get(0));
+        assertEquals("rvirtualvalue", groupTO.getVirAttr("rvirtualdata").orElseThrow().getValues().getFirst());
 
         assertTrue(groupTO.getResources().contains(RESOURCE_NAME_LDAP));
 
@@ -572,7 +572,7 @@ public class GroupITCase extends AbstractITCase {
 
         // 3. add the new mandatory schema to the default group type
         AnyTypeTO type = ANY_TYPE_SERVICE.read(AnyTypeKind.GROUP.name());
-        String typeClassName = type.getClasses().get(0);
+        String typeClassName = type.getClasses().getFirst();
         AnyTypeClassTO typeClass = ANY_TYPE_CLASS_SERVICE.read(typeClassName);
         typeClass.getPlainSchemas().add(badge.getKey());
         ANY_TYPE_CLASS_SERVICE.update(typeClass);
@@ -627,7 +627,7 @@ public class GroupITCase extends AbstractITCase {
         groupCR.getPlainAttrs().add(attr("dd", "A"));
 
         GroupTO group = createGroup(groupCR).getEntity();
-        assertEquals("A", group.getPlainAttr("dd").orElseThrow().getValues().get(0));
+        assertEquals("A", group.getPlainAttr("dd").orElseThrow().getValues().getFirst());
     }
 
     @Test
@@ -642,7 +642,7 @@ public class GroupITCase extends AbstractITCase {
 
         // 2. add the new schema to the default group type
         AnyTypeTO type = ANY_TYPE_SERVICE.read(AnyTypeKind.GROUP.name());
-        String typeClassName = type.getClasses().get(0);
+        String typeClassName = type.getClasses().getFirst();
         AnyTypeClassTO typeClass = ANY_TYPE_CLASS_SERVICE.read(typeClassName);
         typeClass.getPlainSchemas().add(encrypted.getKey());
         ANY_TYPE_CLASS_SERVICE.update(typeClass);
@@ -656,7 +656,7 @@ public class GroupITCase extends AbstractITCase {
 
         assertEquals(encryptorManager.getInstance(System.getProperty("obscureSecretKey")).
                 encode("testvalue", encrypted.getCipherAlgorithm()),
-                group.getPlainAttr(encrypted.getKey()).orElseThrow().getValues().get(0));
+                group.getPlainAttr(encrypted.getKey()).orElseThrow().getValues().getFirst());
 
         // 4. update schema to return cleartext values
         encrypted.setAnyTypeClass(typeClassName);
@@ -671,14 +671,14 @@ public class GroupITCase extends AbstractITCase {
                 new Attr.Builder(encrypted.getKey()).value("testvalue").build()).build());
         group = updateGroup(groupUR).getEntity();
 
-        assertEquals("testvalue", group.getPlainAttr(encrypted.getKey()).orElseThrow().getValues().get(0));
+        assertEquals("testvalue", group.getPlainAttr(encrypted.getKey()).orElseThrow().getValues().getFirst());
 
         // 6. update schema again to disallow cleartext values
         encrypted.setConversionPattern(null);
         SCHEMA_SERVICE.update(SchemaType.PLAIN, encrypted);
 
         group = GROUP_SERVICE.read(group.getKey());
-        assertNotEquals("testvalue", group.getPlainAttr(encrypted.getKey()).orElseThrow().getValues().get(0));
+        assertNotEquals("testvalue", group.getPlainAttr(encrypted.getKey()).orElseThrow().getValues().getFirst());
     }
 
     @Test
@@ -859,8 +859,8 @@ public class GroupITCase extends AbstractITCase {
             ProvisioningResult<GroupTO> result = createGroup(groupCR);
             assertNotNull(result);
             assertEquals(1, result.getPropagationStatuses().size());
-            assertEquals(RESOURCE_NAME_LDAP, result.getPropagationStatuses().get(0).getResource());
-            assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
+            assertEquals(RESOURCE_NAME_LDAP, result.getPropagationStatuses().getFirst().getResource());
+            assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
             GroupTO group = result.getEntity();
 
             // 2. update succeeds
@@ -869,8 +869,8 @@ public class GroupITCase extends AbstractITCase {
                     build());
             assertNotNull(result);
             assertEquals(1, result.getPropagationStatuses().size());
-            assertEquals(RESOURCE_NAME_LDAP, result.getPropagationStatuses().get(0).getResource());
-            assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
+            assertEquals(RESOURCE_NAME_LDAP, result.getPropagationStatuses().getFirst().getResource());
+            assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
             group = result.getEntity();
 
             // 3. enable capability override with only search allowed
@@ -887,8 +887,8 @@ public class GroupITCase extends AbstractITCase {
                     build());
             assertNotNull(result);
             assertEquals(1, result.getPropagationStatuses().size());
-            assertEquals(RESOURCE_NAME_LDAP, result.getPropagationStatuses().get(0).getResource());
-            assertEquals(ExecStatus.NOT_ATTEMPTED, result.getPropagationStatuses().get(0).getStatus());
+            assertEquals(RESOURCE_NAME_LDAP, result.getPropagationStatuses().getFirst().getResource());
+            assertEquals(ExecStatus.NOT_ATTEMPTED, result.getPropagationStatuses().getFirst().getStatus());
         } finally {
             ldap.setCapabilitiesOverride(Optional.empty());
             RESOURCE_SERVICE.update(ldap);
@@ -945,7 +945,7 @@ public class GroupITCase extends AbstractITCase {
         groupUR.getResources().add(new StringPatchItem.Builder().value(RESOURCE_NAME_LDAP).build());
         ProvisioningResult<GroupTO> groupUpdateResult = updateGroup(groupUR);
 
-        PropagationStatus propStatus = groupUpdateResult.getPropagationStatuses().get(0);
+        PropagationStatus propStatus = groupUpdateResult.getPropagationStatuses().getFirst();
         assertEquals(RESOURCE_NAME_LDAP, propStatus.getResource());
         assertEquals(ExecStatus.SUCCESS, propStatus.getStatus());
 
@@ -971,7 +971,7 @@ public class GroupITCase extends AbstractITCase {
                     return false;
                 }
             });
-            assertEquals(TaskJob.Status.SUCCESS.name(), execs.get().get(0).getStatus());
+            assertEquals(TaskJob.Status.SUCCESS.name(), execs.get().getFirst().getStatus());
 
             // 6. verify that the user above is now fond on LDAP
             ConnObject userOnLdap =
@@ -999,7 +999,7 @@ public class GroupITCase extends AbstractITCase {
         UserTO userTO = createUser(userCR).getEntity();
 
         assertFalse(userTO.getMemberships().isEmpty());
-        assertEquals(groupTO.getKey(), userTO.getMemberships().get(0).getGroupKey());
+        assertEquals(groupTO.getKey(), userTO.getMemberships().getFirst().getGroupKey());
     }
 
     @Test
@@ -1145,7 +1145,7 @@ public class GroupITCase extends AbstractITCase {
 
         GroupTO groupTO = createGroup(groupCR).getEntity();
         assertNotNull(groupTO);
-        assertEquals("11.23", groupTO.getPlainAttr(doubleSchemaName).orElseThrow().getValues().get(0));
+        assertEquals("11.23", groupTO.getPlainAttr(doubleSchemaName).orElseThrow().getValues().getFirst());
 
         // 3. update schema, set conversion pattern
         schema = SCHEMA_SERVICE.read(SchemaType.PLAIN, schema.getKey());
@@ -1155,7 +1155,7 @@ public class GroupITCase extends AbstractITCase {
         // 4. re-read group, verify that pattern was applied
         groupTO = GROUP_SERVICE.read(groupTO.getKey());
         assertNotNull(groupTO);
-        assertEquals("11.230", groupTO.getPlainAttr(doubleSchemaName).orElseThrow().getValues().get(0));
+        assertEquals("11.230", groupTO.getPlainAttr(doubleSchemaName).orElseThrow().getValues().getFirst());
 
         // 5. modify group with new double value
         GroupUR groupUR = new GroupUR();
@@ -1164,7 +1164,7 @@ public class GroupITCase extends AbstractITCase {
 
         groupTO = updateGroup(groupUR).getEntity();
         assertNotNull(groupTO);
-        assertEquals("11.257", groupTO.getPlainAttr(doubleSchemaName).orElseThrow().getValues().get(0));
+        assertEquals("11.257", groupTO.getPlainAttr(doubleSchemaName).orElseThrow().getValues().getFirst());
 
         // 6. update schema, unset conversion pattern
         schema.setConversionPattern(null);
@@ -1177,7 +1177,7 @@ public class GroupITCase extends AbstractITCase {
 
         groupTO = updateGroup(groupUR).getEntity();
         assertNotNull(groupTO);
-        assertEquals("11.23", groupTO.getPlainAttr(doubleSchemaName).orElseThrow().getValues().get(0));
+        assertEquals("11.23", groupTO.getPlainAttr(doubleSchemaName).orElseThrow().getValues().getFirst());
     }
 
     @Test
@@ -1196,7 +1196,7 @@ public class GroupITCase extends AbstractITCase {
             ConnObject connObjectTO =
                     RESOURCE_SERVICE.readConnObject(RESOURCE_NAME_LDAP, AnyTypeKind.GROUP.name(), groupTO.getKey());
             assertNotNull(connObjectTO);
-            assertEquals("issueSYNCOPE1467", connObjectTO.getAttr("cn").orElseThrow().getValues().get(0));
+            assertEquals("issueSYNCOPE1467", connObjectTO.getAttr("cn").orElseThrow().getValues().getFirst());
 
             GroupUR groupUR = new GroupUR();
             groupUR.setKey(groupTO.getKey());
@@ -1204,13 +1204,13 @@ public class GroupITCase extends AbstractITCase {
 
             ProvisioningResult<GroupTO> result = updateGroup(groupUR);
             assertEquals(1, result.getPropagationStatuses().size());
-            assertEquals(RESOURCE_NAME_LDAP, result.getPropagationStatuses().get(0).getResource());
-            assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
+            assertEquals(RESOURCE_NAME_LDAP, result.getPropagationStatuses().getFirst().getResource());
+            assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
 
             connObjectTO = RESOURCE_SERVICE.readConnObject(
                     RESOURCE_NAME_LDAP, AnyTypeKind.GROUP.name(), groupTO.getKey());
             assertNotNull(connObjectTO);
-            assertEquals("fixedSYNCOPE1467", connObjectTO.getAttr("cn").orElseThrow().getValues().get(0));
+            assertEquals("fixedSYNCOPE1467", connObjectTO.getAttr("cn").orElseThrow().getValues().getFirst());
         } finally {
             Optional.ofNullable(groupTO).ifPresent(g -> GROUP_SERVICE.delete(g.getKey()));
         }

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/KeymasterITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/KeymasterITCase.java
@@ -179,7 +179,7 @@ public class KeymasterITCase extends AbstractITCase {
         list = findNetworkServices(NetworkService.Type.SRA, List::isEmpty, 30);
         assertFalse(list.isEmpty());
         assertEquals(1, list.size());
-        assertEquals(sra1, list.get(0));
+        assertEquals(sra1, list.getFirst());
 
         assertEquals(sra1, serviceOps.get(NetworkService.Type.SRA));
 
@@ -192,7 +192,7 @@ public class KeymasterITCase extends AbstractITCase {
         list = findNetworkServices(NetworkService.Type.SRA, List::isEmpty, 30);
         assertFalse(list.isEmpty());
         assertEquals(1, list.size());
-        assertEquals(sra1, list.get(0));
+        assertEquals(sra1, list.getFirst());
 
         assertEquals(sra1, serviceOps.get(NetworkService.Type.SRA));
 
@@ -213,9 +213,9 @@ public class KeymasterITCase extends AbstractITCase {
         List<Domain> initial = domainOps.list();
         assertNotNull(initial);
         assumeTrue(initial.stream().anyMatch(domain -> "Two".equals(domain.getKey())));
-        assumeTrue(initial.get(0) instanceof JPADomain);
+        assumeTrue(initial.getFirst() instanceof JPADomain);
 
-        JPADomain two = (JPADomain) initial.get(0);
+        JPADomain two = (JPADomain) initial.getFirst();
         String newdb = "syncopetest";
 
         // 1. create new domain
@@ -310,12 +310,12 @@ public class KeymasterITCase extends AbstractITCase {
         assertNotNull(initial);
         assumeTrue(initial.stream().anyMatch(domain -> "Two".equals(domain.getKey())));
 
-        if (initial.get(0) instanceof JPADomain) {
+        if (initial.getFirst() instanceof JPADomain) {
             assertThrows(KeymasterException.class, () -> domainOps.create(new JPADomain.Builder("Two").build()));
-        } else if (initial.get(0) instanceof Neo4jDomain) {
+        } else if (initial.getFirst() instanceof Neo4jDomain) {
             assertThrows(KeymasterException.class, () -> domainOps.create(new Neo4jDomain.Builder("Two").build()));
         } else {
-            throw new IllegalStateException("Unsupported Domain class: " + initial.get(0).getClass().getName());
+            throw new IllegalStateException("Unsupported Domain class: " + initial.getFirst().getClass().getName());
         }
     }
 

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/LinkedAccountITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/LinkedAccountITCase.java
@@ -98,9 +98,9 @@ public class LinkedAccountITCase extends AbstractITCase {
                 new TaskQuery.Builder(TaskType.PROPAGATION).resource(RESOURCE_NAME_LDAP).
                         anyTypeKind(AnyTypeKind.USER).entityKey(user.getKey()).build());
         assertEquals(1, tasks.getTotalCount());
-        assertEquals(connObjectKeyValue, tasks.getResult().get(0).getConnObjectKey());
-        assertEquals(ResourceOperation.CREATE, tasks.getResult().get(0).getOperation());
-        assertEquals(ExecStatus.SUCCESS.name(), tasks.getResult().get(0).getLatestExecStatus());
+        assertEquals(connObjectKeyValue, tasks.getResult().getFirst().getConnObjectKey());
+        assertEquals(ResourceOperation.CREATE, tasks.getResult().getFirst().getOperation());
+        assertEquals(ExecStatus.SUCCESS.name(), tasks.getResult().getFirst().getLatestExecStatus());
 
         ConnObject ldapObj = RESOURCE_SERVICE.readConnObject(
                 RESOURCE_NAME_LDAP, AnyTypeKind.USER.name(), connObjectKeyValue);
@@ -108,7 +108,7 @@ public class LinkedAccountITCase extends AbstractITCase {
         assertEquals(
                 user.getPlainAttr("email").orElseThrow().getValues(),
                 ldapObj.getAttr("mail").orElseThrow().getValues());
-        assertEquals("LINKED_SURNAME", ldapObj.getAttr("sn").orElseThrow().getValues().get(0));
+        assertEquals("LINKED_SURNAME", ldapObj.getAttr("sn").orElseThrow().getValues().getFirst());
 
         // 3. update linked account
         UserUR userUR = new UserUR();
@@ -121,24 +121,24 @@ public class LinkedAccountITCase extends AbstractITCase {
 
         user = updateUser(userUR).getEntity();
         assertEquals(1, user.getLinkedAccounts().size());
-        assertEquals("UPDATED_SURNAME", user.getLinkedAccounts().get(0).
-                getPlainAttr("surname").orElseThrow().getValues().get(0));
-        assertEquals("UPDATED_EMAIL@syncope.apache.org", user.getLinkedAccounts().get(0).
-                getPlainAttr("email").orElseThrow().getValues().get(0));
+        assertEquals("UPDATED_SURNAME", user.getLinkedAccounts().getFirst().
+                getPlainAttr("surname").orElseThrow().getValues().getFirst());
+        assertEquals("UPDATED_EMAIL@syncope.apache.org", user.getLinkedAccounts().getFirst().
+                getPlainAttr("email").orElseThrow().getValues().getFirst());
 
         // 4 verify that account was updated on resource
         ldapObj = RESOURCE_SERVICE.readConnObject(RESOURCE_NAME_LDAP, AnyTypeKind.USER.name(), connObjectKeyValue);
         assertNotNull(ldapObj);
 
         assertTrue(ldapObj.getAttr("mail").orElseThrow().getValues().contains("UPDATED_EMAIL@syncope.apache.org"));
-        assertEquals("UPDATED_SURNAME", ldapObj.getAttr("sn").orElseThrow().getValues().get(0));
+        assertEquals("UPDATED_SURNAME", ldapObj.getAttr("sn").orElseThrow().getValues().getFirst());
 
         // 5. remove linked account from user
         userUR = new UserUR();
         userUR.setKey(user.getKey());
         userUR.getLinkedAccounts().add(new LinkedAccountUR.Builder().
                 operation(PatchOperation.DELETE).
-                linkedAccountTO(user.getLinkedAccounts().get(0)).build());
+                linkedAccountTO(user.getLinkedAccounts().getFirst()).build());
 
         user = updateUser(userUR).getEntity();
         assertTrue(user.getLinkedAccounts().isEmpty());
@@ -193,9 +193,9 @@ public class LinkedAccountITCase extends AbstractITCase {
                 new TaskQuery.Builder(TaskType.PROPAGATION).resource(RESOURCE_NAME_LDAP).
                         anyTypeKind(AnyTypeKind.USER).entityKey(user.getKey()).build());
         assertEquals(1, tasks.getTotalCount());
-        assertEquals(connObjectKeyValue, tasks.getResult().get(0).getConnObjectKey());
-        assertEquals(ResourceOperation.CREATE, tasks.getResult().get(0).getOperation());
-        assertEquals(ExecStatus.SUCCESS.name(), tasks.getResult().get(0).getLatestExecStatus());
+        assertEquals(connObjectKeyValue, tasks.getResult().getFirst().getConnObjectKey());
+        assertEquals(ResourceOperation.CREATE, tasks.getResult().getFirst().getOperation());
+        assertEquals(ExecStatus.SUCCESS.name(), tasks.getResult().getFirst().getLatestExecStatus());
 
         ConnObject ldapObj = RESOURCE_SERVICE.readConnObject(
                 RESOURCE_NAME_LDAP, AnyTypeKind.USER.name(), connObjectKeyValue);
@@ -203,7 +203,7 @@ public class LinkedAccountITCase extends AbstractITCase {
         assertEquals(
                 user.getPlainAttr("email").orElseThrow().getValues(),
                 ldapObj.getAttr("mail").orElseThrow().getValues());
-        assertEquals("LINKED_SURNAME", ldapObj.getAttr("sn").orElseThrow().getValues().get(0));
+        assertEquals("LINKED_SURNAME", ldapObj.getAttr("sn").orElseThrow().getValues().getFirst());
     }
 
     @Test
@@ -229,7 +229,7 @@ public class LinkedAccountITCase extends AbstractITCase {
 
         user = updateUser(userUR).getEntity();
         assertEquals(1, user.getLinkedAccounts().size());
-        assertNull(user.getLinkedAccounts().get(0).getPassword());
+        assertNull(user.getLinkedAccounts().getFirst().getPassword());
 
         // 4. update linked account with adding a password
         account.setPassword("Password123");
@@ -251,18 +251,18 @@ public class LinkedAccountITCase extends AbstractITCase {
         // set a correct password
         account.setPassword("Password123");
         user = updateUser(userUR).getEntity();
-        assertNotNull(user.getLinkedAccounts().get(0).getPassword());
+        assertNotNull(user.getLinkedAccounts().getFirst().getPassword());
 
         // 5. update linked account  password
-        String beforeUpdatePassword = user.getLinkedAccounts().get(0).getPassword();
+        String beforeUpdatePassword = user.getLinkedAccounts().getFirst().getPassword();
         account.setPassword("Password123Updated");
         userUR = new UserUR();
         userUR.setKey(user.getKey());
 
         userUR.getLinkedAccounts().add(new LinkedAccountUR.Builder().linkedAccountTO(account).build());
         user = updateUser(userUR).getEntity();
-        assertNotNull(user.getLinkedAccounts().get(0).getPassword());
-        assertNotEquals(beforeUpdatePassword, user.getLinkedAccounts().get(0).getPassword());
+        assertNotNull(user.getLinkedAccounts().getFirst().getPassword());
+        assertNotEquals(beforeUpdatePassword, user.getLinkedAccounts().getFirst().getPassword());
 
         // 6. set linked account password to null
         account.setPassword(null);
@@ -271,7 +271,7 @@ public class LinkedAccountITCase extends AbstractITCase {
 
         userUR.getLinkedAccounts().add(new LinkedAccountUR.Builder().linkedAccountTO(account).build());
         user = updateUser(userUR).getEntity();
-        assertNull(user.getLinkedAccounts().get(0).getPassword());
+        assertNull(user.getLinkedAccounts().getFirst().getPassword());
 
         confParamOps.set(SyncopeConstants.MASTER_DOMAIN, "return.password.value", false);
     }
@@ -307,9 +307,9 @@ public class LinkedAccountITCase extends AbstractITCase {
                     new TaskQuery.Builder(TaskType.PROPAGATION).resource(RESOURCE_NAME_REST).
                             anyTypeKind(AnyTypeKind.USER).entityKey(user.getKey()).build());
             assertEquals(1, tasks.getTotalCount());
-            assertEquals(connObjectKeyValue, tasks.getResult().get(0).getConnObjectKey());
-            assertEquals(ResourceOperation.CREATE, tasks.getResult().get(0).getOperation());
-            assertEquals(ExecStatus.SUCCESS.name(), tasks.getResult().get(0).getLatestExecStatus());
+            assertEquals(connObjectKeyValue, tasks.getResult().getFirst().getConnObjectKey());
+            assertEquals(ResourceOperation.CREATE, tasks.getResult().getFirst().getOperation());
+            assertEquals(ExecStatus.SUCCESS.name(), tasks.getResult().getFirst().getLatestExecStatus());
 
             WebClient webClient = WebClient.create(BUILD_TOOLS_ADDRESS + "/rest/users/" + connObjectKeyValue).
                     accept(MediaType.APPLICATION_JSON_TYPE);
@@ -344,7 +344,7 @@ public class LinkedAccountITCase extends AbstractITCase {
 
             TaskTO task = TASK_SERVICE.read(TaskType.PUSH, sendUser.getKey(), true);
             assertEquals(1, task.getExecutions().size());
-            assertEquals(ExecStatus.SUCCESS.name(), task.getExecutions().get(0).getStatus());
+            assertEquals(ExecStatus.SUCCESS.name(), task.getExecutions().getFirst().getStatus());
 
             await().until(() -> TASK_SERVICE.search(
                     new TaskQuery.Builder(TaskType.PROPAGATION).resource(RESOURCE_NAME_REST)
@@ -419,7 +419,7 @@ public class LinkedAccountITCase extends AbstractITCase {
         PagedResult<PullTaskTO> tasks = TASK_SERVICE.search(
                 new TaskQuery.Builder(TaskType.PULL).resource(RESOURCE_NAME_REST).build());
         if (tasks.getTotalCount() > 0) {
-            pullTaskKey = tasks.getResult().get(0).getKey();
+            pullTaskKey = tasks.getResult().getFirst().getKey();
         } else {
             PullTaskTO task = new PullTaskTO();
             task.setDestinationRealm(SyncopeConstants.ROOT_REALM);
@@ -500,7 +500,7 @@ public class LinkedAccountITCase extends AbstractITCase {
             assertEquals("linkedaccount1", firstAccount.orElseThrow().getUsername());
             assertEquals(
                     "Pasquale",
-                    firstAccount.orElseThrow().getPlainAttr("firstname").orElseThrow().getValues().get(0));
+                    firstAccount.orElseThrow().getPlainAttr("firstname").orElseThrow().getValues().getFirst());
 
             Optional<LinkedAccountTO> secondAccount = accounts.stream().
                     filter(account -> user2Key.equals(account.getConnObjectKeyValue())).
@@ -511,7 +511,7 @@ public class LinkedAccountITCase extends AbstractITCase {
             assertNull(secondAccount.orElseThrow().getUsername());
             assertEquals(
                     "Giovannino",
-                    secondAccount.orElseThrow().getPlainAttr("firstname").orElseThrow().getValues().get(0));
+                    secondAccount.orElseThrow().getPlainAttr("firstname").orElseThrow().getValues().getFirst());
 
             Optional<LinkedAccountTO> thirdAccount = accounts.stream().
                     filter(account -> user3Key.equals(account.getConnObjectKeyValue())).

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/LiveSyncITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/LiveSyncITCase.java
@@ -168,8 +168,8 @@ public class LiveSyncITCase extends AbstractITCase {
         UserCR userCR = UserITCase.getUniqueSample("kafka@syncope.apache.org");
         userCR.getResources().add(RESOURCE_NAME_KAFKA);
         ProvisioningResult<UserTO> created = createUser(userCR);
-        assertEquals(RESOURCE_NAME_KAFKA, created.getPropagationStatuses().get(0).getResource());
-        assertEquals(ExecStatus.SUCCESS, created.getPropagationStatuses().get(0).getStatus());
+        assertEquals(RESOURCE_NAME_KAFKA, created.getPropagationStatuses().getFirst().getResource());
+        assertEquals(ExecStatus.SUCCESS, created.getPropagationStatuses().getFirst().getStatus());
 
         assertTrue(found(SyncDeltaType.CREATE, created.getEntity().getUsername()));
 
@@ -177,8 +177,8 @@ public class LiveSyncITCase extends AbstractITCase {
         req.setKey(created.getEntity().getKey());
         req.getPlainAttrs().add(attrAddReplacePatch("firstname", "Updated"));
         ProvisioningResult<UserTO> updated = updateUser(req);
-        assertEquals(RESOURCE_NAME_KAFKA, updated.getPropagationStatuses().get(0).getResource());
-        assertEquals(ExecStatus.SUCCESS, updated.getPropagationStatuses().get(0).getStatus());
+        assertEquals(RESOURCE_NAME_KAFKA, updated.getPropagationStatuses().getFirst().getResource());
+        assertEquals(ExecStatus.SUCCESS, updated.getPropagationStatuses().getFirst().getStatus());
 
         assertTrue(found(SyncDeltaType.UPDATE, updated.getEntity().getUsername()));
 
@@ -240,11 +240,11 @@ public class LiveSyncITCase extends AbstractITCase {
                             return null;
                         }
                     }, Objects::nonNull);
-            assertEquals(email, user.getPlainAttr("email").orElseThrow().getValues().get(0));
-            assertEquals(email, user.getPlainAttr("userId").orElseThrow().getValues().get(0));
-            assertEquals(email, user.getPlainAttr("userId").orElseThrow().getValues().get(0));
-            assertEquals("LiveSync", user.getPlainAttr("firstname").orElseThrow().getValues().get(0));
-            assertEquals("LiveSync", user.getPlainAttr("surname").orElseThrow().getValues().get(0));
+            assertEquals(email, user.getPlainAttr("email").orElseThrow().getValues().getFirst());
+            assertEquals(email, user.getPlainAttr("userId").orElseThrow().getValues().getFirst());
+            assertEquals(email, user.getPlainAttr("userId").orElseThrow().getValues().getFirst());
+            assertEquals("LiveSync", user.getPlainAttr("firstname").orElseThrow().getValues().getFirst());
+            assertEquals("LiveSync", user.getPlainAttr("surname").orElseThrow().getValues().getFirst());
 
             await().atMost(MAX_WAIT_SECONDS, TimeUnit.SECONDS).pollInterval(1, TimeUnit.SECONDS).until(
                     () -> TASK_SERVICE.read(TaskType.LIVE_SYNC, actual.getKey(), true).getExecutions(),

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/MembershipITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/MembershipITCase.java
@@ -96,14 +96,14 @@ public class MembershipITCase extends AbstractITCase {
 
             // 1. verify that 'aLong' is correctly populated for user
             assertEquals(1, userTO.getPlainAttr("aLong").orElseThrow().getValues().size());
-            assertEquals("1976", userTO.getPlainAttr("aLong").orElseThrow().getValues().get(0));
+            assertEquals("1976", userTO.getPlainAttr("aLong").orElseThrow().getValues().getFirst());
 
             // 2. verify that 'aLong' is correctly populated for user's membership
             assertEquals(1, userCR.getMemberships().size());
             membership = userTO.getMembership("034740a9-fa10-453b-af37-dc7897e98fb1").orElseThrow();
             assertNotNull(membership);
             assertEquals(1, membership.getPlainAttr("aLong").orElseThrow().getValues().size());
-            assertEquals("1977", membership.getPlainAttr("aLong").orElseThrow().getValues().get(0));
+            assertEquals("1977", membership.getPlainAttr("aLong").orElseThrow().getValues().getFirst());
 
             // 3. verify that derived attributes from 'csv' and 'other' are also populated for user's membership
             assertFalse(membership.getDerAttr("csvuserid").orElseThrow().getValues().isEmpty());
@@ -125,7 +125,7 @@ public class MembershipITCase extends AbstractITCase {
 
             // 4. verify that 'aLong' is correctly populated for user
             assertEquals(1, userTO.getPlainAttr("aLong").orElseThrow().getValues().size());
-            assertEquals("1977", userTO.getPlainAttr("aLong").orElseThrow().getValues().get(0));
+            assertEquals("1977", userTO.getPlainAttr("aLong").orElseThrow().getValues().getFirst());
             assertFalse(userTO.getPlainAttr("ctype").isPresent());
 
             // 5. verify that 'aLong' is correctly populated for user's membership
@@ -133,10 +133,10 @@ public class MembershipITCase extends AbstractITCase {
             membership = userTO.getMembership("034740a9-fa10-453b-af37-dc7897e98fb1").orElseThrow();
             assertNotNull(membership);
             assertEquals(1, membership.getPlainAttr("aLong").orElseThrow().getValues().size());
-            assertEquals("1976", membership.getPlainAttr("aLong").orElseThrow().getValues().get(0));
+            assertEquals("1976", membership.getPlainAttr("aLong").orElseThrow().getValues().getFirst());
 
             // 6. verify that 'ctype' is correctly populated for user's membership
-            assertEquals("membership type", membership.getPlainAttr("ctype").orElseThrow().getValues().get(0));
+            assertEquals("membership type", membership.getPlainAttr("ctype").orElseThrow().getValues().getFirst());
 
             // finally remove membership
             userUR = new UserUR();
@@ -199,7 +199,7 @@ public class MembershipITCase extends AbstractITCase {
         membership = user.getMembership(groupTO.getKey()).orElseThrow();
         assertNotNull(membership);
         assertEquals(1, membership.getPlainAttr("aLong").orElseThrow().getValues().size());
-        assertEquals("1454", membership.getPlainAttr("aLong").orElseThrow().getValues().get(0));
+        assertEquals("1454", membership.getPlainAttr("aLong").orElseThrow().getValues().getFirst());
 
         // verify that derived attrbutes from 'csv' and 'other' are also populated for user's membership
         assertFalse(membership.getDerAttr("csvuserid").orElseThrow().getValues().isEmpty());
@@ -292,9 +292,9 @@ public class MembershipITCase extends AbstractITCase {
                     fiql(SyncopeClient.getUserSearchConditionBuilder().
                             is("username").equalTo(user.getUsername()).query()).build());
             assertEquals(1, users.getTotalCount());
-            assertEquals(1, users.getResult().get(0).getMemberships().size());
-            assertEquals("5432", users.getResult().get(0).getMemberships().get(0).
-                    getPlainAttr("aLong").orElseThrow().getValues().get(0));
+            assertEquals(1, users.getResult().getFirst().getMemberships().size());
+            assertEquals("5432", users.getResult().getFirst().getMemberships().getFirst().
+                    getPlainAttr("aLong").orElseThrow().getValues().getFirst());
         } catch (Exception e) {
             LOG.error("Unexpected error", e);
             fail(e::getMessage);

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/MultitenancyITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/MultitenancyITCase.java
@@ -106,13 +106,13 @@ public class MultitenancyITCase extends AbstractITCase {
                 search(new RealmQuery.Builder().keyword("*").build());
         assertEquals(1, realms.getTotalCount());
         assertEquals(1, realms.getResult().size());
-        assertEquals(SyncopeConstants.ROOT_REALM, realms.getResult().get(0).getName());
+        assertEquals(SyncopeConstants.ROOT_REALM, realms.getResult().getFirst().getName());
     }
 
     @Test
     public void createUser() {
         assertNull(ADMIN_CLIENT.getService(RealmService.class).
-                search(new RealmQuery.Builder().keyword("*").build()).getResult().get(0).getPasswordPolicy());
+                search(new RealmQuery.Builder().keyword("*").build()).getResult().getFirst().getPasswordPolicy());
 
         UserCR userCR = new UserCR();
         userCR.setRealm(SyncopeConstants.ROOT_REALM);
@@ -225,7 +225,7 @@ public class MultitenancyITCase extends AbstractITCase {
             assertEquals(1, matchingUsers.getResult().size());
 
             // SYNCOPE-1374
-            String pullFromLDAPKey = matchingUsers.getResult().get(0).getKey();
+            String pullFromLDAPKey = matchingUsers.getResult().getFirst().getKey();
 
             assertEquals(0, ADMIN_CLIENT.getService(TaskService.class).
                     search(new TaskQuery.Builder(TaskType.PROPAGATION).

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/PolicyITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/PolicyITCase.java
@@ -241,7 +241,7 @@ public class PolicyITCase extends AbstractITCase {
         assertNotEquals("ce93fcda-dc3a-4369-a7b0-a6108c261c85", policy.getKey());
 
         ImplementationTO rule = IMPLEMENTATION_SERVICE.read(
-                IdRepoImplementationType.PASSWORD_RULE, policy.getRules().get(0));
+                IdRepoImplementationType.PASSWORD_RULE, policy.getRules().getFirst());
         assertNotNull(rule);
 
         DefaultPasswordRuleConf ruleConf = POJOHelper.deserialize(rule.getBody(), DefaultPasswordRuleConf.class);

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/PropagationTaskITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/PropagationTaskITCase.java
@@ -718,7 +718,8 @@ public class PropagationTaskITCase extends AbstractTaskITCase {
                         tasks.getResult().getFirst().getPropagationData(), PropagationData.class).getAttributes());
             }
 
-            OffsetDateTime loginDate = LocalDate.parse(user.getPlainAttr("loginDate").orElseThrow().getValues().getFirst()).
+            OffsetDateTime loginDate = LocalDate.parse(user.getPlainAttr("loginDate").
+                    orElseThrow().getValues().getFirst()).
                     atStartOfDay(ZoneOffset.UTC).toOffsetDateTime();
 
             Attribute employeeNumber = AttributeUtil.find("employeeNumber", propagationAttrs);
@@ -735,7 +736,8 @@ public class PropagationTaskITCase extends AbstractTaskITCase {
 
             Attribute carLicense = AttributeUtil.find("carLicense", propagationAttrs);
             assertNotNull(carLicense);
-            assertEquals(DateTimeFormatter.ISO_LOCAL_DATE.format(loginDate.plusDays(1)), carLicense.getValue().getFirst());
+            assertEquals(DateTimeFormatter.ISO_LOCAL_DATE.format(loginDate.plusDays(1)),
+                carLicense.getValue().getFirst());
         } finally {
             try {
                 RESOURCE_SERVICE.delete(ldap.getKey());

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/PropagationTaskITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/PropagationTaskITCase.java
@@ -238,7 +238,7 @@ public class PropagationTaskITCase extends AbstractTaskITCase {
 
             // 1. create printer on external resource
             AnyObjectCR anyObjectCR = AnyObjectITCase.getSample("propagationJEXLTransformer");
-            String originalLocation = anyObjectCR.getPlainAttr("location").orElseThrow().getValues().get(0);
+            String originalLocation = anyObjectCR.getPlainAttr("location").orElseThrow().getValues().getFirst();
             assertFalse(originalLocation.endsWith(suffix));
 
             AnyObjectTO anyObjectTO = createAnyObject(anyObjectCR).getEntity();
@@ -248,8 +248,8 @@ public class PropagationTaskITCase extends AbstractTaskITCase {
             // (location ends with given suffix on external resource)
             ConnObject connObjectTO = RESOURCE_SERVICE.
                     readConnObject(RESOURCE_NAME_DBSCRIPTED, anyObjectTO.getType(), anyObjectTO.getKey());
-            assertFalse(anyObjectTO.getPlainAttr("location").orElseThrow().getValues().get(0).endsWith(suffix));
-            assertTrue(connObjectTO.getAttr("LOCATION").orElseThrow().getValues().get(0).endsWith(suffix));
+            assertFalse(anyObjectTO.getPlainAttr("location").orElseThrow().getValues().getFirst().endsWith(suffix));
+            assertTrue(connObjectTO.getAttr("LOCATION").orElseThrow().getValues().getFirst().endsWith(suffix));
         } finally {
             RESOURCE_SERVICE.update(originalResource);
         }
@@ -317,9 +317,9 @@ public class PropagationTaskITCase extends AbstractTaskITCase {
                                     anyTypeKind(AnyTypeKind.ANY_OBJECT).entityKey(entityKey).build()),
                     p -> p.getTotalCount() > 0);
 
-            propagations.getResult().get(0).getExecutions().stream().
+            propagations.getResult().getFirst().getExecutions().stream().
                     anyMatch(e -> ExecStatus.FAILURE.name().equals(e.getStatus()));
-            propagations.getResult().get(0).getExecutions().stream().
+            propagations.getResult().getFirst().getExecutions().stream().
                     anyMatch(e -> ExecStatus.SUCCESS.name().equals(e.getStatus()));
         } finally {
             SyncopeClient.nullPriorityAsync(ANY_OBJECT_SERVICE, false);
@@ -366,8 +366,8 @@ public class PropagationTaskITCase extends AbstractTaskITCase {
             userCR.getPlainAttrs().add(attr("title", "title1"));
             userCR.getMemberships().add(new MembershipTO.Builder(group1.getKey()).build());
             ProvisioningResult<UserTO> created = createUser(userCR);
-            assertEquals(RESOURCE_NAME_LDAP, created.getPropagationStatuses().get(0).getResource());
-            assertEquals(ExecStatus.SUCCESS, created.getPropagationStatuses().get(0).getStatus());
+            assertEquals(RESOURCE_NAME_LDAP, created.getPropagationStatuses().getFirst().getResource());
+            assertEquals(ExecStatus.SUCCESS, created.getPropagationStatuses().getFirst().getStatus());
 
             // 1b. read from LDAP the effective object
             ReconStatus status = RECONCILIATION_SERVICE.status(
@@ -385,10 +385,10 @@ public class PropagationTaskITCase extends AbstractTaskITCase {
             assertEquals(1, tasks.getSize());
 
             PropagationData data = POJOHelper.deserialize(
-                    tasks.getResult().get(0).getPropagationData(), PropagationData.class);
+                    tasks.getResult().getFirst().getPropagationData(), PropagationData.class);
             assertNull(data.getAttributeDeltas());
 
-            TASK_SERVICE.delete(TaskType.PROPAGATION, tasks.getResult().get(0).getKey());
+            TASK_SERVICE.delete(TaskType.PROPAGATION, tasks.getResult().getFirst().getKey());
 
             // 2a. update user on LDAP and verify success
             UserUR userUR = new UserUR.Builder(created.getEntity().getKey()).plainAttr(new AttrPatch.Builder(
@@ -396,8 +396,8 @@ public class PropagationTaskITCase extends AbstractTaskITCase {
                     membership(new MembershipUR.Builder(group2.getKey()).build()).
                     build();
             ProvisioningResult<UserTO> updated = updateUser(userUR);
-            assertEquals(RESOURCE_NAME_LDAP, updated.getPropagationStatuses().get(0).getResource());
-            assertEquals(ExecStatus.SUCCESS, updated.getPropagationStatuses().get(0).getStatus());
+            assertEquals(RESOURCE_NAME_LDAP, updated.getPropagationStatuses().getFirst().getResource());
+            assertEquals(ExecStatus.SUCCESS, updated.getPropagationStatuses().getFirst().getStatus());
 
             // 2b. read from LDAP the effective object
             status = RECONCILIATION_SERVICE.status(
@@ -417,10 +417,10 @@ public class PropagationTaskITCase extends AbstractTaskITCase {
                     anyTypeKind(AnyTypeKind.USER).entityKey(created.getEntity().getKey()).build());
             assertEquals(1, tasks.getSize());
 
-            data = POJOHelper.deserialize(tasks.getResult().get(0).getPropagationData(), PropagationData.class);
+            data = POJOHelper.deserialize(tasks.getResult().getFirst().getPropagationData(), PropagationData.class);
             assertNotNull(data.getAttributeDeltas());
 
-            TASK_SERVICE.delete(TaskType.PROPAGATION, tasks.getResult().get(0).getKey());
+            TASK_SERVICE.delete(TaskType.PROPAGATION, tasks.getResult().getFirst().getKey());
         } finally {
             ldap.setPropagationPolicy(null);
             RESOURCE_SERVICE.update(ldap);
@@ -458,8 +458,8 @@ public class PropagationTaskITCase extends AbstractTaskITCase {
         try {
             // 1a. create printer on db and verify success
             created = createAnyObject(AnyObjectITCase.getSample("ppOptimizeToDB"));
-            assertEquals(RESOURCE_NAME_DBSCRIPTED, created.getPropagationStatuses().get(0).getResource());
-            assertEquals(ExecStatus.SUCCESS, created.getPropagationStatuses().get(0).getStatus());
+            assertEquals(RESOURCE_NAME_DBSCRIPTED, created.getPropagationStatuses().getFirst().getResource());
+            assertEquals(ExecStatus.SUCCESS, created.getPropagationStatuses().getFirst().getStatus());
 
             // 1b. check the generated propagation data
             PagedResult<PropagationTaskTO> tasks = TASK_SERVICE.search(new TaskQuery.Builder(TaskType.PROPAGATION).
@@ -468,18 +468,18 @@ public class PropagationTaskITCase extends AbstractTaskITCase {
             assertEquals(1, tasks.getSize());
 
             PropagationData data = POJOHelper.deserialize(
-                    tasks.getResult().get(0).getPropagationData(), PropagationData.class);
+                    tasks.getResult().getFirst().getPropagationData(), PropagationData.class);
             assertNull(data.getAttributeDeltas());
 
-            TASK_SERVICE.delete(TaskType.PROPAGATION, tasks.getResult().get(0).getKey());
+            TASK_SERVICE.delete(TaskType.PROPAGATION, tasks.getResult().getFirst().getKey());
 
             // 2a. update printer on db and verify success
             AnyObjectUR req = new AnyObjectUR.Builder(created.getEntity().getKey()).plainAttr(new AttrPatch.Builder(
                     new Attr.Builder("paperformat").values("format1", "format2").build()).build()).
                     build();
             ProvisioningResult<AnyObjectTO> updated = updateAnyObject(req);
-            assertEquals(RESOURCE_NAME_DBSCRIPTED, updated.getPropagationStatuses().get(0).getResource());
-            assertEquals(ExecStatus.SUCCESS, updated.getPropagationStatuses().get(0).getStatus());
+            assertEquals(RESOURCE_NAME_DBSCRIPTED, updated.getPropagationStatuses().getFirst().getResource());
+            assertEquals(ExecStatus.SUCCESS, updated.getPropagationStatuses().getFirst().getStatus());
 
             // 2b. read from db the effective object
             JdbcTemplate jdbcTemplate = new JdbcTemplate(testDataSource);
@@ -496,18 +496,18 @@ public class PropagationTaskITCase extends AbstractTaskITCase {
                     anyTypeKind(AnyTypeKind.ANY_OBJECT).entityKey(created.getEntity().getKey()).build());
             assertEquals(1, tasks.getSize());
 
-            data = POJOHelper.deserialize(tasks.getResult().get(0).getPropagationData(), PropagationData.class);
+            data = POJOHelper.deserialize(tasks.getResult().getFirst().getPropagationData(), PropagationData.class);
             assertNotNull(data.getAttributeDeltas());
 
-            TASK_SERVICE.delete(TaskType.PROPAGATION, tasks.getResult().get(0).getKey());
+            TASK_SERVICE.delete(TaskType.PROPAGATION, tasks.getResult().getFirst().getKey());
 
             // 3a. update printer on db and verify success
             req = new AnyObjectUR.Builder(created.getEntity().getKey()).plainAttr(new AttrPatch.Builder(
                     new Attr.Builder("paperformat").values("format1", "format3").build()).build()).
                     build();
             updated = updateAnyObject(req);
-            assertEquals(RESOURCE_NAME_DBSCRIPTED, updated.getPropagationStatuses().get(0).getResource());
-            assertEquals(ExecStatus.SUCCESS, updated.getPropagationStatuses().get(0).getStatus());
+            assertEquals(RESOURCE_NAME_DBSCRIPTED, updated.getPropagationStatuses().getFirst().getResource());
+            assertEquals(ExecStatus.SUCCESS, updated.getPropagationStatuses().getFirst().getStatus());
 
             // 3b. read from db the effective object
             values = queryForList(jdbcTemplate,
@@ -523,10 +523,10 @@ public class PropagationTaskITCase extends AbstractTaskITCase {
                     anyTypeKind(AnyTypeKind.ANY_OBJECT).entityKey(created.getEntity().getKey()).build());
             assertEquals(1, tasks.getSize());
 
-            data = POJOHelper.deserialize(tasks.getResult().get(0).getPropagationData(), PropagationData.class);
+            data = POJOHelper.deserialize(tasks.getResult().getFirst().getPropagationData(), PropagationData.class);
             assertNotNull(data.getAttributeDeltas());
 
-            TASK_SERVICE.delete(TaskType.PROPAGATION, tasks.getResult().get(0).getKey());
+            TASK_SERVICE.delete(TaskType.PROPAGATION, tasks.getResult().getFirst().getKey());
         } finally {
             Optional.ofNullable(created).map(c -> c.getEntity().getKey()).ifPresent(ANY_OBJECT_SERVICE::delete);
 
@@ -713,29 +713,29 @@ public class PropagationTaskITCase extends AbstractTaskITCase {
             assertEquals(1, tasks.getSize());
 
             Set<Attribute> propagationAttrs = new HashSet<>();
-            if (StringUtils.isNotBlank(tasks.getResult().get(0).getPropagationData())) {
+            if (StringUtils.isNotBlank(tasks.getResult().getFirst().getPropagationData())) {
                 propagationAttrs.addAll(POJOHelper.deserialize(
-                        tasks.getResult().get(0).getPropagationData(), PropagationData.class).getAttributes());
+                        tasks.getResult().getFirst().getPropagationData(), PropagationData.class).getAttributes());
             }
 
-            OffsetDateTime loginDate = LocalDate.parse(user.getPlainAttr("loginDate").orElseThrow().getValues().get(0)).
+            OffsetDateTime loginDate = LocalDate.parse(user.getPlainAttr("loginDate").orElseThrow().getValues().getFirst()).
                     atStartOfDay(ZoneOffset.UTC).toOffsetDateTime();
 
             Attribute employeeNumber = AttributeUtil.find("employeeNumber", propagationAttrs);
             assertNotNull(employeeNumber);
-            assertEquals(loginDate.toInstant().toEpochMilli(), employeeNumber.getValue().get(0));
+            assertEquals(loginDate.toInstant().toEpochMilli(), employeeNumber.getValue().getFirst());
 
             Attribute street = AttributeUtil.find("street", propagationAttrs);
             assertNotNull(street);
-            assertEquals(loginDate.toInstant().toString().split("T")[0].replace("-", ""), street.getValue().get(0));
+            assertEquals(loginDate.toInstant().toString().split("T")[0].replace("-", ""), street.getValue().getFirst());
 
             Attribute st = AttributeUtil.find("st", propagationAttrs);
             assertNotNull(st);
-            assertEquals(loginDate.toInstant().toEpochMilli(), st.getValue().get(0));
+            assertEquals(loginDate.toInstant().toEpochMilli(), st.getValue().getFirst());
 
             Attribute carLicense = AttributeUtil.find("carLicense", propagationAttrs);
             assertNotNull(carLicense);
-            assertEquals(DateTimeFormatter.ISO_LOCAL_DATE.format(loginDate.plusDays(1)), carLicense.getValue().get(0));
+            assertEquals(DateTimeFormatter.ISO_LOCAL_DATE.format(loginDate.plusDays(1)), carLicense.getValue().getFirst());
         } finally {
             try {
                 RESOURCE_SERVICE.delete(ldap.getKey());
@@ -885,11 +885,11 @@ public class PropagationTaskITCase extends AbstractTaskITCase {
             assertEquals(1, tasks.getSize());
 
             Set<Attribute> propagationAttrs = POJOHelper.deserialize(
-                    tasks.getResult().get(0).getPropagationData(), PropagationData.class).getAttributes();
+                    tasks.getResult().getFirst().getPropagationData(), PropagationData.class).getAttributes();
             List<Object> value = Optional.ofNullable(AttributeUtil.find("l", propagationAttrs)).
                     map(Attribute::getValue).orElseThrow();
             assertFalse(CollectionUtils.isEmpty(value));
-            assertEquals("Canon MFC8030", value.get(0).toString());
+            assertEquals("Canon MFC8030", value.getFirst().toString());
 
             // 3. check propagated value
             ConnObject connObject =
@@ -897,7 +897,7 @@ public class PropagationTaskITCase extends AbstractTaskITCase {
             assertNotNull(connObject);
             List<String> values = connObject.getAttr("l").map(Attr::getValues).orElseThrow();
             assertFalse(values.isEmpty());
-            assertEquals("Canon MFC8030", values.get(0));
+            assertEquals("Canon MFC8030", values.getFirst());
         } finally {
             try {
                 RESOURCE_SERVICE.delete(ldap.getKey());
@@ -949,8 +949,8 @@ public class PropagationTaskITCase extends AbstractTaskITCase {
             PagedResult<PropagationTaskTO> tasks = TASK_SERVICE.search(new TaskQuery.Builder(TaskType.PROPAGATION).
                     resource(ldap.getKey()).anyTypeKind(AnyTypeKind.GROUP).entityKey(groupTO.getKey()).build());
             assertEquals(1, tasks.getSize());
-            assertEquals(ResourceOperation.CREATE, tasks.getResult().get(0).getOperation());
-            assertEquals(ExecStatus.SUCCESS.name(), tasks.getResult().get(0).getLatestExecStatus());
+            assertEquals(ResourceOperation.CREATE, tasks.getResult().getFirst().getOperation());
+            assertEquals(ExecStatus.SUCCESS.name(), tasks.getResult().getFirst().getLatestExecStatus());
 
             ConnObject beforeConnObject =
                     RESOURCE_SERVICE.readConnObject(ldap.getKey(), AnyTypeKind.GROUP.name(), groupTO.getKey());
@@ -965,14 +965,14 @@ public class PropagationTaskITCase extends AbstractTaskITCase {
                     resource(ldap.getKey()).anyTypeKind(AnyTypeKind.GROUP).entityKey(groupTO.getKey()).
                     orderBy("start DESC").build());
             assertEquals(2, tasks.getSize());
-            assertEquals(ResourceOperation.UPDATE, tasks.getResult().get(0).getOperation());
-            assertEquals(ExecStatus.SUCCESS.name(), tasks.getResult().get(0).getLatestExecStatus());
+            assertEquals(ResourceOperation.UPDATE, tasks.getResult().getFirst().getOperation());
+            assertEquals(ExecStatus.SUCCESS.name(), tasks.getResult().getFirst().getLatestExecStatus());
 
             ConnObject afterConnObject =
                     RESOURCE_SERVICE.readConnObject(ldap.getKey(), AnyTypeKind.GROUP.name(), groupTO.getKey());
-            assertNotEquals(afterConnObject.getAttr(Name.NAME).orElseThrow().getValues().get(0),
-                    beforeConnObject.getAttr(Name.NAME).orElseThrow().getValues().get(0));
-            assertTrue(afterConnObject.getAttr(Name.NAME).orElseThrow().getValues().get(0).
+            assertNotEquals(afterConnObject.getAttr(Name.NAME).orElseThrow().getValues().getFirst(),
+                    beforeConnObject.getAttr(Name.NAME).orElseThrow().getValues().getFirst());
+            assertTrue(afterConnObject.getAttr(Name.NAME).orElseThrow().getValues().getFirst().
                     contains("new" + originalName));
         } finally {
             try {
@@ -1009,7 +1009,7 @@ public class PropagationTaskITCase extends AbstractTaskITCase {
         assertFalse(propTasks.getResult().isEmpty());
         assertEquals(1, propTasks.getSize());
         PropagationData propagationData = POJOHelper.deserialize(
-                PropagationTaskTO.class.cast(propTasks.getResult().get(0)).getPropagationData(),
+                PropagationTaskTO.class.cast(propTasks.getResult().getFirst()).getPropagationData(),
                 PropagationData.class);
         assertTrue(propagationData.getAttributes().stream().
                 anyMatch(a -> OperationalAttributes.PASSWORD_NAME.equals(a.getName())));

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/PullTaskITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/PullTaskITCase.java
@@ -339,9 +339,9 @@ public class PullTaskITCase extends AbstractTaskITCase {
             assertEquals(userName, userTO.getUsername());
             assertEquals(IS_FLOWABLE_ENABLED
                     ? "active" : "created", userTO.getStatus());
-            assertEquals("test9@syncope.apache.org", userTO.getPlainAttr("email").orElseThrow().getValues().get(0));
-            assertEquals("test9@syncope.apache.org", userTO.getPlainAttr("userId").orElseThrow().getValues().get(0));
-            assertTrue(Integer.parseInt(userTO.getPlainAttr("fullname").orElseThrow().getValues().get(0)) <= 10);
+            assertEquals("test9@syncope.apache.org", userTO.getPlainAttr("email").orElseThrow().getValues().getFirst());
+            assertEquals("test9@syncope.apache.org", userTO.getPlainAttr("userId").orElseThrow().getValues().getFirst());
+            assertTrue(Integer.parseInt(userTO.getPlainAttr("fullname").orElseThrow().getValues().getFirst()) <= 10);
             assertTrue(userTO.getResources().contains(RESOURCE_NAME_TESTDB));
             assertTrue(userTO.getResources().contains(RESOURCE_NAME_WS2));
 
@@ -351,12 +351,12 @@ public class PullTaskITCase extends AbstractTaskITCase {
             // check for user template
             userTO = USER_SERVICE.read("test7");
             assertNotNull(userTO);
-            assertEquals("TYPE_OTHER", userTO.getPlainAttr("ctype").orElseThrow().getValues().get(0));
+            assertEquals("TYPE_OTHER", userTO.getPlainAttr("ctype").orElseThrow().getValues().getFirst());
             assertEquals(3, userTO.getResources().size());
             assertTrue(userTO.getResources().contains(RESOURCE_NAME_TESTDB));
             assertTrue(userTO.getResources().contains(RESOURCE_NAME_WS2));
             assertEquals(1, userTO.getMemberships().size());
-            assertEquals("f779c0d4-633b-4be5-8f57-32eb478a3ca5", userTO.getMemberships().get(0).getGroupKey());
+            assertEquals("f779c0d4-633b-4be5-8f57-32eb478a3ca5", userTO.getMemberships().getFirst().getGroupKey());
 
             // Unmatching --> Assign (link) - SYNCOPE-658
             assertTrue(userTO.getResources().contains(RESOURCE_NAME_CSV));
@@ -365,7 +365,7 @@ public class PullTaskITCase extends AbstractTaskITCase {
 
             userTO = USER_SERVICE.read("test8");
             assertNotNull(userTO);
-            assertEquals("TYPE_8", userTO.getPlainAttr("ctype").orElseThrow().getValues().get(0));
+            assertEquals("TYPE_8", userTO.getPlainAttr("ctype").orElseThrow().getValues().getFirst());
 
             // Check for ignored user - SYNCOPE-663
             try {
@@ -418,7 +418,7 @@ public class PullTaskITCase extends AbstractTaskITCase {
             assertNotNull(userTO);
             assertEquals(
                     "reconciled@syncope.apache.org",
-                    userTO.getPlainAttr("userId").orElseThrow().getValues().get(0));
+                    userTO.getPlainAttr("userId").orElseThrow().getValues().getFirst());
             assertEquals("suspended", userTO.getStatus());
 
             // enable user on external resource
@@ -472,7 +472,7 @@ public class PullTaskITCase extends AbstractTaskITCase {
                 build());
         assertNotNull(matchingGroups);
         assertEquals(1, matchingGroups.getResult().size());
-        assertEquals(SyncopeConstants.ROOT_REALM, matchingGroups.getResult().get(0).getRealm());
+        assertEquals(SyncopeConstants.ROOT_REALM, matchingGroups.getResult().getFirst().getRealm());
 
         // 3. verify that pulled user is found
         PagedResult<UserTO> matchingUsers = USER_SERVICE.search(
@@ -483,17 +483,17 @@ public class PullTaskITCase extends AbstractTaskITCase {
         assertNotNull(matchingUsers);
         assertEquals(1, matchingUsers.getResult().size());
         // SYNCOPE-898
-        assertEquals("/odd", matchingUsers.getResult().get(0).getRealm());
+        assertEquals("/odd", matchingUsers.getResult().getFirst().getRealm());
 
         // Check for SYNCOPE-436
         assertEquals("pullFromLDAP",
-                matchingUsers.getResult().get(0).getVirAttr("virtualReadOnly").orElseThrow().getValues().get(0));
+                matchingUsers.getResult().getFirst().getVirAttr("virtualReadOnly").orElseThrow().getValues().getFirst());
         // Check for SYNCOPE-270
-        assertNotNull(matchingUsers.getResult().get(0).getPlainAttr("obscure"));
+        assertNotNull(matchingUsers.getResult().getFirst().getPlainAttr("obscure"));
         // Check for SYNCOPE-123
-        assertNotNull(matchingUsers.getResult().get(0).getPlainAttr("photo"));
+        assertNotNull(matchingUsers.getResult().getFirst().getPlainAttr("photo"));
         // Check for SYNCOPE-1343
-        assertEquals("odd", matchingUsers.getResult().get(0).getPlainAttr("title").orElseThrow().getValues().get(0));
+        assertEquals("odd", matchingUsers.getResult().getFirst().getPlainAttr("title").orElseThrow().getValues().getFirst());
 
         PagedResult<UserTO> matchByLastChangeContext = USER_SERVICE.search(
                 new AnyQuery.Builder().realm(SyncopeConstants.ROOT_REALM).
@@ -503,21 +503,21 @@ public class PullTaskITCase extends AbstractTaskITCase {
         assertNotNull(matchByLastChangeContext);
         assertNotEquals(0, matchByLastChangeContext.getTotalCount());
 
-        GroupTO groupTO = matchingGroups.getResult().get(0);
+        GroupTO groupTO = matchingGroups.getResult().getFirst();
         assertNotNull(groupTO);
         assertEquals("testLDAPGroup", groupTO.getName());
         assertTrue(groupTO.getLastChangeContext().contains("Task " + task.getKey()));
-        assertEquals("true", groupTO.getPlainAttr("show").orElseThrow().getValues().get(0));
-        assertEquals(matchingUsers.getResult().get(0).getKey(), groupTO.getUserOwner());
+        assertEquals("true", groupTO.getPlainAttr("show").orElseThrow().getValues().getFirst());
+        assertEquals(matchingUsers.getResult().getFirst().getKey(), groupTO.getUserOwner());
         assertNull(groupTO.getGroupOwner());
         // SYNCOPE-1343, set value title to null on LDAP
         ConnObject userConnObject = RESOURCE_SERVICE.readConnObject(
-                RESOURCE_NAME_LDAP, AnyTypeKind.USER.name(), matchingUsers.getResult().get(0).getKey());
+                RESOURCE_NAME_LDAP, AnyTypeKind.USER.name(), matchingUsers.getResult().getFirst().getKey());
         assertNotNull(userConnObject);
-        assertEquals("odd", userConnObject.getAttr("title").orElseThrow().getValues().get(0));
+        assertEquals("odd", userConnObject.getAttr("title").orElseThrow().getValues().getFirst());
         Attr userDn = userConnObject.getAttr(Name.NAME).orElseThrow();
         updateLdapRemoteObject(RESOURCE_LDAP_ADMIN_DN, RESOURCE_LDAP_ADMIN_PWD,
-                userDn.getValues().get(0), Collections.singletonMap("title", null));
+                userDn.getValues().getFirst(), Collections.singletonMap("title", null));
 
         // SYNCOPE-317
         execSchedTask(TASK_SERVICE, TaskType.PULL, LDAP_PULL_TASK, MAX_WAIT_SECONDS, false);
@@ -544,15 +544,15 @@ public class PullTaskITCase extends AbstractTaskITCase {
                         fiql(SyncopeClient.getUserSearchConditionBuilder().is("username").equalTo("pullFromLDAP").
                                 query()).
                         build());
-        assertNull(matchingUsers.getResult().get(0).getPlainAttr("title").orElse(null));
+        assertNull(matchingUsers.getResult().getFirst().getPlainAttr("title").orElse(null));
 
         // SYNCOPE-1356 remove group membership from LDAP, pull and check in Syncope
         ConnObject groupConnObject = RESOURCE_SERVICE.readConnObject(
-                RESOURCE_NAME_LDAP, AnyTypeKind.GROUP.name(), matchingGroups.getResult().get(0).getKey());
+                RESOURCE_NAME_LDAP, AnyTypeKind.GROUP.name(), matchingGroups.getResult().getFirst().getKey());
         assertNotNull(groupConnObject);
         Attr groupDn = groupConnObject.getAttr(Name.NAME).orElseThrow();
         updateLdapRemoteObject(RESOURCE_LDAP_ADMIN_DN, RESOURCE_LDAP_ADMIN_PWD,
-                groupDn.getValues().get(0), Map.of("uniquemember", "uid=admin,ou=system"));
+                groupDn.getValues().getFirst(), Map.of("uniquemember", "uid=admin,ou=system"));
 
         execSchedTask(TASK_SERVICE, TaskType.PULL, LDAP_PULL_TASK, MAX_WAIT_SECONDS, false);
 
@@ -618,15 +618,15 @@ public class PullTaskITCase extends AbstractTaskITCase {
             AnyObjectCR anyObjectCR = AnyObjectITCase.getSample("pull");
             AnyObjectTO anyObjectTO = createAnyObject(anyObjectCR).getEntity();
             assertNotNull(anyObjectTO);
-            String originalLocation = anyObjectTO.getPlainAttr("location").orElseThrow().getValues().get(0);
+            String originalLocation = anyObjectTO.getPlainAttr("location").orElseThrow().getValues().getFirst();
             assertFalse(originalLocation.startsWith(prefix));
 
             // 2. verify that PrefixMappingItemTransformer was applied during propagation
             // (location starts with given prefix on external resource)
             ConnObject connObjectTO = RESOURCE_SERVICE.readConnObject(
                     RESOURCE_NAME_DBSCRIPTED, anyObjectTO.getType(), anyObjectTO.getKey());
-            assertFalse(anyObjectTO.getPlainAttr("location").orElseThrow().getValues().get(0).startsWith(prefix));
-            assertTrue(connObjectTO.getAttr("LOCATION").orElseThrow().getValues().get(0).startsWith(prefix));
+            assertFalse(anyObjectTO.getPlainAttr("location").orElseThrow().getValues().getFirst().startsWith(prefix));
+            assertTrue(connObjectTO.getAttr("LOCATION").orElseThrow().getValues().getFirst().startsWith(prefix));
 
             // 3. unlink any existing printer and delete from Syncope (printer is now only on external resource)
             if (IS_EXT_SEARCH_ENABLED) {
@@ -856,7 +856,7 @@ public class PullTaskITCase extends AbstractTaskITCase {
 
         // 2. create PullTask with remediation enabled, for the new resource
         PullTaskTO pullTask = (PullTaskTO) TASK_SERVICE.search(new TaskQuery.Builder(TaskType.PULL).
-                resource(RESOURCE_NAME_LDAP).build()).getResult().get(0);
+                resource(RESOURCE_NAME_LDAP).build()).getResult().getFirst();
         assertNotNull(pullTask);
         pullTask.setName(getUUIDString());
         pullTask.setResource(ldap.getKey());
@@ -900,7 +900,7 @@ public class PullTaskITCase extends AbstractTaskITCase {
             AnyCR userCR = remediation.getAnyCRPayload();
             userCR.getResources().clear();
 
-            String email = userCR.getPlainAttr("email").orElseThrow().getValues().get(0);
+            String email = userCR.getPlainAttr("email").orElseThrow().getValues().getFirst();
             userCR.getPlainAttrs().add(new Attr.Builder("userId").value(email).build());
 
             REMEDIATION_SERVICE.remedy(remediation.getKey(), userCR);
@@ -908,7 +908,7 @@ public class PullTaskITCase extends AbstractTaskITCase {
             // 5. user is now found
             UserTO user = USER_SERVICE.read("pullFromLDAP");
             assertNotNull(user);
-            assertEquals(email, user.getPlainAttr("userId").orElseThrow().getValues().get(0));
+            assertEquals(email, user.getPlainAttr("userId").orElseThrow().getValues().getFirst());
 
             // 6. remediation was removed
             try {
@@ -1117,7 +1117,7 @@ public class PullTaskITCase extends AbstractTaskITCase {
             assertNotNull(userTO);
             assertEquals(
                     "testuser2@syncope.apache.org",
-                    userTO.getPlainAttr("userId").orElseThrow().getValues().get(0));
+                    userTO.getPlainAttr("userId").orElseThrow().getValues().getFirst());
             assertEquals(2, userTO.getMemberships().size());
             assertEquals(4, userTO.getResources().size());
         } finally {
@@ -1143,7 +1143,7 @@ public class PullTaskITCase extends AbstractTaskITCase {
         // 3. read e-mail address for user created by the PullTask first execution
         UserTO userTO = USER_SERVICE.read("issuesyncope230");
         assertNotNull(userTO);
-        String email = userTO.getPlainAttr("email").orElseThrow().getValues().iterator().next();
+        String email = userTO.getPlainAttr("email").orElseThrow().getValues().getFirst();
         assertNotNull(email);
 
         // 4. update TESTPULL on external H2 by changing e-mail address
@@ -1156,7 +1156,7 @@ public class PullTaskITCase extends AbstractTaskITCase {
         // 6. verify that the e-mail was updated
         userTO = USER_SERVICE.read("issuesyncope230");
         assertNotNull(userTO);
-        email = userTO.getPlainAttr("email").orElseThrow().getValues().iterator().next();
+        email = userTO.getPlainAttr("email").orElseThrow().getValues().getFirst();
         assertNotNull(email);
         assertEquals("updatedSYNCOPE230@syncope.apache.org", email);
     }
@@ -1248,7 +1248,7 @@ public class PullTaskITCase extends AbstractTaskITCase {
         try {
             assertNotNull(userTO);
             assertEquals(1, result.getPropagationStatuses().size());
-            assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
+            assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
 
             ExecTO taskExecTO = execSchedTask(
                     TASK_SERVICE, TaskType.PULL, "986867e2-993b-430e-8feb-aa9abb4c1dcd", MAX_WAIT_SECONDS, false);
@@ -1258,7 +1258,7 @@ public class PullTaskITCase extends AbstractTaskITCase {
 
             userTO = USER_SERVICE.read(userTO.getKey());
             assertNotNull(userTO);
-            assertNotNull(userTO.getPlainAttr("firstname").orElseThrow().getValues().get(0));
+            assertNotNull(userTO.getPlainAttr("firstname").orElseThrow().getValues().getFirst());
         } finally {
             removeTestUsers();
         }
@@ -1310,7 +1310,7 @@ public class PullTaskITCase extends AbstractTaskITCase {
 
         // 2. virtual attribute
         userTO = USER_SERVICE.read(userTO.getKey());
-        assertEquals("virtualvalue", userTO.getVirAttr("virtualdata").orElseThrow().getValues().get(0));
+        assertEquals("virtualvalue", userTO.getVirAttr("virtualdata").orElseThrow().getValues().getFirst());
     }
 
     @Test
@@ -1403,9 +1403,9 @@ public class PullTaskITCase extends AbstractTaskITCase {
             ConnObject connObject =
                     RESOURCE_SERVICE.readConnObject(RESOURCE_NAME_LDAP, AnyTypeKind.USER.name(), user.getKey());
             assertNotNull(getLdapRemoteObject(
-                    connObject.getAttr(Name.NAME).orElseThrow().getValues().get(0),
+                    connObject.getAttr(Name.NAME).orElseThrow().getValues().getFirst(),
                     oldCleanPassword,
-                    connObject.getAttr(Name.NAME).orElseThrow().getValues().get(0)));
+                    connObject.getAttr(Name.NAME).orElseThrow().getValues().getFirst()));
 
             // 5. Update the LDAP Connector to retrieve passwords
             ResourceTO ldapResource = RESOURCE_SERVICE.read(RESOURCE_NAME_LDAP);
@@ -1512,7 +1512,7 @@ public class PullTaskITCase extends AbstractTaskITCase {
             user = USER_SERVICE.read("pullFromLDAP");
             assertNotNull(user);
             assertEquals("pullFromLDAP@syncope.apache.org",
-                    user.getPlainAttr("email").orElseThrow().getValues().get(0));
+                    user.getPlainAttr("email").orElseThrow().getValues().getFirst());
 
             group = GROUP_SERVICE.read("testLDAPGroup");
             assertNotNull(group);
@@ -1522,12 +1522,12 @@ public class PullTaskITCase extends AbstractTaskITCase {
             assertNotNull(connObject);
             assertEquals(
                     "pullFromLDAP@syncope.apache.org",
-                    connObject.getAttr("mail").orElseThrow().getValues().get(0));
+                    connObject.getAttr("mail").orElseThrow().getValues().getFirst());
             Attr userDn = connObject.getAttr(Name.NAME).orElseThrow();
             assertNotNull(userDn);
             assertEquals(1, userDn.getValues().size());
             assertNotNull(
-                    getLdapRemoteObject(RESOURCE_LDAP_ADMIN_DN, RESOURCE_LDAP_ADMIN_PWD, userDn.getValues().get(0)));
+                    getLdapRemoteObject(RESOURCE_LDAP_ADMIN_DN, RESOURCE_LDAP_ADMIN_PWD, userDn.getValues().getFirst()));
 
             // ...and propagated
             PagedResult<TaskTO> propagationTasks = TASK_SERVICE.search(new TaskQuery.Builder(TaskType.PROPAGATION).
@@ -1537,13 +1537,13 @@ public class PullTaskITCase extends AbstractTaskITCase {
 
             // 4. update the user on the external resource
             updateLdapRemoteObject(RESOURCE_LDAP_ADMIN_DN, RESOURCE_LDAP_ADMIN_PWD,
-                    userDn.getValues().get(0), Map.of("mail", "pullFromLDAP2@syncope.apache.org"));
+                    userDn.getValues().getFirst(), Map.of("mail", "pullFromLDAP2@syncope.apache.org"));
 
             connObject = RESOURCE_SERVICE.readConnObject(RESOURCE_NAME_LDAP, AnyTypeKind.USER.name(), user.getKey());
             assertNotNull(connObject);
             assertEquals(
                     "pullFromLDAP2@syncope.apache.org",
-                    connObject.getAttr("mail").orElseThrow().getValues().get(0));
+                    connObject.getAttr("mail").orElseThrow().getValues().getFirst());
 
             // 5. exec the pull task again
             execution = execSchedTask(TASK_SERVICE, TaskType.PULL, pullTask.getKey(), MAX_WAIT_SECONDS, false);
@@ -1554,7 +1554,7 @@ public class PullTaskITCase extends AbstractTaskITCase {
             assertNotNull(user);
             assertEquals(
                     "pullFromLDAP2@syncope.apache.org",
-                    user.getPlainAttr("email").orElseThrow().getValues().get(0));
+                    user.getPlainAttr("email").orElseThrow().getValues().getFirst());
 
             // ...and propagated
             propagationTasks = TASK_SERVICE.search(new TaskQuery.Builder(TaskType.PROPAGATION).
@@ -1608,25 +1608,25 @@ public class PullTaskITCase extends AbstractTaskITCase {
 
             pullFromLDAP4issue1656 = USER_SERVICE.read("pullFromLDAP_issue1656");
             assertEquals("pullFromLDAP_issue1656@syncope.apache.org",
-                    pullFromLDAP4issue1656.getPlainAttr("email").orElseThrow().getValues().get(0));
+                    pullFromLDAP4issue1656.getPlainAttr("email").orElseThrow().getValues().getFirst());
             // 2. Edit mail attribute directly on the resource in order to have a not valid email
             ConnObject connObject = RESOURCE_SERVICE.readConnObject(
                     RESOURCE_NAME_LDAP, AnyTypeKind.USER.name(), pullFromLDAP4issue1656.getKey());
             assertNotNull(connObject);
             assertEquals("pullFromLDAP_issue1656@syncope.apache.org",
-                    connObject.getAttr("mail").orElseThrow().getValues().get(0));
+                    connObject.getAttr("mail").orElseThrow().getValues().getFirst());
             Attr userDn = connObject.getAttr(Name.NAME).orElseThrow();
             assertNotNull(userDn);
             assertEquals(1, userDn.getValues().size());
             updateLdapRemoteObject(RESOURCE_LDAP_ADMIN_DN, RESOURCE_LDAP_ADMIN_PWD,
-                    userDn.getValues().get(0), Map.of("mail", "pullFromLDAP_issue1656@"));
+                    userDn.getValues().getFirst(), Map.of("mail", "pullFromLDAP_issue1656@"));
             // 3. Pull again from resource-ldap
             execution = execSchedTask(TASK_SERVICE, TaskType.PULL, pullTask.getKey(), MAX_WAIT_SECONDS, false);
             assertEquals(ExecStatus.SUCCESS, ExecStatus.valueOf(execution.getStatus()));
             assertTrue(execution.getMessage().contains("UPDATE FAILURE"));
             pullFromLDAP4issue1656 = USER_SERVICE.read("pullFromLDAP_issue1656");
             assertEquals("pullFromLDAP_issue1656@syncope.apache.org",
-                    pullFromLDAP4issue1656.getPlainAttr("email").orElseThrow().getValues().get(0));
+                    pullFromLDAP4issue1656.getPlainAttr("email").orElseThrow().getValues().getFirst());
             String pullFromLDAP4issue1656Key = pullFromLDAP4issue1656.getKey();
             // a remediation for pullFromLDAP_issue1656 email should have been created
             PagedResult<RemediationTO> remediations =

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/PullTaskITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/PullTaskITCase.java
@@ -339,9 +339,12 @@ public class PullTaskITCase extends AbstractTaskITCase {
             assertEquals(userName, userTO.getUsername());
             assertEquals(IS_FLOWABLE_ENABLED
                     ? "active" : "created", userTO.getStatus());
-            assertEquals("test9@syncope.apache.org", userTO.getPlainAttr("email").orElseThrow().getValues().getFirst());
-            assertEquals("test9@syncope.apache.org", userTO.getPlainAttr("userId").orElseThrow().getValues().getFirst());
-            assertTrue(Integer.parseInt(userTO.getPlainAttr("fullname").orElseThrow().getValues().getFirst()) <= 10);
+            assertEquals("test9@syncope.apache.org", userTO.getPlainAttr("email").
+                orElseThrow().getValues().getFirst());
+            assertEquals("test9@syncope.apache.org", userTO.getPlainAttr("userId").
+                orElseThrow().getValues().getFirst());
+            assertTrue(Integer.parseInt(userTO.getPlainAttr("fullname").
+                orElseThrow().getValues().getFirst()) <= 10);
             assertTrue(userTO.getResources().contains(RESOURCE_NAME_TESTDB));
             assertTrue(userTO.getResources().contains(RESOURCE_NAME_WS2));
 
@@ -351,7 +354,8 @@ public class PullTaskITCase extends AbstractTaskITCase {
             // check for user template
             userTO = USER_SERVICE.read("test7");
             assertNotNull(userTO);
-            assertEquals("TYPE_OTHER", userTO.getPlainAttr("ctype").orElseThrow().getValues().getFirst());
+            assertEquals("TYPE_OTHER", userTO.getPlainAttr("ctype").
+                orElseThrow().getValues().getFirst());
             assertEquals(3, userTO.getResources().size());
             assertTrue(userTO.getResources().contains(RESOURCE_NAME_TESTDB));
             assertTrue(userTO.getResources().contains(RESOURCE_NAME_WS2));
@@ -487,13 +491,15 @@ public class PullTaskITCase extends AbstractTaskITCase {
 
         // Check for SYNCOPE-436
         assertEquals("pullFromLDAP",
-                matchingUsers.getResult().getFirst().getVirAttr("virtualReadOnly").orElseThrow().getValues().getFirst());
+                matchingUsers.getResult().getFirst().getVirAttr("virtualReadOnly").
+                    orElseThrow().getValues().getFirst());
         // Check for SYNCOPE-270
         assertNotNull(matchingUsers.getResult().getFirst().getPlainAttr("obscure"));
         // Check for SYNCOPE-123
         assertNotNull(matchingUsers.getResult().getFirst().getPlainAttr("photo"));
         // Check for SYNCOPE-1343
-        assertEquals("odd", matchingUsers.getResult().getFirst().getPlainAttr("title").orElseThrow().getValues().getFirst());
+        assertEquals("odd", matchingUsers.getResult().getFirst().getPlainAttr("title").
+            orElseThrow().getValues().getFirst());
 
         PagedResult<UserTO> matchByLastChangeContext = USER_SERVICE.search(
                 new AnyQuery.Builder().realm(SyncopeConstants.ROOT_REALM).
@@ -1527,7 +1533,8 @@ public class PullTaskITCase extends AbstractTaskITCase {
             assertNotNull(userDn);
             assertEquals(1, userDn.getValues().size());
             assertNotNull(
-                    getLdapRemoteObject(RESOURCE_LDAP_ADMIN_DN, RESOURCE_LDAP_ADMIN_PWD, userDn.getValues().getFirst()));
+                    getLdapRemoteObject(RESOURCE_LDAP_ADMIN_DN, RESOURCE_LDAP_ADMIN_PWD,
+                        userDn.getValues().getFirst()));
 
             // ...and propagated
             PagedResult<TaskTO> propagationTasks = TASK_SERVICE.search(new TaskQuery.Builder(TaskType.PROPAGATION).

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/RealmITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/RealmITCase.java
@@ -139,7 +139,7 @@ public class RealmITCase extends AbstractITCase {
         List<RealmTO> realms = REALM_SERVICE.search(new RealmQuery.Builder().
                 base("/even/two/73~1~19534").build()).getResult();
         assertEquals(1, realms.size());
-        assertEquals(realm.getName(), realms.get(0).getName());
+        assertEquals(realm.getName(), realms.getFirst().getName());
     }
 
     @Test
@@ -348,24 +348,24 @@ public class RealmITCase extends AbstractITCase {
         });
         assertNotNull(result);
         assertEquals(1, result.getPropagationStatuses().size());
-        assertEquals(RESOURCE_NAME_LDAP_ORGUNIT, result.getPropagationStatuses().get(0).getResource());
-        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
+        assertEquals(RESOURCE_NAME_LDAP_ORGUNIT, result.getPropagationStatuses().getFirst().getResource());
+        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
 
         ProvisioningResult<RealmTO> resultChild = REALM_SERVICE.create("/test", childRealm).readEntity(
                 new GenericType<>() {
         });
         assertNotNull(resultChild);
         assertEquals(1, resultChild.getPropagationStatuses().size());
-        assertEquals(RESOURCE_NAME_LDAP_ORGUNIT, resultChild.getPropagationStatuses().get(0).getResource());
-        assertEquals(ExecStatus.SUCCESS, resultChild.getPropagationStatuses().get(0).getStatus());
+        assertEquals(RESOURCE_NAME_LDAP_ORGUNIT, resultChild.getPropagationStatuses().getFirst().getResource());
+        assertEquals(ExecStatus.SUCCESS, resultChild.getPropagationStatuses().getFirst().getStatus());
 
         ProvisioningResult<RealmTO> resultDescendant = REALM_SERVICE.create("/test/child", descendantRealm).readEntity(
                 new GenericType<>() {
         });
         assertNotNull(resultDescendant);
         assertEquals(1, resultDescendant.getPropagationStatuses().size());
-        assertEquals(RESOURCE_NAME_LDAP_ORGUNIT, resultDescendant.getPropagationStatuses().get(0).getResource());
-        assertEquals(ExecStatus.SUCCESS, resultDescendant.getPropagationStatuses().get(0).getStatus());
+        assertEquals(RESOURCE_NAME_LDAP_ORGUNIT, resultDescendant.getPropagationStatuses().getFirst().getResource());
+        assertEquals(ExecStatus.SUCCESS, resultDescendant.getPropagationStatuses().getFirst().getStatus());
 
         // 3. check on LDAP
         assertNotNull(
@@ -392,7 +392,7 @@ public class RealmITCase extends AbstractITCase {
     @Test
     public void issueSYNCOPE1472() {
         // 1. assign twice resource-ldap-orgunit to /odd
-        RealmTO realmTO = REALM_SERVICE.search(new RealmQuery.Builder().base("/odd").build()).getResult().get(0);
+        RealmTO realmTO = REALM_SERVICE.search(new RealmQuery.Builder().base("/odd").build()).getResult().getFirst();
         realmTO.getResources().clear();
         realmTO.getResources().add("resource-ldap-orgunit");
         realmTO.getResources().add("resource-ldap-orgunit");
@@ -442,7 +442,7 @@ public class RealmITCase extends AbstractITCase {
             Response response = REALM_SERVICE.create(SyncopeConstants.ROOT_REALM, realmTO);
             assertEquals(Response.Status.CREATED.getStatusCode(), response.getStatusInfo().getStatusCode());
             childRealm = REALM_SERVICE.search(new RealmQuery.Builder().
-                    base(SyncopeConstants.ROOT_REALM).keyword("child").build()).getResult().get(0);
+                    base(SyncopeConstants.ROOT_REALM).keyword("child").build()).getResult().getFirst();
 
             // MANAGER CANNOT UPDATE /child
             try {

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/ReconciliationITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/ReconciliationITCase.java
@@ -131,7 +131,7 @@ public class ReconciliationITCase extends AbstractITCase {
         printerCR.getResources().clear();
         AnyObjectTO printer = createAnyObject(printerCR).getEntity();
         assertNotNull(printer.getKey());
-        assertNotEquals("Nowhere", printer.getPlainAttr("location").get().getValues().get(0));
+        assertNotEquals("Nowhere", printer.getPlainAttr("location").get().getValues().getFirst());
 
         // 2. add row into the external resource's table, with same name
         JdbcTemplate jdbcTemplate = new JdbcTemplate(testDataSource);
@@ -156,7 +156,7 @@ public class ReconciliationITCase extends AbstractITCase {
 
         // 5. verify reconciliation result (and resource is still not assigned)
         printer = ANY_OBJECT_SERVICE.read(printer.getKey());
-        assertEquals("Nowhere", printer.getPlainAttr("location").get().getValues().get(0));
+        assertEquals("Nowhere", printer.getPlainAttr("location").get().getValues().getFirst());
         assertTrue(printer.getResources().isEmpty());
     }
 
@@ -180,8 +180,8 @@ public class ReconciliationITCase extends AbstractITCase {
         assertNull(status.getMatchType());
         assertNull(status.getOnSyncope());
         assertNotNull(status.getOnResource());
-        assertEquals(externalKey, status.getOnResource().getAttr(Uid.NAME).get().getValues().get(0));
-        assertEquals(externalName, status.getOnResource().getAttr("PRINTERNAME").get().getValues().get(0));
+        assertEquals(externalKey, status.getOnResource().getAttr(Uid.NAME).get().getValues().getFirst());
+        assertEquals(externalName, status.getOnResource().getAttr("PRINTERNAME").get().getValues().getFirst());
 
         // 3. pull
         PullTaskTO pullTask = new PullTaskTO();
@@ -205,21 +205,21 @@ public class ReconciliationITCase extends AbstractITCase {
         InputStream csv = getClass().getResourceAsStream("/test1.csv");
 
         List<ProvisioningReport> results = service.pull(spec, csv);
-        assertEquals(AnyTypeKind.USER.name(), results.get(0).getAnyType());
-        assertNotNull(results.get(0).getKey());
-        assertEquals("donizetti", results.get(0).getName());
-        assertEquals("donizetti", results.get(0).getUidValue());
-        assertEquals(ResourceOperation.CREATE, results.get(0).getOperation());
-        assertEquals(ProvisioningReport.Status.SUCCESS, results.get(0).getStatus());
+        assertEquals(AnyTypeKind.USER.name(), results.getFirst().getAnyType());
+        assertNotNull(results.getFirst().getKey());
+        assertEquals("donizetti", results.getFirst().getName());
+        assertEquals("donizetti", results.getFirst().getUidValue());
+        assertEquals(ResourceOperation.CREATE, results.getFirst().getOperation());
+        assertEquals(ProvisioningReport.Status.SUCCESS, results.getFirst().getStatus());
 
-        UserTO donizetti = USER_SERVICE.read(results.get(0).getKey());
+        UserTO donizetti = USER_SERVICE.read(results.getFirst().getKey());
         assertNotNull(donizetti);
-        assertEquals("Gaetano", donizetti.getPlainAttr("firstname").get().getValues().get(0));
+        assertEquals("Gaetano", donizetti.getPlainAttr("firstname").get().getValues().getFirst());
         assertEquals(1, donizetti.getPlainAttr("loginDate").get().getValues().size());
 
         UserTO cimarosa = USER_SERVICE.read(results.get(1).getKey());
         assertNotNull(cimarosa);
-        assertEquals("Domenico Cimarosa", cimarosa.getPlainAttr("fullname").get().getValues().get(0));
+        assertEquals("Domenico Cimarosa", cimarosa.getPlainAttr("fullname").get().getValues().getFirst());
         assertEquals(2, cimarosa.getPlainAttr("loginDate").get().getValues().size());
     }
 

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/ReportITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/ReportITCase.java
@@ -189,8 +189,8 @@ public class ReportITCase extends AbstractITCase {
                 new ExecQuery.Builder().key(report.getKey()).after(start).before(end).build());
         List<BatchResponseItem> batchResponseItems = parseBatchResponse(response);
         assertEquals(1, batchResponseItems.size());
-        assertEquals(execKey, batchResponseItems.get(0).getHeaders().get(RESTHeaders.RESOURCE_KEY).get(0));
-        assertEquals(Response.Status.OK.getStatusCode(), batchResponseItems.get(0).getStatus());
+        assertEquals(execKey, batchResponseItems.getFirst().getHeaders().get(RESTHeaders.RESOURCE_KEY).getFirst());
+        assertEquals(Response.Status.OK.getStatusCode(), batchResponseItems.getFirst().getStatus());
     }
 
     @Test

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/SCIMITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/SCIMITCase.java
@@ -381,7 +381,7 @@ public class SCIMITCase extends AbstractITCase {
         assertNotNull(groups);
         assertEquals(1, groups.getTotalResults());
 
-        SCIMGroup additional = groups.getResources().get(0);
+        SCIMGroup additional = groups.getResources().getFirst();
         assertEquals("additional", additional.getDisplayName());
 
         // eq via POST
@@ -397,7 +397,7 @@ public class SCIMITCase extends AbstractITCase {
         assertNotNull(groups);
         assertEquals(1, groups.getTotalResults());
 
-        additional = groups.getResources().get(0);
+        additional = groups.getResources().getFirst();
         assertEquals("additional", additional.getDisplayName());
 
         // gt
@@ -418,7 +418,7 @@ public class SCIMITCase extends AbstractITCase {
         assertNotNull(users);
         assertEquals(1, users.getTotalResults());
 
-        SCIMUser newSCIMUser = users.getResources().get(0);
+        SCIMUser newSCIMUser = users.getResources().getFirst();
         assertEquals(newUser.getUsername(), newSCIMUser.getUserName());
 
         SCIMEnterpriseUserConf beforeEntConf = CONF.getEnterpriseUserConf();
@@ -451,7 +451,7 @@ public class SCIMITCase extends AbstractITCase {
             });
             assertNotNull(users);
             assertEquals(1, users.getTotalResults());
-            assertFalse(users.getResources().get(0).getGroups().isEmpty());
+            assertFalse(users.getResources().getFirst().getGroups().isEmpty());
 
             // Extension User
             response = webClient().path("Users").query(
@@ -492,14 +492,14 @@ public class SCIMITCase extends AbstractITCase {
         UserTO userTO = USER_SERVICE.read(user.getId());
         assertEquals(user.getUserName(), userTO.getUsername());
         assertTrue(user.isActive());
-        assertEquals(user.getDisplayName(), userTO.getDerAttr("cn").get().getValues().get(0));
-        assertEquals(user.getName().getGivenName(), userTO.getPlainAttr("firstname").get().getValues().get(0));
-        assertEquals(user.getName().getFamilyName(), userTO.getPlainAttr("surname").get().getValues().get(0));
-        assertEquals(user.getName().getFormatted(), userTO.getPlainAttr("fullname").get().getValues().get(0));
-        assertEquals(user.getEmails().get(0).getValue(), userTO.getPlainAttr("userId").get().getValues().get(0));
-        assertEquals(user.getEmails().get(1).getValue(), userTO.getPlainAttr("email").get().getValues().get(0));
-        assertEquals(user.getRoles().get(0).getValue(), userTO.getRoles().get(0));
-        assertEquals(user.getGroups().get(0).getValue(), userTO.getMemberships().get(0).getGroupKey());
+        assertEquals(user.getDisplayName(), userTO.getDerAttr("cn").get().getValues().getFirst());
+        assertEquals(user.getName().getGivenName(), userTO.getPlainAttr("firstname").get().getValues().getFirst());
+        assertEquals(user.getName().getFamilyName(), userTO.getPlainAttr("surname").get().getValues().getFirst());
+        assertEquals(user.getName().getFormatted(), userTO.getPlainAttr("fullname").get().getValues().getFirst());
+        assertEquals(user.getEmails().get(0).getValue(), userTO.getPlainAttr("userId").get().getValues().getFirst());
+        assertEquals(user.getEmails().get(1).getValue(), userTO.getPlainAttr("email").get().getValues().getFirst());
+        assertEquals(user.getRoles().getFirst().getValue(), userTO.getRoles().getFirst());
+        assertEquals(user.getGroups().getFirst().getValue(), userTO.getMemberships().getFirst().getGroupKey());
     }
 
     @Test
@@ -530,14 +530,14 @@ public class SCIMITCase extends AbstractITCase {
         UserTO userTO = USER_SERVICE.read(user.getId());
         assertEquals(user.getUserName(), userTO.getUsername());
         assertTrue(user.isActive());
-        assertEquals(user.getDisplayName(), userTO.getDerAttr("cn").get().getValues().get(0));
-        assertEquals(user.getName().getGivenName(), userTO.getPlainAttr("firstname").get().getValues().get(0));
-        assertEquals(user.getName().getFamilyName(), userTO.getPlainAttr("surname").get().getValues().get(0));
-        assertEquals(user.getName().getFormatted(), userTO.getPlainAttr("fullname").get().getValues().get(0));
-        assertEquals(user.getEmails().get(0).getValue(), userTO.getPlainAttr("userId").get().getValues().get(0));
-        assertEquals(user.getEmails().get(1).getValue(), userTO.getPlainAttr("email").get().getValues().get(0));
+        assertEquals(user.getDisplayName(), userTO.getDerAttr("cn").get().getValues().getFirst());
+        assertEquals(user.getName().getGivenName(), userTO.getPlainAttr("firstname").get().getValues().getFirst());
+        assertEquals(user.getName().getFamilyName(), userTO.getPlainAttr("surname").get().getValues().getFirst());
+        assertEquals(user.getName().getFormatted(), userTO.getPlainAttr("fullname").get().getValues().getFirst());
+        assertEquals(user.getEmails().get(0).getValue(), userTO.getPlainAttr("userId").get().getValues().getFirst());
+        assertEquals(user.getEmails().get(1).getValue(), userTO.getPlainAttr("email").get().getValues().getFirst());
         assertEquals(user.getExtensionInfo().getAttributes().get("gender"),
-                userTO.getPlainAttr("gender").get().getValues().get(0));
+                userTO.getPlainAttr("gender").get().getValues().getFirst());
 
         response = webClient().path("Users").path(user.getId()).delete();
         assertEquals(Response.Status.NO_CONTENT.getStatusCode(), response.getStatus());
@@ -767,7 +767,7 @@ public class SCIMITCase extends AbstractITCase {
         assertNotNull(group.getId());
         assertTrue(response.getLocation().toASCIIString().endsWith(group.getId()));
         assertEquals(1, group.getMembers().size());
-        assertEquals("1417acbe-cbf6-4277-9372-e75e04f97000", group.getMembers().get(0).getValue());
+        assertEquals("1417acbe-cbf6-4277-9372-e75e04f97000", group.getMembers().getFirst().getValue());
 
         response = webClient().path("Users").path("1417acbe-cbf6-4277-9372-e75e04f97000").get();
         assertEquals(Response.Status.OK.getStatusCode(), response.getStatus());
@@ -874,7 +874,7 @@ public class SCIMITCase extends AbstractITCase {
         group = response.readEntity(SCIMGroup.class);
         assertNotNull(group.getId());
         assertEquals(1, group.getMembers().size());
-        assertEquals("b3cbc78d-32e6-4bd4-92e0-bbe07566a2ee", group.getMembers().get(0).getValue());
+        assertEquals("b3cbc78d-32e6-4bd4-92e0-bbe07566a2ee", group.getMembers().getFirst().getValue());
 
         GroupTO groupTO = GROUP_SERVICE.read(group.getId());
         assertNotNull(groupTO);
@@ -907,7 +907,7 @@ public class SCIMITCase extends AbstractITCase {
 
         group = response.readEntity(SCIMGroup.class);
         assertEquals(1, group.getMembers().size());
-        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", group.getMembers().get(0).getValue());
+        assertEquals("c9b2dec2-00a7-4855-97c0-d854842b4b24", group.getMembers().getFirst().getValue());
     }
 
     @Test

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/SchedTaskITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/SchedTaskITCase.java
@@ -118,9 +118,9 @@ public class SchedTaskITCase extends AbstractTaskITCase {
         PagedResult<ExecTO> execs = TASK_SERVICE.listExecutions(new ExecQuery.Builder().key(taskKey).build());
         assertEquals(1, execs.getTotalCount());
 
-        assertTrue(execs.getResult().get(0).getStart().isAfter(initial));
+        assertTrue(execs.getResult().getFirst().getStart().isAfter(initial));
         // round 1 sec for safety
-        assertTrue(execs.getResult().get(0).getStart().plusSeconds(1).isAfter(later));
+        assertTrue(execs.getResult().getFirst().getStart().plusSeconds(1).isAfter(later));
     }
 
     @Test

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/SearchITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/SearchITCase.java
@@ -96,21 +96,21 @@ public class SearchITCase extends AbstractITCase {
                                 is("username").equalToIgnoreCase("RoSsINI").and("key").lessThan(2).query()).build());
         assertNotNull(matchingUsers);
         assertEquals(1, matchingUsers.getResult().size());
-        assertEquals("rossini", matchingUsers.getResult().get(0).getUsername());
+        assertEquals("rossini", matchingUsers.getResult().getFirst().getUsername());
 
         matchingUsers = USER_SERVICE.search(
                 new AnyQuery.Builder().realm(SyncopeConstants.ROOT_REALM).
                         fiql("fullname=~*oSsINi").page(1).size(2).build());
         assertNotNull(matchingUsers);
         assertEquals(1, matchingUsers.getResult().size());
-        assertEquals("rossini", matchingUsers.getResult().get(0).getUsername());
+        assertEquals("rossini", matchingUsers.getResult().getFirst().getUsername());
 
         matchingUsers = USER_SERVICE.search(
                 new AnyQuery.Builder().realm(SyncopeConstants.ROOT_REALM).
                         fiql("fullname=~*ino*rossini*").page(1).size(2).build());
         assertNotNull(matchingUsers);
         assertEquals(1, matchingUsers.getResult().size());
-        assertEquals("rossini", matchingUsers.getResult().get(0).getUsername());
+        assertEquals("rossini", matchingUsers.getResult().getFirst().getUsername());
     }
 
     @Test
@@ -121,7 +121,7 @@ public class SearchITCase extends AbstractITCase {
                                 is("username").equalTo("rossini").and("key").lessThan(2).query()).build());
         assertNotNull(matchingUsers);
         assertEquals(1, matchingUsers.getResult().size());
-        assertEquals("rossini", matchingUsers.getResult().get(0).getUsername());
+        assertEquals("rossini", matchingUsers.getResult().getFirst().getUsername());
     }
 
     @Test
@@ -132,8 +132,8 @@ public class SearchITCase extends AbstractITCase {
                         query()).build());
         assertNotNull(groups);
         assertEquals(1, groups.getResult().size());
-        assertEquals("root", groups.getResult().iterator().next().getName());
-        assertEquals("37d15e4c-cdc1-460b-a591-8505c8133806", groups.getResult().iterator().next().getKey());
+        assertEquals("root", groups.getResult().getFirst().getName());
+        assertEquals("37d15e4c-cdc1-460b-a591-8505c8133806", groups.getResult().getFirst().getKey());
     }
 
     @Test
@@ -354,7 +354,7 @@ public class SearchITCase extends AbstractITCase {
                         is("userOwner").equalTo("823074dc-d280-436d-a7dd-07399fae48ec").query()).build());
         assertNotNull(groups);
         assertEquals(1, groups.getResult().size());
-        assertEquals("ebf97068-aa4b-4a85-9f01-680e8c4cf227", groups.getResult().get(0).getKey());
+        assertEquals("ebf97068-aa4b-4a85-9f01-680e8c4cf227", groups.getResult().getFirst().getKey());
     }
 
     @Test
@@ -763,7 +763,7 @@ public class SearchITCase extends AbstractITCase {
                             inGroups("29f96485-729e-4d31-88a1-6fc60e4677f3").
                             query()).build());
             assertEquals(1, matching.getSize());
-            assertEquals(serviceKey, matching.getResult().get(0).getKey());
+            assertEquals(serviceKey, matching.getResult().getFirst().getKey());
         } finally {
             if (serviceKey != null) {
                 ANY_OBJECT_SERVICE.delete(serviceKey);
@@ -802,7 +802,7 @@ public class SearchITCase extends AbstractITCase {
                     SyncopeClient.getUserSearchConditionBuilder().is("ctype").equalTo("ou=sample%252Co=isp").query()).
                     build());
             assertEquals(1, users.getTotalCount());
-            assertEquals("vivaldi", users.getResult().get(0).getUsername());
+            assertEquals("vivaldi", users.getResult().getFirst().getUsername());
         } finally {
             req.getPlainAttrs().clear();
             req.getPlainAttrs().add(new AttrPatch.Builder(attr("ctype", "F")).build());
@@ -829,7 +829,7 @@ public class SearchITCase extends AbstractITCase {
                 orderBy(SyncopeClient.getOrderByClauseBuilder().asc("loginDate").build()).
                 build());
         assertEquals(1, issueSYNCOPE1416.getSize());
-        assertEquals("rossini", issueSYNCOPE1416.getResult().get(0).getUsername());
+        assertEquals("rossini", issueSYNCOPE1416.getResult().getFirst().getUsername());
 
         // search by attribute with unique constraint
         issueSYNCOPE1416 = USER_SERVICE.search(new AnyQuery.Builder().
@@ -873,7 +873,7 @@ public class SearchITCase extends AbstractITCase {
                 new Attr.Builder("loginDate").value("2009-05-26").build()).build());
         rossini = updateUser(req).getEntity();
         assertNotNull(rossini);
-        assertEquals("2009-05-26", rossini.getPlainAttr("loginDate").orElseThrow().getValues().get(0));
+        assertEquals("2009-05-26", rossini.getPlainAttr("loginDate").orElseThrow().getValues().getFirst());
 
         if (IS_EXT_SEARCH_ENABLED) {
             try {
@@ -954,7 +954,7 @@ public class SearchITCase extends AbstractITCase {
                 fiql(SyncopeClient.getUserSearchConditionBuilder().is("realm").
                         equalTo(realm.getKey()).query()).build());
         assertEquals(1, users.getResult().size());
-        assertEquals(user.getKey(), users.getResult().get(0).getKey());
+        assertEquals(user.getKey(), users.getResult().getFirst().getKey());
 
         // 4. update parent Realm
         realm.setParent(getRealm("/odd").orElseThrow().getKey());
@@ -966,7 +966,7 @@ public class SearchITCase extends AbstractITCase {
                 fiql(SyncopeClient.getUserSearchConditionBuilder().is("realm").
                         equalTo(realm.getKey()).query()).build());
         assertEquals(1, users.getResult().size());
-        assertEquals(user.getKey(), users.getResult().get(0).getKey());
+        assertEquals(user.getKey(), users.getResult().getFirst().getKey());
     }
 
     @Test
@@ -996,13 +996,13 @@ public class SearchITCase extends AbstractITCase {
                             and().is("userId").equalTo("syncope1779_*").query()).
                     build());
             assertEquals(1, users.getResult().size());
-            assertEquals(userWith.getKey(), users.getResult().get(0).getKey());
+            assertEquals(userWith.getKey(), users.getResult().getFirst().getKey());
             // Search also by attribute
             users = USER_SERVICE.search(new AnyQuery.Builder().realm(SyncopeConstants.ROOT_REALM).
                     fiql(SyncopeClient.getUserSearchConditionBuilder().is("email").equalTo("syncope1779_*").query()).
                     build());
             assertEquals(1, users.getResult().size());
-            assertEquals(userWith.getKey(), users.getResult().get(0).getKey());
+            assertEquals(userWith.getKey(), users.getResult().getFirst().getKey());
             // search for both
             users = USER_SERVICE.search(new AnyQuery.Builder().realm(SyncopeConstants.ROOT_REALM).
                     fiql(SyncopeClient.getUserSearchConditionBuilder().is("email").equalTo("syncope1779*").query()).
@@ -1014,7 +1014,7 @@ public class SearchITCase extends AbstractITCase {
                     new AnyQuery.Builder().realm(SyncopeConstants.ROOT_REALM).
                             fiql("$type==PRINTER;name==_syncope1779").build());
             assertEquals(1, printers.getResult().size());
-            assertEquals(printer.getKey(), printers.getResult().get(0).getKey());
+            assertEquals(printer.getKey(), printers.getResult().getFirst().getKey());
         } finally {
             USER_SERVICE.delete(userWith.getKey());
             USER_SERVICE.delete(userWithout.getKey());
@@ -1032,7 +1032,7 @@ public class SearchITCase extends AbstractITCase {
         assertTrue(before > 0);
         assertFalse(users.getResult().isEmpty());
         assertTrue(users.getResult().stream().
-                allMatch(u -> "verdi@syncope.org".equals(u.getPlainAttr("email").orElseThrow().getValues().get(0))));
+                allMatch(u -> "verdi@syncope.org".equals(u.getPlainAttr("email").orElseThrow().getValues().getFirst())));
 
         // 1. create user with similar email
         UserTO user = createUser(UserITCase.getSample("bisverdi@syncope.org")).getEntity();
@@ -1053,7 +1053,7 @@ public class SearchITCase extends AbstractITCase {
         assertEquals(before, users.getTotalCount());
         assertFalse(users.getResult().isEmpty());
         assertTrue(users.getResult().stream().
-                allMatch(u -> "verdi@syncope.org".equals(u.getPlainAttr("email").orElseThrow().getValues().get(0))));
+                allMatch(u -> "verdi@syncope.org".equals(u.getPlainAttr("email").orElseThrow().getValues().getFirst())));
         assertTrue(users.getResult().stream().noneMatch(u -> user.getKey().equals(u.getKey())));
     }
 
@@ -1065,7 +1065,7 @@ public class SearchITCase extends AbstractITCase {
         surname.getValues().clear();
         surname.getValues().add("D'Amico");
         UserTO user = createUser(userCR).getEntity();
-        assertEquals("D'Amico", user.getPlainAttr("surname").orElseThrow().getValues().get(0));
+        assertEquals("D'Amico", user.getPlainAttr("surname").orElseThrow().getValues().getFirst());
 
         // 2. search for user
         if (IS_EXT_SEARCH_ENABLED) {
@@ -1079,7 +1079,7 @@ public class SearchITCase extends AbstractITCase {
         PagedResult<UserTO> users = USER_SERVICE.search(new AnyQuery.Builder().realm(SyncopeConstants.ROOT_REALM).
                 fiql("surname=~D'*").build());
         assertEquals(1, users.getResult().size());
-        assertEquals(user.getKey(), users.getResult().get(0).getKey());
+        assertEquals(user.getKey(), users.getResult().getFirst().getKey());
     }
 
     @Test

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/SearchITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/SearchITCase.java
@@ -1032,7 +1032,8 @@ public class SearchITCase extends AbstractITCase {
         assertTrue(before > 0);
         assertFalse(users.getResult().isEmpty());
         assertTrue(users.getResult().stream().
-                allMatch(u -> "verdi@syncope.org".equals(u.getPlainAttr("email").orElseThrow().getValues().getFirst())));
+                allMatch(u -> "verdi@syncope.org".equals(u.getPlainAttr("email").
+                    orElseThrow().getValues().getFirst())));
 
         // 1. create user with similar email
         UserTO user = createUser(UserITCase.getSample("bisverdi@syncope.org")).getEntity();
@@ -1053,7 +1054,8 @@ public class SearchITCase extends AbstractITCase {
         assertEquals(before, users.getTotalCount());
         assertFalse(users.getResult().isEmpty());
         assertTrue(users.getResult().stream().
-                allMatch(u -> "verdi@syncope.org".equals(u.getPlainAttr("email").orElseThrow().getValues().getFirst())));
+                allMatch(u -> "verdi@syncope.org".equals(u.getPlainAttr("email").
+                    orElseThrow().getValues().getFirst())));
         assertTrue(users.getResult().stream().noneMatch(u -> user.getKey().equals(u.getKey())));
     }
 

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/UserITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/UserITCase.java
@@ -103,7 +103,7 @@ import org.junit.jupiter.api.Test;
 public class UserITCase extends AbstractITCase {
 
     private static boolean getBooleanAttribute(final ConnObject connObjectTO, final String attrName) {
-        return Boolean.parseBoolean(connObjectTO.getAttr(attrName).get().getValues().get(0));
+        return Boolean.parseBoolean(connObjectTO.getAttr(attrName).get().getValues().getFirst());
     }
 
     public static UserCR getUniqueSample(final String email) {
@@ -151,10 +151,10 @@ public class UserITCase extends AbstractITCase {
         assertNotNull(tasks);
         assertFalse(tasks.getResult().isEmpty());
 
-        PropagationTaskTO taskTO = tasks.getResult().get(0);
+        PropagationTaskTO taskTO = tasks.getResult().getFirst();
         assertNotNull(taskTO);
         assertFalse(taskTO.getExecutions().isEmpty());
-        assertEquals(ExecStatus.NOT_ATTEMPTED.name(), taskTO.getExecutions().get(0).getStatus());
+        assertEquals(ExecStatus.NOT_ATTEMPTED.name(), taskTO.getExecutions().getFirst().getStatus());
     }
 
     @Test
@@ -224,7 +224,7 @@ public class UserITCase extends AbstractITCase {
         ProvisioningResult<UserTO> result = createUser(userCR);
         assertNotNull(result);
         assertEquals(1, result.getPropagationStatuses().size());
-        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
+        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
     }
 
     @Test
@@ -290,7 +290,7 @@ public class UserITCase extends AbstractITCase {
         assertNotNull(tasks);
         assertFalse(tasks.getResult().isEmpty());
 
-        String maxKey = tasks.getResult().iterator().next().getKey();
+        String maxKey = tasks.getResult().getFirst().getKey();
         PropagationTaskTO taskTO = TASK_SERVICE.read(TaskType.PROPAGATION, maxKey, true);
 
         assertNotNull(taskTO);
@@ -330,7 +330,7 @@ public class UserITCase extends AbstractITCase {
         assertNotNull(tasks);
         assertFalse(tasks.getResult().isEmpty());
 
-        String newMaxKey = tasks.getResult().iterator().next().getKey();
+        String newMaxKey = tasks.getResult().getFirst().getKey();
 
         // default configuration for ws-target-resource2:
         // only failed executions have to be registered
@@ -429,7 +429,7 @@ public class UserITCase extends AbstractITCase {
 
         // check for propagation result
         assertFalse(result.getPropagationStatuses().isEmpty());
-        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
+        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
 
         try {
             USER_SERVICE.delete(userTO.getKey());
@@ -458,7 +458,7 @@ public class UserITCase extends AbstractITCase {
 
         // check for propagation result
         assertFalse(result.getPropagationStatuses().isEmpty());
-        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
+        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
 
         try {
             USER_SERVICE.read(userTO.getKey());
@@ -575,7 +575,7 @@ public class UserITCase extends AbstractITCase {
 
         userUR.getMemberships().add(new MembershipUR.Builder("f779c0d4-633b-4be5-8f57-32eb478a3ca5").
                 operation(PatchOperation.ADD_REPLACE).build());
-        userUR.getMemberships().add(new MembershipUR.Builder(userTO.getMemberships().get(0).getGroupKey()).
+        userUR.getMemberships().add(new MembershipUR.Builder(userTO.getMemberships().getFirst().getGroupKey()).
                 operation(PatchOperation.ADD_REPLACE).build());
 
         userTO = updateUser(userUR).getEntity();
@@ -926,7 +926,7 @@ public class UserITCase extends AbstractITCase {
         ConnObject connObjectTO =
                 RESOURCE_SERVICE.readConnObject(RESOURCE_NAME_CSV, AnyTypeKind.USER.name(), userTO.getKey());
         assertNotNull(connObjectTO);
-        assertEquals("sx-dx", connObjectTO.getAttr("THEIRGROUP").get().getValues().get(0));
+        assertEquals("sx-dx", connObjectTO.getAttr("THEIRGROUP").get().getValues().getFirst());
     }
 
     @Test
@@ -959,7 +959,7 @@ public class UserITCase extends AbstractITCase {
         passwordPolicy = createPolicy(PolicyType.PASSWORD, passwordPolicy);
         assertNotNull(passwordPolicy);
 
-        RealmTO realm = REALM_SERVICE.search(new RealmQuery.Builder().keyword("two").build()).getResult().get(0);
+        RealmTO realm = REALM_SERVICE.search(new RealmQuery.Builder().keyword("two").build()).getResult().getFirst();
         String oldAccountPolicy = realm.getAccountPolicy();
         realm.setAccountPolicy(accountPolicy.getKey());
         String oldPasswordPolicy = realm.getPasswordPolicy();
@@ -1330,9 +1330,9 @@ public class UserITCase extends AbstractITCase {
         // 1. create
         ProvisioningResult<UserTO> result = createUser(userCR);
         assertEquals(1, result.getPropagationStatuses().size());
-        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
-        assertEquals(RESOURCE_NAME_REST, result.getPropagationStatuses().get(0).getResource());
-        assertEquals("surname", result.getEntity().getPlainAttr("surname").get().getValues().get(0));
+        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
+        assertEquals(RESOURCE_NAME_REST, result.getPropagationStatuses().getFirst().getResource());
+        assertEquals("surname", result.getEntity().getPlainAttr("surname").get().getValues().getFirst());
 
         // verify user exists on the backend REST service
         WebClient webClient = WebClient.create(BUILD_TOOLS_ADDRESS + "/rest/users/" + result.getEntity().getKey());
@@ -1346,9 +1346,9 @@ public class UserITCase extends AbstractITCase {
                 build();
         result = updateUser(userUR);
         assertEquals(1, result.getPropagationStatuses().size());
-        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
-        assertEquals(RESOURCE_NAME_REST, result.getPropagationStatuses().get(0).getResource());
-        assertEquals("surname2", result.getEntity().getPlainAttr("surname").get().getValues().get(0));
+        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
+        assertEquals(RESOURCE_NAME_REST, result.getPropagationStatuses().getFirst().getResource());
+        assertEquals("surname2", result.getEntity().getPlainAttr("surname").get().getValues().getFirst());
 
         // verify user still exists on the backend REST service
         response = webClient.get();
@@ -1358,8 +1358,8 @@ public class UserITCase extends AbstractITCase {
         // 3. delete
         result = deleteUser(result.getEntity().getKey());
         assertEquals(1, result.getPropagationStatuses().size());
-        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
-        assertEquals(RESOURCE_NAME_REST, result.getPropagationStatuses().get(0).getResource());
+        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
+        assertEquals(RESOURCE_NAME_REST, result.getPropagationStatuses().getFirst().getResource());
 
         // verify user was removed by the backend REST service
         assertEquals(Response.Status.NOT_FOUND.getStatusCode(), webClient.get().getStatus());

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/UserIssuesITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/UserIssuesITCase.java
@@ -1405,13 +1405,15 @@ public class UserIssuesITCase extends AbstractITCase {
         Attr userDn = connObject.getAttr(Name.NAME).orElseThrow();
         assertNotNull(userDn);
         assertEquals(1, userDn.getValues().size());
-        assertNotNull(getLdapRemoteObject(RESOURCE_LDAP_ADMIN_DN, RESOURCE_LDAP_ADMIN_PWD, userDn.getValues().getFirst()));
+        assertNotNull(getLdapRemoteObject(RESOURCE_LDAP_ADMIN_DN,
+            RESOURCE_LDAP_ADMIN_PWD, userDn.getValues().getFirst()));
 
         // 4. remove user
         USER_SERVICE.delete(user.getKey());
 
         // 5. verify that user is not in LDAP anymore
-        assertNull(getLdapRemoteObject(RESOURCE_LDAP_ADMIN_DN, RESOURCE_LDAP_ADMIN_PWD, userDn.getValues().getFirst()));
+        assertNull(getLdapRemoteObject(RESOURCE_LDAP_ADMIN_DN,
+            RESOURCE_LDAP_ADMIN_PWD, userDn.getValues().getFirst()));
     }
 
     @Test

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/UserIssuesITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/UserIssuesITCase.java
@@ -182,7 +182,7 @@ public class UserIssuesITCase extends AbstractITCase {
                 operation(PatchOperation.ADD_REPLACE).value(RESOURCE_NAME_WS1).build());
 
         ProvisioningResult<UserTO> result = updateUser(userUR);
-        assertNotNull(result.getPropagationStatuses().get(0).getFailureReason());
+        assertNotNull(result.getPropagationStatuses().getFirst().getFailureReason());
         userTO = result.getEntity();
 
         // 4. update assigning a resource NOT forcing mandatory constraints
@@ -268,9 +268,9 @@ public class UserIssuesITCase extends AbstractITCase {
         assertNotNull(propagations);
         assertEquals(1, propagations.size());
 
-        assertEquals(ExecStatus.SUCCESS, propagations.get(0).getStatus());
+        assertEquals(ExecStatus.SUCCESS, propagations.getFirst().getStatus());
 
-        String resource = propagations.get(0).getResource();
+        String resource = propagations.getFirst().getResource();
         assertEquals(RESOURCE_NAME_TESTDB, resource);
     }
 
@@ -287,9 +287,9 @@ public class UserIssuesITCase extends AbstractITCase {
         List<PropagationStatus> propagations = result.getPropagationStatuses();
         assertNotNull(propagations);
         assertEquals(1, propagations.size());
-        assertNotEquals(ExecStatus.SUCCESS, propagations.get(0).getStatus());
+        assertNotEquals(ExecStatus.SUCCESS, propagations.getFirst().getStatus());
 
-        String resource = propagations.get(0).getResource();
+        String resource = propagations.getFirst().getResource();
         assertEquals(RESOURCE_NAME_CSV, resource);
     }
 
@@ -332,7 +332,7 @@ public class UserIssuesITCase extends AbstractITCase {
         // Remove the first membership: de-provisioning shouldn't happen
         // -----------------------------------
         UserUR userUR = new UserUR.Builder(userTO.getKey()).
-                membership(new MembershipUR.Builder(userTO.getMemberships().get(0).getGroupKey()).
+                membership(new MembershipUR.Builder(userTO.getMemberships().getFirst().getGroupKey()).
                         operation(PatchOperation.DELETE).build()).
                 build();
 
@@ -366,7 +366,7 @@ public class UserIssuesITCase extends AbstractITCase {
         // Remove the first membership: de-provisioning should happen
         // -----------------------------------
         userUR = new UserUR.Builder(userTO.getKey()).
-                membership(new MembershipUR.Builder(userTO.getMemberships().get(0).getGroupKey()).
+                membership(new MembershipUR.Builder(userTO.getMemberships().getFirst().getGroupKey()).
                         operation(PatchOperation.DELETE).build()).
                 build();
 
@@ -393,8 +393,8 @@ public class UserIssuesITCase extends AbstractITCase {
         ProvisioningResult<UserTO> result = createUser(userCR);
         assertNotNull(result);
         assertFalse(result.getPropagationStatuses().isEmpty());
-        assertEquals(RESOURCE_NAME_LDAP, result.getPropagationStatuses().get(0).getResource());
-        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
+        assertEquals(RESOURCE_NAME_LDAP, result.getPropagationStatuses().getFirst().getResource());
+        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
         UserTO userTO = result.getEntity();
 
         // 2. delete this user
@@ -442,21 +442,21 @@ public class UserIssuesITCase extends AbstractITCase {
         ProvisioningResult<UserTO> result = createUser(userCR);
         assertNotNull(result);
         assertFalse(result.getPropagationStatuses().isEmpty());
-        assertEquals(RESOURCE_NAME_DBVIRATTR, result.getPropagationStatuses().get(0).getResource());
-        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
+        assertEquals(RESOURCE_NAME_DBVIRATTR, result.getPropagationStatuses().getFirst().getResource());
+        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
         UserTO userTO = result.getEntity();
 
         ConnObject connObjectTO =
                 RESOURCE_SERVICE.readConnObject(RESOURCE_NAME_DBVIRATTR, AnyTypeKind.USER.name(), userTO.getKey());
         assertNotNull(connObjectTO);
-        assertEquals("virtualvalue", connObjectTO.getAttr("USERNAME").orElseThrow().getValues().get(0));
+        assertEquals("virtualvalue", connObjectTO.getAttr("USERNAME").orElseThrow().getValues().getFirst());
         // ----------------------------------
 
         userTO = USER_SERVICE.read(userTO.getKey());
 
         assertNotNull(userTO);
         assertEquals(1, userTO.getVirAttrs().size());
-        assertEquals("virtualvalue", userTO.getVirAttrs().iterator().next().getValues().get(0));
+        assertEquals("virtualvalue", userTO.getVirAttrs().iterator().next().getValues().getFirst());
     }
 
     @Test
@@ -484,9 +484,9 @@ public class UserIssuesITCase extends AbstractITCase {
         userCR.getResources().clear();
         userCR.getResources().add(RESOURCE_NAME_TIMEOUT);
         ProvisioningResult<UserTO> result = createUser(userCR);
-        assertEquals(RESOURCE_NAME_TIMEOUT, result.getPropagationStatuses().get(0).getResource());
-        assertNotNull(result.getPropagationStatuses().get(0).getFailureReason());
-        assertEquals(ExecStatus.FAILURE, result.getPropagationStatuses().get(0).getStatus());
+        assertEquals(RESOURCE_NAME_TIMEOUT, result.getPropagationStatuses().getFirst().getResource());
+        assertNotNull(result.getPropagationStatuses().getFirst().getFailureReason());
+        assertEquals(ExecStatus.FAILURE, result.getPropagationStatuses().getFirst().getStatus());
     }
 
     @Test
@@ -511,7 +511,7 @@ public class UserIssuesITCase extends AbstractITCase {
         assertNotNull(pwdOnTestDbAttr);
         assertNotNull(pwdOnTestDbAttr.getValues());
         assertFalse(pwdOnTestDbAttr.getValues().isEmpty());
-        String pwdOnTestDb = pwdOnTestDbAttr.getValues().get(0);
+        String pwdOnTestDb = pwdOnTestDbAttr.getValues().getFirst();
 
         ConnObject userOnDb2 = RESOURCE_SERVICE.readConnObject(
                 RESOURCE_NAME_TESTDB2, AnyTypeKind.USER.name(), userTO.getKey());
@@ -519,7 +519,7 @@ public class UserIssuesITCase extends AbstractITCase {
         assertNotNull(pwdOnTestDb2Attr);
         assertNotNull(pwdOnTestDb2Attr.getValues());
         assertFalse(pwdOnTestDb2Attr.getValues().isEmpty());
-        String pwdOnTestDb2 = pwdOnTestDb2Attr.getValues().get(0);
+        String pwdOnTestDb2 = pwdOnTestDb2Attr.getValues().getFirst();
 
         // 2. request to change password only on testdb (no Syncope, no testdb2)
         UserUR userUR = new UserUR();
@@ -533,7 +533,7 @@ public class UserIssuesITCase extends AbstractITCase {
         // 3a. Chech that only a single propagation took place
         assertNotNull(result.getPropagationStatuses());
         assertEquals(1, result.getPropagationStatuses().size());
-        assertEquals(RESOURCE_NAME_TESTDB, result.getPropagationStatuses().get(0).getResource());
+        assertEquals(RESOURCE_NAME_TESTDB, result.getPropagationStatuses().getFirst().getResource());
 
         // 3b. verify that password hasn't changed on Syncope
         assertEquals(pwdOnSyncope, userTO.getPassword());
@@ -544,7 +544,7 @@ public class UserIssuesITCase extends AbstractITCase {
         assertNotNull(pwdOnTestDbAttrAfter);
         assertNotNull(pwdOnTestDbAttrAfter.getValues());
         assertFalse(pwdOnTestDbAttrAfter.getValues().isEmpty());
-        assertNotEquals(pwdOnTestDb, pwdOnTestDbAttrAfter.getValues().get(0));
+        assertNotEquals(pwdOnTestDb, pwdOnTestDbAttrAfter.getValues().getFirst());
 
         // 3d. verify that password hasn't changed on testdb2
         userOnDb2 = RESOURCE_SERVICE.readConnObject(RESOURCE_NAME_TESTDB2, AnyTypeKind.USER.name(), userTO.getKey());
@@ -552,7 +552,7 @@ public class UserIssuesITCase extends AbstractITCase {
         assertNotNull(pwdOnTestDb2AttrAfter);
         assertNotNull(pwdOnTestDb2AttrAfter.getValues());
         assertFalse(pwdOnTestDb2AttrAfter.getValues().isEmpty());
-        assertEquals(pwdOnTestDb2, pwdOnTestDb2AttrAfter.getValues().get(0));
+        assertEquals(pwdOnTestDb2, pwdOnTestDb2AttrAfter.getValues().getFirst());
     }
 
     @Test
@@ -589,7 +589,7 @@ public class UserIssuesITCase extends AbstractITCase {
             List<PropagationStatus> props = result.getPropagationStatuses();
             assertNotNull(props);
             assertEquals(1, props.size());
-            PropagationStatus prop = props.get(0);
+            PropagationStatus prop = props.getFirst();
             assertNotNull(prop);
             assertEquals(RESOURCE_NAME_LDAP, prop.getResource());
             assertEquals(ExecStatus.SUCCESS, prop.getStatus());
@@ -625,7 +625,7 @@ public class UserIssuesITCase extends AbstractITCase {
         List<PropagationStatus> props = result.getPropagationStatuses();
         assertNotNull(props);
         assertEquals(1, props.size());
-        PropagationStatus prop = props.get(0);
+        PropagationStatus prop = props.getFirst();
         assertNotNull(prop);
         assertEquals(RESOURCE_NAME_LDAP, prop.getResource());
         assertEquals(ExecStatus.SUCCESS, prop.getStatus());
@@ -645,7 +645,7 @@ public class UserIssuesITCase extends AbstractITCase {
             userUR.setKey(userKey);
             userUR.getPlainAttrs().add(attrAddReplacePatch("ctype", "a type"));
             UserTO userTO = updateUser(userUR).getEntity();
-            assertEquals("a type", userTO.getPlainAttr("ctype").orElseThrow().getValues().get(0));
+            assertEquals("a type", userTO.getPlainAttr("ctype").orElseThrow().getValues().getFirst());
         }
     }
 
@@ -686,7 +686,7 @@ public class UserIssuesITCase extends AbstractITCase {
         // 4. remove membership
         UserUR userUR = new UserUR();
         userUR.setKey(userTO.getKey());
-        userUR.getMemberships().add(new MembershipUR.Builder(userTO.getMemberships().get(0).getGroupKey()).
+        userUR.getMemberships().add(new MembershipUR.Builder(userTO.getMemberships().getFirst().getGroupKey()).
                 operation(PatchOperation.DELETE).build());
 
         userTO = updateUser(userUR).getEntity();
@@ -743,8 +743,8 @@ public class UserIssuesITCase extends AbstractITCase {
         Optional<Attr> jpegPhoto = connObj.getAttr("jpegPhoto");
         assertTrue(jpegPhoto.isPresent());
         assertEquals(
-                userTO.getPlainAttr("photo").orElseThrow().getValues().get(0),
-                jpegPhoto.orElseThrow().getValues().get(0));
+                userTO.getPlainAttr("photo").orElseThrow().getValues().getFirst(),
+                jpegPhoto.orElseThrow().getValues().getFirst());
 
         // 4. remove group
         GROUP_SERVICE.delete(groupTO.getKey());
@@ -776,8 +776,8 @@ public class UserIssuesITCase extends AbstractITCase {
         assertNotNull(result);
         userTO = result.getEntity();
         assertEquals(RESOURCE_NAME_TESTDB, userTO.getResources().iterator().next());
-        assertNotEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
-        assertNotNull(result.getPropagationStatuses().get(0).getFailureReason());
+        assertNotEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
+        assertNotNull(result.getPropagationStatuses().getFirst().getFailureReason());
         userTO = result.getEntity();
 
         // 3. request to change password only on testdb
@@ -789,7 +789,7 @@ public class UserIssuesITCase extends AbstractITCase {
 
         result = updateUser(userUR);
         assertEquals(RESOURCE_NAME_TESTDB, userTO.getResources().iterator().next());
-        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
+        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
     }
 
     @Test
@@ -848,7 +848,7 @@ public class UserIssuesITCase extends AbstractITCase {
         }
         assertNotNull(logicActions);
 
-        RealmTO realm = REALM_SERVICE.search(new RealmQuery.Builder().keyword("two").build()).getResult().get(0);
+        RealmTO realm = REALM_SERVICE.search(new RealmQuery.Builder().keyword("two").build()).getResult().getFirst();
         assertNotNull(realm);
         realm.getActions().add(logicActions.getKey());
         REALM_SERVICE.update(realm);
@@ -858,14 +858,14 @@ public class UserIssuesITCase extends AbstractITCase {
         userCR.getPlainAttrs().add(attr("makeItDouble", "3"));
 
         UserTO userTO = createUser(userCR).getEntity();
-        assertEquals("6", userTO.getPlainAttr("makeItDouble").orElseThrow().getValues().get(0));
+        assertEquals("6", userTO.getPlainAttr("makeItDouble").orElseThrow().getValues().getFirst());
 
         UserUR userUR = new UserUR();
         userUR.setKey(userTO.getKey());
         userUR.getPlainAttrs().add(attrAddReplacePatch("makeItDouble", "7"));
 
         userTO = updateUser(userUR).getEntity();
-        assertEquals("14", userTO.getPlainAttr("makeItDouble").orElseThrow().getValues().get(0));
+        assertEquals("14", userTO.getPlainAttr("makeItDouble").orElseThrow().getValues().getFirst());
     }
 
     @Test
@@ -901,8 +901,8 @@ public class UserIssuesITCase extends AbstractITCase {
         assertNotNull(result);
         userTO = result.getEntity();
         assertEquals(Set.of(RESOURCE_NAME_WS1), userTO.getResources());
-        assertNotEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
-        assertTrue(result.getPropagationStatuses().get(0).getFailureReason().
+        assertNotEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
+        assertTrue(result.getPropagationStatuses().getFirst().getFailureReason().
                 startsWith("Not attempted because there are mandatory attributes without value(s): [__PASSWORD__]"));
     }
 
@@ -920,9 +920,9 @@ public class UserIssuesITCase extends AbstractITCase {
 
         // 3. try (and succeed) to perform simple LDAP binding with provided password ('password123')
         assertNotNull(getLdapRemoteObject(
-                connObject.getAttr(Name.NAME).orElseThrow().getValues().get(0),
+                connObject.getAttr(Name.NAME).orElseThrow().getValues().getFirst(),
                 "password123",
-                connObject.getAttr(Name.NAME).orElseThrow().getValues().get(0)));
+                connObject.getAttr(Name.NAME).orElseThrow().getValues().getFirst()));
 
         // 4. update user without any password change request
         UserUR userUR = new UserUR();
@@ -934,9 +934,9 @@ public class UserIssuesITCase extends AbstractITCase {
 
         // 5. try (and succeed again) to perform simple LDAP binding: password has not changed
         assertNotNull(getLdapRemoteObject(
-                connObject.getAttr(Name.NAME).orElseThrow().getValues().get(0),
+                connObject.getAttr(Name.NAME).orElseThrow().getValues().getFirst(),
                 "password123",
-                connObject.getAttr(Name.NAME).orElseThrow().getValues().get(0)));
+                connObject.getAttr(Name.NAME).orElseThrow().getValues().getFirst()));
     }
 
     @Test
@@ -947,7 +947,7 @@ public class UserIssuesITCase extends AbstractITCase {
         ProvisioningResult<UserTO> result = createUser(userCR);
         assertNotNull(result);
         assertEquals(1, result.getPropagationStatuses().size());
-        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
+        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
         UserTO userTO = result.getEntity();
 
         ConnObject actual =
@@ -986,14 +986,14 @@ public class UserIssuesITCase extends AbstractITCase {
         result = updateUser(userUR);
         assertNotNull(userTO);
         assertEquals(1, result.getPropagationStatuses().size());
-        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
+        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
         userTO = result.getEntity();
 
         ConnObject newUser =
                 RESOURCE_SERVICE.readConnObject(RESOURCE_NAME_WS1, AnyTypeKind.USER.name(), userTO.getKey());
 
         assertNotNull(newUser.getAttr("NAME"));
-        assertEquals("firstnameNew", newUser.getAttr("NAME").orElseThrow().getValues().get(0));
+        assertEquals("firstnameNew", newUser.getAttr("NAME").orElseThrow().getValues().getFirst());
 
         // 4.  restore resource ws-target-resource-1 mapping
         ws1NewUMapping = newWs1.getProvision(AnyTypeKind.USER.name()).orElseThrow().getMapping();
@@ -1092,15 +1092,15 @@ public class UserIssuesITCase extends AbstractITCase {
                 RESOURCE_SERVICE.readConnObject(RESOURCE_NAME_LDAP, AnyTypeKind.USER.name(), user.getKey());
 
         assertNotNull(getLdapRemoteObject(
-                connObject.getAttr(Name.NAME).orElseThrow().getValues().get(0),
+                connObject.getAttr(Name.NAME).orElseThrow().getValues().getFirst(),
                 "security123",
-                connObject.getAttr(Name.NAME).orElseThrow().getValues().get(0)));
+                connObject.getAttr(Name.NAME).orElseThrow().getValues().getFirst()));
 
         // 5. Remove LDAPPasswordPropagationActions
         resourceTO = RESOURCE_SERVICE.read(RESOURCE_NAME_LDAP);
         assertNotNull(resourceTO);
         resourceTO.getPropagationActions().remove(LDAPPasswordPropagationActions.class.getSimpleName());
-        resourceTO.getPropagationActions().add(0, GenerateRandomPasswordPropagationActions.class.getSimpleName());
+        resourceTO.getPropagationActions().addFirst(GenerateRandomPasswordPropagationActions.class.getSimpleName());
         RESOURCE_SERVICE.update(resourceTO);
     }
 
@@ -1142,7 +1142,7 @@ public class UserIssuesITCase extends AbstractITCase {
         // check if password has not changed
         assertEquals(
                 "password0",
-                connObjectTO.getAttr(OperationalAttributes.PASSWORD_NAME).orElseThrow().getValues().get(0));
+                connObjectTO.getAttr(OperationalAttributes.PASSWORD_NAME).orElseThrow().getValues().getFirst());
         assertNull(userTO.getPassword());
 
         // 3. create user with not null password and propagate onto resource-csv, specify not to save password on
@@ -1164,7 +1164,7 @@ public class UserIssuesITCase extends AbstractITCase {
         // check if password has been propagated and that saved userTO's password is null
         assertEquals(
                 "passwordTESTNULL1",
-                connObjectTO.getAttr(OperationalAttributes.PASSWORD_NAME).orElseThrow().getValues().get(0));
+                connObjectTO.getAttr(OperationalAttributes.PASSWORD_NAME).orElseThrow().getValues().getFirst());
         assertNull(userTO.getPassword());
 
         // 4. create user and propagate password on resource-csv and on Syncope local storage
@@ -1184,7 +1184,7 @@ public class UserIssuesITCase extends AbstractITCase {
         // check if password has been correctly propagated on Syncope and resource-csv as usual
         assertEquals(
                 "passwordTESTNULL1",
-                connObjectTO.getAttr(OperationalAttributes.PASSWORD_NAME).orElseThrow().getValues().get(0));
+                connObjectTO.getAttr(OperationalAttributes.PASSWORD_NAME).orElseThrow().getValues().getFirst());
         Triple<Map<String, Set<String>>, List<String>, UserTO> self =
                 CLIENT_FACTORY.create(userTO.getUsername(), "passwordTESTNULL1").self();
         assertNotNull(self);
@@ -1237,7 +1237,7 @@ public class UserIssuesITCase extends AbstractITCase {
         ConnObject connObjectTO =
                 RESOURCE_SERVICE.readConnObject(RESOURCE_NAME_LDAP, AnyTypeKind.USER.name(), actual.getKey());
         assertNotNull(connObjectTO);
-        assertEquals("postalAddress", connObjectTO.getAttr("postalAddress").orElseThrow().getValues().get(0));
+        assertEquals("postalAddress", connObjectTO.getAttr("postalAddress").orElseThrow().getValues().getFirst());
 
         UserUR userUR = new UserUR();
         userUR.setKey(actual.getKey());
@@ -1247,7 +1247,7 @@ public class UserIssuesITCase extends AbstractITCase {
 
         connObjectTO = RESOURCE_SERVICE.readConnObject(RESOURCE_NAME_LDAP, AnyTypeKind.USER.name(), actual.getKey());
         assertNotNull(connObjectTO);
-        assertEquals("newPostalAddress", connObjectTO.getAttr("postalAddress").orElseThrow().getValues().get(0));
+        assertEquals("newPostalAddress", connObjectTO.getAttr("postalAddress").orElseThrow().getValues().getFirst());
     }
 
     @Test
@@ -1270,7 +1270,7 @@ public class UserIssuesITCase extends AbstractITCase {
         passwordPolicy = createPolicy(PolicyType.PASSWORD, passwordPolicy);
         assertNotNull(passwordPolicy);
 
-        RealmTO realm = REALM_SERVICE.search(new RealmQuery.Builder().keyword("two").build()).getResult().get(0);
+        RealmTO realm = REALM_SERVICE.search(new RealmQuery.Builder().keyword("two").build()).getResult().getFirst();
         String oldPasswordPolicy = realm.getPasswordPolicy();
         realm.setPasswordPolicy(passwordPolicy.getKey());
         REALM_SERVICE.update(realm);
@@ -1335,7 +1335,7 @@ public class UserIssuesITCase extends AbstractITCase {
             List<PropagationStatus> props = result.getPropagationStatuses();
             assertNotNull(props);
             assertEquals(1, props.size());
-            PropagationStatus prop = props.get(0);
+            PropagationStatus prop = props.getFirst();
             assertNotNull(prop);
             assertEquals(RESOURCE_NAME_LDAP, prop.getResource());
             assertEquals(ExecStatus.SUCCESS, prop.getStatus());
@@ -1377,7 +1377,7 @@ public class UserIssuesITCase extends AbstractITCase {
 
         result = updateUser(userUR);
         assertEquals(1, result.getPropagationStatuses().size());
-        assertEquals(RESOURCE_NAME_TESTDB, result.getPropagationStatuses().get(0).getResource());
+        assertEquals(RESOURCE_NAME_TESTDB, result.getPropagationStatuses().getFirst().getResource());
     }
 
     @Test
@@ -1405,13 +1405,13 @@ public class UserIssuesITCase extends AbstractITCase {
         Attr userDn = connObject.getAttr(Name.NAME).orElseThrow();
         assertNotNull(userDn);
         assertEquals(1, userDn.getValues().size());
-        assertNotNull(getLdapRemoteObject(RESOURCE_LDAP_ADMIN_DN, RESOURCE_LDAP_ADMIN_PWD, userDn.getValues().get(0)));
+        assertNotNull(getLdapRemoteObject(RESOURCE_LDAP_ADMIN_DN, RESOURCE_LDAP_ADMIN_PWD, userDn.getValues().getFirst()));
 
         // 4. remove user
         USER_SERVICE.delete(user.getKey());
 
         // 5. verify that user is not in LDAP anymore
-        assertNull(getLdapRemoteObject(RESOURCE_LDAP_ADMIN_DN, RESOURCE_LDAP_ADMIN_PWD, userDn.getValues().get(0)));
+        assertNull(getLdapRemoteObject(RESOURCE_LDAP_ADMIN_DN, RESOURCE_LDAP_ADMIN_PWD, userDn.getValues().getFirst()));
     }
 
     @Test
@@ -1440,7 +1440,7 @@ public class UserIssuesITCase extends AbstractITCase {
 
         // 4. verify that propagation happened towards the resource of the dynamic group
         assertFalse(created.getPropagationStatuses().isEmpty());
-        assertEquals(RESOURCE_NAME_TESTDB, created.getPropagationStatuses().get(0).getResource());
+        assertEquals(RESOURCE_NAME_TESTDB, created.getPropagationStatuses().getFirst().getResource());
     }
 
     @Test
@@ -1497,7 +1497,7 @@ public class UserIssuesITCase extends AbstractITCase {
 
         result = updateUser(userUR);
         assertEquals(1, result.getPropagationStatuses().size());
-        assertEquals(RESOURCE_NAME_LDAP, result.getPropagationStatuses().get(0).getResource());
+        assertEquals(RESOURCE_NAME_LDAP, result.getPropagationStatuses().getFirst().getResource());
 
         // 4. update again user to not match the dynamic condition any more: expect propagation to LDAP
         userUR = new UserUR();
@@ -1506,7 +1506,7 @@ public class UserIssuesITCase extends AbstractITCase {
 
         result = updateUser(userUR);
         assertEquals(1, result.getPropagationStatuses().size());
-        assertEquals(RESOURCE_NAME_LDAP, result.getPropagationStatuses().get(0).getResource());
+        assertEquals(RESOURCE_NAME_LDAP, result.getPropagationStatuses().getFirst().getResource());
     }
 
     @Test
@@ -1521,7 +1521,7 @@ public class UserIssuesITCase extends AbstractITCase {
         PasswordPolicyTO pwdPolicy = POLICY_SERVICE.read(PolicyType.PASSWORD, "ce93fcda-dc3a-4369-a7b0-a6108c261c85");
         assertEquals(1, pwdPolicy.getHistoryLength());
 
-        RealmTO evenTwo = REALM_SERVICE.search(new RealmQuery.Builder().keyword("two").build()).getResult().get(0);
+        RealmTO evenTwo = REALM_SERVICE.search(new RealmQuery.Builder().keyword("two").build()).getResult().getFirst();
         evenTwo.setPasswordPolicy(pwdPolicy.getKey());
         REALM_SERVICE.update(evenTwo);
 
@@ -1694,19 +1694,19 @@ public class UserIssuesITCase extends AbstractITCase {
             // 2. create
             ProvisioningResult<UserTO> result = createUser(userCR);
             assertEquals(1, result.getPropagationStatuses().size());
-            assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
-            assertEquals(RESOURCE_NAME_REST, result.getPropagationStatuses().get(0).getResource());
-            assertEquals("surname", result.getEntity().getPlainAttr("surname").orElseThrow().getValues().get(0));
+            assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
+            assertEquals(RESOURCE_NAME_REST, result.getPropagationStatuses().getFirst().getResource());
+            assertEquals("surname", result.getEntity().getPlainAttr("surname").orElseThrow().getValues().getFirst());
             // externalKey is going to be populated on create
             assertTrue(result.getEntity().getPlainAttr("externalKey").isPresent());
             assertEquals(result.getEntity().getKey(),
-                    result.getEntity().getPlainAttr("externalKey").orElseThrow().getValues().get(0));
+                    result.getEntity().getPlainAttr("externalKey").orElseThrow().getValues().getFirst());
             // 3. remove resource from the user
             result = updateUser(new UserUR.Builder(result.getEntity()
                     .getKey()).resource(new StringPatchItem.Builder().value(RESOURCE_NAME_REST)
                     .operation(PatchOperation.DELETE)
                     .build()).build());
-            assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
+            assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
             // externalKey is going to be removed on resource unassignment
             assertFalse(result.getEntity().getPlainAttr("externalKey").isPresent());
 
@@ -1715,7 +1715,7 @@ public class UserIssuesITCase extends AbstractITCase {
             userCR.getResources().clear();
             userCR.getResources().add(RESOURCE_NAME_REST);
             result = createUser(userCR);
-            assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
+            assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
             // this time fire a deprovision
             assertNotNull(parseBatchResponse(USER_SERVICE.deassociate(new ResourceDR.Builder().key(result.getEntity()
                     .getKey()).action(ResourceDeassociationAction.DEPROVISION).resource(RESOURCE_NAME_REST).build())));
@@ -1727,7 +1727,7 @@ public class UserIssuesITCase extends AbstractITCase {
             userCR.getResources().clear();
             userCR.getResources().add(RESOURCE_NAME_REST);
             result = createUser(userCR);
-            assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
+            assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
             // this time deprovision
             assertNotNull(parseBatchResponse(USER_SERVICE.deassociate(new ResourceDR.Builder().key(result.getEntity()
                     .getKey()).action(ResourceDeassociationAction.UNLINK).resource(RESOURCE_NAME_REST).build())));
@@ -1794,7 +1794,7 @@ public class UserIssuesITCase extends AbstractITCase {
             ReconStatus onLDAP = RECONCILIATION_SERVICE.status(new ReconQuery.Builder(AnyTypeKind.USER.name(),
                     RESOURCE_NAME_LDAP).anyKey(rossini.getKey()).build());
             Attr enableAttr = onLDAP.getOnResource().getAttr(OperationalAttributes.ENABLE_NAME).orElseThrow();
-            assertFalse(Boolean.parseBoolean(enableAttr.getValues().get(0)));
+            assertFalse(Boolean.parseBoolean(enableAttr.getValues().getFirst()));
 
             // 6. re-enable on resource-db-pull and restore old values to fire a propagation towards resource-ldap
             jdbcTemplate.update("UPDATE TESTPULL SET EMAIL = 'rossini.gioacchino@apache.org', STATUS = "
@@ -1822,7 +1822,7 @@ public class UserIssuesITCase extends AbstractITCase {
                 onLDAP = RECONCILIATION_SERVICE.status(new ReconQuery.Builder(
                         AnyTypeKind.USER.name(), RESOURCE_NAME_LDAP).anyKey(rossini.getKey()).build());
                 enableAttr = onLDAP.getOnResource().getAttr(OperationalAttributes.ENABLE_NAME).orElseThrow();
-                assertTrue(Boolean.parseBoolean(enableAttr.getValues().get(0)));
+                assertTrue(Boolean.parseBoolean(enableAttr.getValues().getFirst()));
             }
         } finally {
             // restore attributes and (if needed) status

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/UserRequestITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/UserRequestITCase.java
@@ -101,11 +101,11 @@ public class UserRequestITCase extends AbstractITCase {
         PagedResult<UserRequest> requests = client.getService(UserRequestService.class).
                 listRequests(new UserRequestQuery.Builder().user(user.getKey()).build());
         assertEquals(1, requests.getTotalCount());
-        assertEquals("directorGroupRequest", requests.getResult().get(0).getBpmnProcess());
+        assertEquals("directorGroupRequest", requests.getResult().getFirst().getBpmnProcess());
 
         // 1st approval -> reject
         UserRequestForm form = USER_REQUEST_SERVICE.listForms(
-                new UserRequestQuery.Builder().user(user.getKey()).build()).getResult().get(0);
+                new UserRequestQuery.Builder().user(user.getKey()).build()).getResult().getFirst();
         form = USER_REQUEST_SERVICE.claimForm(form.getTaskId());
         form.getProperty("firstLevelApprove").get().setValue(Boolean.FALSE.toString());
         USER_REQUEST_SERVICE.submitForm(form);
@@ -121,14 +121,14 @@ public class UserRequestITCase extends AbstractITCase {
 
         // 1st approval -> accept
         form = USER_REQUEST_SERVICE.listForms(
-                new UserRequestQuery.Builder().user(user.getKey()).build()).getResult().get(0);
+                new UserRequestQuery.Builder().user(user.getKey()).build()).getResult().getFirst();
         form = USER_REQUEST_SERVICE.claimForm(form.getTaskId());
         form.getProperty("firstLevelApprove").get().setValue(Boolean.TRUE.toString());
         USER_REQUEST_SERVICE.submitForm(form);
 
         // 2nd approval -> reject
         form = USER_REQUEST_SERVICE.listForms(
-                new UserRequestQuery.Builder().user(user.getKey()).build()).getResult().get(0);
+                new UserRequestQuery.Builder().user(user.getKey()).build()).getResult().getFirst();
         form = USER_REQUEST_SERVICE.claimForm(form.getTaskId());
         form.getProperty("secondLevelApprove").get().setValue(Boolean.FALSE.toString());
         user = USER_REQUEST_SERVICE.submitForm(form).readEntity(new GenericType<ProvisioningResult<UserTO>>() {
@@ -145,14 +145,14 @@ public class UserRequestITCase extends AbstractITCase {
 
         // 1st approval -> accept
         form = USER_REQUEST_SERVICE.listForms(
-                new UserRequestQuery.Builder().user(user.getKey()).build()).getResult().get(0);
+                new UserRequestQuery.Builder().user(user.getKey()).build()).getResult().getFirst();
         form = USER_REQUEST_SERVICE.claimForm(form.getTaskId());
         form.getProperty("firstLevelApprove").get().setValue(Boolean.TRUE.toString());
         USER_REQUEST_SERVICE.submitForm(form);
 
         // 2nd approval -> accept
         form = USER_REQUEST_SERVICE.listForms(
-                new UserRequestQuery.Builder().user(user.getKey()).build()).getResult().get(0);
+                new UserRequestQuery.Builder().user(user.getKey()).build()).getResult().getFirst();
         form = USER_REQUEST_SERVICE.claimForm(form.getTaskId());
         form.getProperty("secondLevelApprove").get().setValue(Boolean.TRUE.toString());
         user = USER_REQUEST_SERVICE.submitForm(form).readEntity(new GenericType<ProvisioningResult<UserTO>>() {
@@ -227,7 +227,7 @@ public class UserRequestITCase extends AbstractITCase {
                 new UserRequestQuery.Builder().user(user.getKey()).build());
         assertEquals(1, userForms.getTotalCount());
 
-        UserRequestForm form = userForms.getResult().get(0);
+        UserRequestForm form = userForms.getResult().getFirst();
         assertEquals("assignPrinterRequest", form.getBpmnProcess());
         form = service.claimForm(form.getTaskId());
 
@@ -246,11 +246,11 @@ public class UserRequestITCase extends AbstractITCase {
         PagedResult<UserRequest> requests = service.listRequests(
                 new UserRequestQuery.Builder().user(user.getKey()).build());
         assertEquals(1, requests.getTotalCount());
-        assertEquals("assignPrinterRequest", requests.getResult().get(0).getBpmnProcess());
+        assertEquals("assignPrinterRequest", requests.getResult().getFirst().getBpmnProcess());
 
         // get (as admin) the new form, claim and submit
         form = USER_REQUEST_SERVICE.listForms(
-                new UserRequestQuery.Builder().user(user.getKey()).build()).getResult().get(0);
+                new UserRequestQuery.Builder().user(user.getKey()).build()).getResult().getFirst();
         assertEquals("assignPrinterRequest", form.getBpmnProcess());
         form = USER_REQUEST_SERVICE.claimForm(form.getTaskId());
 
@@ -300,7 +300,7 @@ public class UserRequestITCase extends AbstractITCase {
                 new UserRequestQuery.Builder().user(user.getKey()).build());
         assertEquals(1, userForms.getTotalCount());
 
-        UserRequestForm form = userForms.getResult().get(0);
+        UserRequestForm form = userForms.getResult().getFirst();
         form = USER_REQUEST_SERVICE.claimForm(form.getTaskId());
         assertEquals(form.getProperty("providedVariable").get().getValue(), "test");
 

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/UserSelfITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/UserSelfITCase.java
@@ -124,7 +124,7 @@ public class UserSelfITCase extends AbstractITCase {
 
         // 2. now approve and verify that propagation has happened
         UserRequestForm form = USER_REQUEST_SERVICE.listForms(
-                new UserRequestQuery.Builder().user(userTO.getKey()).build()).getResult().get(0);
+                new UserRequestQuery.Builder().user(userTO.getKey()).build()).getResult().getFirst();
         form = USER_REQUEST_SERVICE.claimForm(form.getTaskId());
         form.getProperty("approveCreate").get().setValue(Boolean.TRUE.toString());
         userTO = USER_REQUEST_SERVICE.submitForm(form).readEntity(new GenericType<ProvisioningResult<UserTO>>() {
@@ -160,7 +160,7 @@ public class UserSelfITCase extends AbstractITCase {
 
         // 2. unclaim and verify that propagation has NOT happened
         UserRequestForm form = USER_REQUEST_SERVICE.listForms(
-                new UserRequestQuery.Builder().user(userTO.getKey()).build()).getResult().get(0);
+                new UserRequestQuery.Builder().user(userTO.getKey()).build()).getResult().getFirst();
         form = USER_REQUEST_SERVICE.unclaimForm(form.getTaskId());
         assertNull(form.getAssignee());
         assertNotNull(userTO);
@@ -174,7 +174,7 @@ public class UserSelfITCase extends AbstractITCase {
 
         // 3. approve and verify that propagation has happened
         form = USER_REQUEST_SERVICE.listForms(
-                new UserRequestQuery.Builder().user(userTO.getKey()).build()).getResult().get(0);
+                new UserRequestQuery.Builder().user(userTO.getKey()).build()).getResult().getFirst();
         form = USER_REQUEST_SERVICE.claimForm(form.getTaskId());
         form.getProperty("approveCreate").get().setValue(Boolean.TRUE.toString());
         userTO = USER_REQUEST_SERVICE.submitForm(form).readEntity(new GenericType<ProvisioningResult<UserTO>>() {
@@ -204,7 +204,7 @@ public class UserSelfITCase extends AbstractITCase {
     public void authenticateByPlainAttribute() {
         UserTO rossini = USER_SERVICE.read("rossini");
         assertNotNull(rossini);
-        String userId = rossini.getPlainAttr("userId").get().getValues().get(0);
+        String userId = rossini.getPlainAttr("userId").get().getValues().getFirst();
         assertNotNull(userId);
 
         Triple<Map<String, Set<String>>, List<String>, UserTO> self = CLIENT_FACTORY.create(userId, ADMIN_PWD).self();
@@ -274,7 +274,7 @@ public class UserSelfITCase extends AbstractITCase {
 
         // 3. approve self-update as admin
         UserRequestForm form = USER_REQUEST_SERVICE.listForms(
-                new UserRequestQuery.Builder().user(updated.getKey()).build()).getResult().get(0);
+                new UserRequestQuery.Builder().user(updated.getKey()).build()).getResult().getFirst();
         form = USER_REQUEST_SERVICE.claimForm(form.getTaskId());
         form.getProperty("approveUpdate").get().setValue(Boolean.TRUE.toString());
         updated = USER_REQUEST_SERVICE.submitForm(form).readEntity(new GenericType<ProvisioningResult<UserTO>>() {
@@ -465,12 +465,12 @@ public class UserSelfITCase extends AbstractITCase {
         UserTO userTO = createUser(userCR).getEntity();
         assertNotNull(userTO);
         assertEquals(1, userTO.getMemberships().size());
-        assertEquals("0cbcabd2-4410-4b6b-8f05-a052b451d18f", userTO.getMemberships().get(0).getGroupKey());
+        assertEquals("0cbcabd2-4410-4b6b-8f05-a052b451d18f", userTO.getMemberships().getFirst().getGroupKey());
         assertEquals("createApproval", userTO.getStatus());
 
         // 2. request if there is any pending task for user just created
         UserRequestForm form = USER_REQUEST_SERVICE.listForms(
-                new UserRequestQuery.Builder().user(userTO.getKey()).build()).getResult().get(0);
+                new UserRequestQuery.Builder().user(userTO.getKey()).build()).getResult().getFirst();
         assertNotNull(form);
         assertNotNull(form.getUsername());
         assertEquals(userTO.getUsername(), form.getUsername());
@@ -547,7 +547,7 @@ public class UserSelfITCase extends AbstractITCase {
         assertNotNull(result);
         UserTO userTO = result.getEntity();
         assertEquals(1, userTO.getMemberships().size());
-        assertEquals("0cbcabd2-4410-4b6b-8f05-a052b451d18f", userTO.getMemberships().get(0).getGroupKey());
+        assertEquals("0cbcabd2-4410-4b6b-8f05-a052b451d18f", userTO.getMemberships().getFirst().getGroupKey());
         assertEquals("createApproval", userTO.getStatus());
         assertEquals(Set.of(RESOURCE_NAME_TESTDB), userTO.getResources());
 
@@ -575,7 +575,7 @@ public class UserSelfITCase extends AbstractITCase {
         updateUser(userUR);
 
         UserRequestForm form = USER_REQUEST_SERVICE.listForms(
-                new UserRequestQuery.Builder().user(userTO.getKey()).build()).getResult().get(0);
+                new UserRequestQuery.Builder().user(userTO.getKey()).build()).getResult().getFirst();
         assertNotNull(form);
         assertNotNull(form.getTaskId());
         assertNotNull(form.getUserTO());
@@ -641,7 +641,7 @@ public class UserSelfITCase extends AbstractITCase {
         assertEquals(preForms + 1, forms.getTotalCount());
 
         UserRequestForm form = USER_REQUEST_SERVICE.listForms(
-                new UserRequestQuery.Builder().user(created.getKey()).build()).getResult().get(0);
+                new UserRequestQuery.Builder().user(created.getKey()).build()).getResult().getFirst();
         assertNotNull(form);
         assertNotNull(form.getTaskId());
         assertNull(form.getAssignee());
@@ -661,7 +661,7 @@ public class UserSelfITCase extends AbstractITCase {
 
         // the patch is not updated in the approval form
         form = USER_REQUEST_SERVICE.listForms(
-                new UserRequestQuery.Builder().user(created.getKey()).build()).getResult().get(0);
+                new UserRequestQuery.Builder().user(created.getKey()).build()).getResult().getFirst();
         assertEquals(req, form.getUserUR());
 
         // approve the user
@@ -716,7 +716,7 @@ public class UserSelfITCase extends AbstractITCase {
         assertEquals(preForms + 1, forms.getTotalCount());
 
         UserRequestForm form = USER_REQUEST_SERVICE.listForms(
-                new UserRequestQuery.Builder().user(userTO.getEntity().getKey()).build()).getResult().get(0);
+                new UserRequestQuery.Builder().user(userTO.getEntity().getKey()).build()).getResult().getFirst();
         assertNotNull(form);
 
         // 3. first claim by bellini ....

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/VirAttrITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/VirAttrITCase.java
@@ -80,7 +80,7 @@ public class VirAttrITCase extends AbstractITCase {
         // 2. check for virtual attribute value
         userTO = USER_SERVICE.read(userTO.getKey());
         assertNotNull(userTO);
-        assertEquals("virtualvalue", userTO.getVirAttr("virtualdata").get().getValues().get(0));
+        assertEquals("virtualvalue", userTO.getVirAttr("virtualdata").get().getValues().getFirst());
 
         UserUR userUR = new UserUR();
         userUR.setKey(userTO.getKey());
@@ -93,7 +93,7 @@ public class VirAttrITCase extends AbstractITCase {
         // 4. check for virtual attribute value
         userTO = USER_SERVICE.read(userTO.getKey());
         assertNotNull(userTO);
-        assertEquals("virtualupdated", userTO.getVirAttr("virtualdata").get().getValues().get(0));
+        assertEquals("virtualupdated", userTO.getVirAttr("virtualdata").get().getValues().getFirst());
     }
 
     @Test
@@ -129,13 +129,13 @@ public class VirAttrITCase extends AbstractITCase {
         ProvisioningResult<UserTO> result = createUser(userCR);
         assertNotNull(result);
         assertFalse(result.getPropagationStatuses().isEmpty());
-        assertEquals(RESOURCE_NAME_WS2, result.getPropagationStatuses().get(0).getResource());
-        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
+        assertEquals(RESOURCE_NAME_WS2, result.getPropagationStatuses().getFirst().getResource());
+        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
         UserTO userTO = result.getEntity();
 
         ConnObject connObjectTO =
                 RESOURCE_SERVICE.readConnObject(RESOURCE_NAME_WS2, AnyTypeKind.USER.name(), userTO.getKey());
-        assertEquals("virtualvalue", connObjectTO.getAttr("COMPANYNAME").get().getValues().get(0));
+        assertEquals("virtualvalue", connObjectTO.getAttr("COMPANYNAME").get().getValues().getFirst());
         // ----------------------------------
 
         // ----------------------------------
@@ -148,12 +148,12 @@ public class VirAttrITCase extends AbstractITCase {
         result = updateUser(userUR);
         assertNotNull(result);
         assertFalse(result.getPropagationStatuses().isEmpty());
-        assertEquals(RESOURCE_NAME_WS2, result.getPropagationStatuses().get(0).getResource());
-        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
+        assertEquals(RESOURCE_NAME_WS2, result.getPropagationStatuses().getFirst().getResource());
+        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
         userTO = result.getEntity();
 
         connObjectTO = RESOURCE_SERVICE.readConnObject(RESOURCE_NAME_WS2, AnyTypeKind.USER.name(), userTO.getKey());
-        assertEquals("virtualvalue2", connObjectTO.getAttr("COMPANYNAME").get().getValues().get(0));
+        assertEquals("virtualvalue2", connObjectTO.getAttr("COMPANYNAME").get().getValues().getFirst());
         // ----------------------------------
 
         // ----------------------------------
@@ -165,7 +165,7 @@ public class VirAttrITCase extends AbstractITCase {
         assertEquals("suspended", userTO.getStatus());
 
         connObjectTO = RESOURCE_SERVICE.readConnObject(RESOURCE_NAME_WS2, AnyTypeKind.USER.name(), userTO.getKey());
-        assertEquals("virtualvalue2", connObjectTO.getAttr("COMPANYNAME").get().getValues().get(0));
+        assertEquals("virtualvalue2", connObjectTO.getAttr("COMPANYNAME").get().getValues().getFirst());
 
         statusR = new StatusR.Builder(userTO.getKey(), StatusRType.REACTIVATE).build();
         userTO = USER_SERVICE.status(statusR).readEntity(new GenericType<ProvisioningResult<UserTO>>() {
@@ -173,7 +173,7 @@ public class VirAttrITCase extends AbstractITCase {
         assertEquals("active", userTO.getStatus());
 
         connObjectTO = RESOURCE_SERVICE.readConnObject(RESOURCE_NAME_WS2, AnyTypeKind.USER.name(), userTO.getKey());
-        assertEquals("virtualvalue2", connObjectTO.getAttr("COMPANYNAME").get().getValues().get(0));
+        assertEquals("virtualvalue2", connObjectTO.getAttr("COMPANYNAME").get().getValues().getFirst());
         // ----------------------------------
 
         // ----------------------------------
@@ -186,16 +186,16 @@ public class VirAttrITCase extends AbstractITCase {
         result = updateUser(userUR);
         assertNotNull(result);
         assertFalse(result.getPropagationStatuses().isEmpty());
-        assertEquals(RESOURCE_NAME_WS2, result.getPropagationStatuses().get(0).getResource());
-        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().get(0).getStatus());
+        assertEquals(RESOURCE_NAME_WS2, result.getPropagationStatuses().getFirst().getResource());
+        assertEquals(ExecStatus.SUCCESS, result.getPropagationStatuses().getFirst().getStatus());
         userTO = result.getEntity();
 
         connObjectTO = RESOURCE_SERVICE.readConnObject(RESOURCE_NAME_WS2, AnyTypeKind.USER.name(), userTO.getKey());
-        assertEquals("Surname2", connObjectTO.getAttr("SURNAME").get().getValues().get(0));
+        assertEquals("Surname2", connObjectTO.getAttr("SURNAME").get().getValues().getFirst());
 
         // virtual attribute value did not change
         assertFalse(connObjectTO.getAttr("COMPANYNAME").get().getValues().isEmpty());
-        assertEquals("virtualvalue2", connObjectTO.getAttr("COMPANYNAME").get().getValues().get(0));
+        assertEquals("virtualvalue2", connObjectTO.getAttr("COMPANYNAME").get().getValues().getFirst());
         // ----------------------------------
     }
 
@@ -219,7 +219,7 @@ public class VirAttrITCase extends AbstractITCase {
 
         // 2. check for virtual attribute value
         actual = USER_SERVICE.read(actual.getKey());
-        assertEquals("virattrcache", actual.getVirAttr("virtualdata").get().getValues().get(0));
+        assertEquals("virattrcache", actual.getVirAttr("virtualdata").get().getValues().getFirst());
 
         // 3. update virtual attribute directly
         JdbcTemplate jdbcTemplate = new JdbcTemplate(testDataSource);
@@ -235,7 +235,7 @@ public class VirAttrITCase extends AbstractITCase {
 
         // 4. check for cached attribute value
         actual = USER_SERVICE.read(actual.getKey());
-        assertEquals("virattrcache", actual.getVirAttr("virtualdata").get().getValues().get(0));
+        assertEquals("virattrcache", actual.getVirAttr("virtualdata").get().getValues().getFirst());
 
         UserUR userUR = new UserUR();
         userUR.setKey(actual.getKey());
@@ -248,7 +248,7 @@ public class VirAttrITCase extends AbstractITCase {
         // 6. check for virtual attribute value
         actual = USER_SERVICE.read(actual.getKey());
         assertNotNull(actual);
-        assertEquals("virtualupdated", actual.getVirAttr("virtualdata").get().getValues().get(0));
+        assertEquals("virtualupdated", actual.getVirAttr("virtualdata").get().getValues().getFirst());
     }
 
     @Test
@@ -258,18 +258,18 @@ public class VirAttrITCase extends AbstractITCase {
         ResourceTO csv = RESOURCE_SERVICE.read(RESOURCE_NAME_CSV);
 
         // change mapping of resource-csv
-        Mapping origMapping = SerializationUtils.clone(csv.getProvisions().get(0).getMapping());
+        Mapping origMapping = SerializationUtils.clone(csv.getProvisions().getFirst().getMapping());
         try {
             // remove this mapping
-            Optional<Item> email = csv.getProvisions().get(0).getMapping().getItems().stream().
+            Optional<Item> email = csv.getProvisions().getFirst().getMapping().getItems().stream().
                     filter(item -> "email".equals(item.getIntAttrName())).findFirst();
             if (email.isPresent()) {
-                csv.getProvisions().get(0).getMapping().getItems().remove(email.get());
+                csv.getProvisions().getFirst().getMapping().getItems().remove(email.get());
             }
 
             RESOURCE_SERVICE.update(csv);
             csv = RESOURCE_SERVICE.read(RESOURCE_NAME_CSV);
-            assertNotNull(csv.getProvisions().get(0).getMapping());
+            assertNotNull(csv.getProvisions().getFirst().getMapping());
 
             // create new virtual schema for the resource below
             Provision provision = csv.getProvision(AnyTypeKind.USER.name()).get();
@@ -306,7 +306,7 @@ public class VirAttrITCase extends AbstractITCase {
             // make std controls about user
             assertNotNull(userTO);
             assertTrue(RESOURCE_NAME_CSV.equals(userTO.getResources().iterator().next()));
-            assertEquals("test@testone.org", userTO.getVirAttrs().iterator().next().getValues().get(0));
+            assertEquals("test@testone.org", userTO.getVirAttrs().iterator().next().getValues().getFirst());
 
             // update user
             UserTO toBeUpdated = USER_SERVICE.read(userTO.getKey());
@@ -334,7 +334,7 @@ public class VirAttrITCase extends AbstractITCase {
             assertEquals(2, result.getPropagationStatuses().size());
         } finally {
             // restore mapping of resource-csv
-            csv.getProvisions().get(0).setMapping(origMapping);
+            csv.getProvisions().getFirst().setMapping(origMapping);
             RESOURCE_SERVICE.update(csv);
         }
     }
@@ -359,7 +359,7 @@ public class VirAttrITCase extends AbstractITCase {
 
         // 2. check for virtual attribute value
         userTO = USER_SERVICE.read(userTO.getKey());
-        assertEquals("virattrcache", userTO.getVirAttr("virtualdata").get().getValues().get(0));
+        assertEquals("virattrcache", userTO.getVirAttr("virtualdata").get().getValues().getFirst());
 
         // ----------------------------------------
         // 3. change connector URL so that we are sure that any provided value will come from virtual cache
@@ -369,7 +369,7 @@ public class VirAttrITCase extends AbstractITCase {
                 RESOURCE_NAME_DBVIRATTR, Locale.ENGLISH.getLanguage());
         for (ConnConfProperty prop : connInstanceTO.getConf()) {
             if ("jdbcUrlTemplate".equals(prop.getSchema().getName())) {
-                jdbcURL = prop.getValues().iterator().next().toString();
+                jdbcURL = prop.getValues().getFirst().toString();
                 prop.getValues().clear();
                 prop.getValues().add("jdbc:h2:tcp://localhost:9092/xxx");
             }
@@ -395,7 +395,7 @@ public class VirAttrITCase extends AbstractITCase {
         // ----------------------------------------
 
         userTO = USER_SERVICE.read(userTO.getKey());
-        assertEquals("virattrcache", userTO.getVirAttr("virtualdata").get().getValues().get(0));
+        assertEquals("virattrcache", userTO.getVirAttr("virtualdata").get().getValues().getFirst());
 
         // ----------------------------------------
         // 5. restore connector URL, values can be read again from external resource
@@ -412,7 +412,7 @@ public class VirAttrITCase extends AbstractITCase {
 
         // cached value still in place...
         userTO = USER_SERVICE.read(userTO.getKey());
-        assertEquals("virattrcache", userTO.getVirAttr("virtualdata").get().getValues().get(0));
+        assertEquals("virattrcache", userTO.getVirAttr("virtualdata").get().getValues().getFirst());
 
         // force cache update by adding a resource which has virtualdata mapped for propagation
         UserUR userUR = new UserUR();
@@ -423,7 +423,7 @@ public class VirAttrITCase extends AbstractITCase {
         assertNotNull(userTO);
 
         userTO = USER_SERVICE.read(userTO.getKey());
-        assertEquals("virattrcache2", userTO.getVirAttr("virtualdata").get().getValues().get(0));
+        assertEquals("virattrcache2", userTO.getVirAttr("virtualdata").get().getValues().getFirst());
     }
 
     @Test
@@ -524,7 +524,7 @@ public class VirAttrITCase extends AbstractITCase {
             GroupTO groupTO = createGroup(groupCR).getEntity();
             groupKey = groupTO.getKey();
             assertEquals(1, groupTO.getVirAttrs().size());
-            assertEquals("ml@group.it", groupTO.getVirAttrs().iterator().next().getValues().get(0));
+            assertEquals("ml@group.it", groupTO.getVirAttrs().iterator().next().getValues().getFirst());
             // -------------------------------------------
 
             // -------------------------------------------
@@ -549,9 +549,9 @@ public class VirAttrITCase extends AbstractITCase {
 
             Map<String, Object> actuals = jdbcTemplate.queryForMap(
                     "SELECT id, surname, email FROM testpull WHERE id=?",
-                    new Object[] { userTO.getPlainAttr("fullname").get().getValues().get(0) });
+                    new Object[] { userTO.getPlainAttr("fullname").get().getValues().getFirst() });
 
-            assertEquals(userTO.getPlainAttr("fullname").get().getValues().get(0), actuals.get("id").toString());
+            assertEquals(userTO.getPlainAttr("fullname").get().getValues().getFirst(), actuals.get("id").toString());
             assertEquals("ml@group.it", actuals.get("email"));
             // -------------------------------------------
         } catch (Exception e) {
@@ -597,7 +597,7 @@ public class VirAttrITCase extends AbstractITCase {
         UserTO userTO = createUser(userCR).getEntity();
 
         assertNotNull(userTO.getVirAttr("virtualdata"));
-        assertEquals("syncope501@apache.org", userTO.getVirAttr("virtualdata").get().getValues().get(0));
+        assertEquals("syncope501@apache.org", userTO.getVirAttr("virtualdata").get().getValues().getFirst());
 
         // 2. update virtual attribute
         UserUR userUR = new UserUR();
@@ -610,7 +610,7 @@ public class VirAttrITCase extends AbstractITCase {
 
         // 3. check that user virtual attribute has really been updated 
         assertFalse(userTO.getVirAttr("virtualdata").get().getValues().isEmpty());
-        assertEquals("syncope501_updated@apache.org", userTO.getVirAttr("virtualdata").get().getValues().get(0));
+        assertEquals("syncope501_updated@apache.org", userTO.getVirAttr("virtualdata").get().getValues().getFirst());
     }
 
     @Test

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/VirSchemaITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/VirSchemaITCase.java
@@ -58,18 +58,18 @@ public class VirSchemaITCase extends AbstractITCase {
         ResourceTO csv = RESOURCE_SERVICE.read(RESOURCE_NAME_CSV);
         assertNotNull(csv);
         assertEquals(1, csv.getProvisions().size());
-        assertTrue(csv.getProvisions().get(0).getVirSchemas().isEmpty());
+        assertTrue(csv.getProvisions().getFirst().getVirSchemas().isEmpty());
 
         VirSchemaTO schema = new VirSchemaTO();
         schema.setKey("virtualTest" + getUUIDString());
         schema.setExtAttrName("name");
         schema.setResource(RESOURCE_NAME_CSV);
-        schema.setAnyType(csv.getProvisions().get(0).getAnyType());
+        schema.setAnyType(csv.getProvisions().getFirst().getAnyType());
         schema.getLabels().put(Locale.ENGLISH, "Virtual");
 
         schema = createSchema(SchemaType.VIRTUAL, schema);
         assertNotNull(schema);
-        assertEquals(csv.getProvisions().get(0).getAnyType(), schema.getAnyType());
+        assertEquals(csv.getProvisions().getFirst().getAnyType(), schema.getAnyType());
         assertEquals(1, schema.getLabels().size());
         assertEquals("Virtual", schema.getLabel(Locale.ENGLISH));
         assertEquals(schema.getKey(), schema.getLabel(Locale.CHINESE));
@@ -77,7 +77,7 @@ public class VirSchemaITCase extends AbstractITCase {
         csv = RESOURCE_SERVICE.read(RESOURCE_NAME_CSV);
         assertNotNull(csv);
         assertEquals(1, csv.getProvisions().size());
-        assertFalse(csv.getProvisions().get(0).getVirSchemas().isEmpty());
+        assertFalse(csv.getProvisions().getFirst().getVirSchemas().isEmpty());
 
         schema = SCHEMA_SERVICE.read(SchemaType.VIRTUAL, schema.getKey());
         assertNotNull(schema);
@@ -94,7 +94,7 @@ public class VirSchemaITCase extends AbstractITCase {
         csv = RESOURCE_SERVICE.read(RESOURCE_NAME_CSV);
         assertNotNull(csv);
         assertEquals(1, csv.getProvisions().size());
-        assertTrue(csv.getProvisions().get(0).getVirSchemas().isEmpty());
+        assertTrue(csv.getProvisions().getFirst().getVirSchemas().isEmpty());
     }
 
     @Test
@@ -131,13 +131,13 @@ public class VirSchemaITCase extends AbstractITCase {
         ResourceTO ws1 = RESOURCE_SERVICE.read(RESOURCE_NAME_WS1);
         assertNotNull(ws1);
         assertEquals(1, ws1.getProvisions().size());
-        assertTrue(ws1.getProvisions().get(0).getVirSchemas().isEmpty());
+        assertTrue(ws1.getProvisions().getFirst().getVirSchemas().isEmpty());
 
         VirSchemaTO schema = new VirSchemaTO();
         schema.setKey("http://schemas.examples.org/security/authorization/organizationUnit");
         schema.setExtAttrName("name");
         schema.setResource(RESOURCE_NAME_WS1);
-        schema.setAnyType(ws1.getProvisions().get(0).getAnyType());
+        schema.setAnyType(ws1.getProvisions().getFirst().getAnyType());
 
         try {
             createSchema(SchemaType.VIRTUAL, schema);

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/wa/GoogleMfaAuthAccountITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/wa/GoogleMfaAuthAccountITCase.java
@@ -90,7 +90,7 @@ public class GoogleMfaAuthAccountITCase extends AbstractITCase {
         acct.setScratchCodes(List.of(9, 8, 7, 6, 5));
         GOOGLE_MFA_AUTH_ACCOUNT_SERVICE.update(owner, acct);
         assertEquals(1, GOOGLE_MFA_AUTH_ACCOUNT_SERVICE.list().getTotalCount());
-        acct = GOOGLE_MFA_AUTH_ACCOUNT_SERVICE.read(owner).getResult().get(0);
+        acct = GOOGLE_MFA_AUTH_ACCOUNT_SERVICE.read(owner).getResult().getFirst();
         assertEquals(acct.getSecretKey(), acct.getSecretKey());
         GOOGLE_MFA_AUTH_ACCOUNT_SERVICE.delete(owner);
     }

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/wa/WebAuthnAccountITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/wa/WebAuthnAccountITCase.java
@@ -74,7 +74,7 @@ public class WebAuthnAccountITCase extends AbstractITCase {
         String owner = UUID.randomUUID().toString();
         WebAuthnAccount acct = createWebAuthnRegisteredAccount();
         WEBAUTHN_REGISTRATION_SERVICE.create(owner, acct);
-        WEBAUTHN_REGISTRATION_SERVICE.delete(owner, acct.getCredentials().get(0).getIdentifier());
+        WEBAUTHN_REGISTRATION_SERVICE.delete(owner, acct.getCredentials().getFirst().getIdentifier());
         acct = WEBAUTHN_REGISTRATION_SERVICE.read(owner);
         assertTrue(acct.getCredentials().isEmpty());
     }

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/enduser/AuthenticatedITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/enduser/AuthenticatedITCase.java
@@ -113,7 +113,7 @@ public class AuthenticatedITCase extends AbstractEnduserITCase {
 
         assertEquals(IS_FLOWABLE_ENABLED
                 ? "active" : "created", USER_SERVICE.read(username).getStatus());
-        assertEquals(newEmail, USER_SERVICE.read(username).getPlainAttr("email").get().getValues().get(0));
+        assertEquals(newEmail, USER_SERVICE.read(username).getPlainAttr("email").get().getValues().getFirst());
 
         TESTER.cleanupFeedbackMessages();
     }

--- a/fit/wa-reference/src/test/java/org/apache/syncope/fit/ui/SAML2SP4UIITCase.java
+++ b/fit/wa-reference/src/test/java/org/apache/syncope/fit/ui/SAML2SP4UIITCase.java
@@ -122,7 +122,7 @@ public class SAML2SP4UIITCase extends AbstractUIITCase {
         List<SAML2SP4UIIdPTO> idps = SAML2SP4UI_IDP_SERVICE.list();
         assertEquals(1, idps.size());
 
-        SAML2SP4UIIdPTO cas = idps.get(0);
+        SAML2SP4UIIdPTO cas = idps.getFirst();
         cas.setEntityID(WA_ADDRESS + "/saml");
         cas.setName("CAS");
         cas.setCreateUnmatching(true);
@@ -306,7 +306,7 @@ public class SAML2SP4UIITCase extends AbstractUIITCase {
         List<SAML2SP4UIIdPTO> idps = SAML2SP4UI_IDP_SERVICE.list();
         assertEquals(1, idps.size());
 
-        SAML2SP4UIIdPTO cas = idps.get(0);
+        SAML2SP4UIIdPTO cas = idps.getFirst();
         cas.setCreateUnmatching(false);
         cas.setSelfRegUnmatching(true);
         SAML2SP4UI_IDP_SERVICE.update(cas);

--- a/sra/src/main/java/org/apache/syncope/sra/filters/ModifyResponseGatewayFilterFactory.java
+++ b/sra/src/main/java/org/apache/syncope/sra/filters/ModifyResponseGatewayFilterFactory.java
@@ -87,7 +87,7 @@ public abstract class ModifyResponseGatewayFilterFactory extends CustomGatewayFi
                             : super.writeWith(Flux.from(body).
                                     collectList().
                                     filter(list -> !list.isEmpty()).
-                                    map(list -> list.get(0).factory().join(list)).
+                                    map(list -> list.getFirst().factory().join(list)).
                                     doOnDiscard(PooledDataBuffer.class, DataBufferUtils::release).
                                     map(dataBuffer -> {
                                         if (dataBuffer.readableByteCount() > 0) {

--- a/sra/src/main/java/org/apache/syncope/sra/security/saml2/SAML2WebSsoAuthenticationWebFilter.java
+++ b/sra/src/main/java/org/apache/syncope/sra/security/saml2/SAML2WebSsoAuthenticationWebFilter.java
@@ -106,7 +106,7 @@ public class SAML2WebSsoAuthenticationWebFilter extends AuthenticationWebFilter 
                 return webFilterExchange.getExchange().getFormData().
                         flatMap(form -> this.redirectStrategy.sendRedirect(
                         webFilterExchange.getExchange(),
-                        URI.create(form.get("RelayState").get(0))));
+                        URI.create(form.get("RelayState").getFirst())));
             }
         };
     }

--- a/wa/starter/src/test/java/org/apache/syncope/wa/starter/WAServiceRegistryTest.java
+++ b/wa/starter/src/test/java/org/apache/syncope/wa/starter/WAServiceRegistryTest.java
@@ -251,7 +251,7 @@ public class WAServiceRegistryTest extends AbstractTest {
 
         WAClientApp waClientApp = new WAClientApp();
         waClientApp.setClientAppTO(buildOIDCRP());
-        waClientApp.getAuthModules().add(0, authModuleTO);
+        waClientApp.getAuthModules().addFirst(authModuleTO);
         Long clientAppId = waClientApp.getClientAppTO().getClientAppId();
         addPolicies(waClientApp, false);
         DefaultAuthPolicyConf authPolicyConf = (DefaultAuthPolicyConf) waClientApp.getAuthPolicy().getConf();


### PR DESCRIPTION
Small reformattings required to pass checkstyle line length rule.