### PR TITLE
Chore: simplify stream API calls

### DIFF
--- a/client/am/console/src/main/java/org/apache/syncope/client/console/clientapps/ClientAppModalPanelBuilder.java
+++ b/client/am/console/src/main/java/org/apache/syncope/client/console/clientapps/ClientAppModalPanelBuilder.java
@@ -194,7 +194,7 @@ public class ClientAppModalPanelBuilder<T extends ClientAppTO> extends AbstractM
                     return realmRestClient.search(fullRealmsTree
                             ? RealmsUtils.buildRootQuery()
                             : RealmsUtils.buildKeywordQuery(input)).getResult().stream().
-                            map(RealmTO::getFullPath).collect(Collectors.toList()).iterator();
+                            map(RealmTO::getFullPath).toList().iterator();
                 }
             };
             fields.add(realm.setOutputMarkupId(true));

--- a/client/am/console/src/main/java/org/apache/syncope/client/console/clientapps/ClientAppModalPanelBuilder.java
+++ b/client/am/console/src/main/java/org/apache/syncope/client/console/clientapps/ClientAppModalPanelBuilder.java
@@ -194,7 +194,7 @@ public class ClientAppModalPanelBuilder<T extends ClientAppTO> extends AbstractM
                     return realmRestClient.search(fullRealmsTree
                             ? RealmsUtils.buildRootQuery()
                             : RealmsUtils.buildKeywordQuery(input)).getResult().stream().
-                            map(RealmTO::getFullPath).toList().iterator();
+                            map(RealmTO::getFullPath).iterator();
                 }
             };
             fields.add(realm.setOutputMarkupId(true));

--- a/client/am/console/src/main/java/org/apache/syncope/client/console/commons/AMRealmPolicyProvider.java
+++ b/client/am/console/src/main/java/org/apache/syncope/client/console/commons/AMRealmPolicyProvider.java
@@ -77,7 +77,7 @@ public class AMRealmPolicyProvider extends IdRepoRealmPolicyProvider {
                 new PropertyModel<>(realmTO, "authPolicy"),
                 false);
         authPolicy.setChoiceRenderer(new PolicyRenderer(authPolicies));
-        authPolicy.setChoices(authPolicies.keySet().stream().collect(Collectors.toList()));
+        authPolicy.setChoices(new ArrayList<>(authPolicies.keySet()));
         ((AbstractSingleSelectChoice<?>) authPolicy.getField()).setNullValid(true);
         view.add(authPolicy);
 
@@ -89,7 +89,7 @@ public class AMRealmPolicyProvider extends IdRepoRealmPolicyProvider {
                 new PropertyModel<>(realmTO, "ticketExpirationPolicy"),
                 false);
         ticketExpirationPolicy.setChoiceRenderer(new PolicyRenderer(ticketExpirationPolicies));
-        ticketExpirationPolicy.setChoices(ticketExpirationPolicies.keySet().stream().collect(Collectors.toList()));
+        ticketExpirationPolicy.setChoices(new ArrayList<>(ticketExpirationPolicies.keySet()));
         ((AbstractSingleSelectChoice<?>) ticketExpirationPolicy.getField()).setNullValid(true);
         view.add(ticketExpirationPolicy);
     }

--- a/client/am/console/src/main/java/org/apache/syncope/client/console/panels/WAConfigModalPanel.java
+++ b/client/am/console/src/main/java/org/apache/syncope/client/console/panels/WAConfigModalPanel.java
@@ -19,7 +19,6 @@
 package org.apache.syncope.client.console.panels;
 
 import java.io.Serializable;
-import java.util.stream.Collectors;
 import org.apache.syncope.client.console.rest.WAConfigRestClient;
 import org.apache.syncope.client.console.wicket.markup.html.bootstrap.dialog.BaseModal;
 import org.apache.syncope.client.ui.commons.wizards.AjaxWizard;
@@ -44,7 +43,7 @@ public class WAConfigModalPanel extends AbstractModalPanel<Attr> {
     protected static Attr toAttr(final ConfParam confParam) {
         Attr attr = new Attr.Builder(confParam.getSchema()).build();
         attr.getValues().addAll(
-                confParam.getValues().stream().map(Serializable::toString).collect(Collectors.toList()));
+                confParam.getValues().stream().map(Serializable::toString).toList());
         return attr;
     }
 

--- a/client/am/console/src/main/java/org/apache/syncope/client/console/rest/SAML2IdPEntityRestClient.java
+++ b/client/am/console/src/main/java/org/apache/syncope/client/console/rest/SAML2IdPEntityRestClient.java
@@ -18,8 +18,8 @@
  */
 package org.apache.syncope.client.console.rest;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.syncope.common.lib.to.SAML2IdPEntityTO;
 import org.apache.syncope.common.rest.api.service.SAML2IdPEntityService;
 
@@ -28,7 +28,7 @@ public class SAML2IdPEntityRestClient extends BaseRestClient {
     private static final long serialVersionUID = -1392090291817187902L;
 
     public List<SAML2IdPEntityTO> list() {
-        return getService(SAML2IdPEntityService.class).list().stream().collect(Collectors.toList());
+        return new ArrayList<>(getService(SAML2IdPEntityService.class).list());
     }
 
     public SAML2IdPEntityTO get(final String key) {

--- a/client/am/console/src/main/java/org/apache/syncope/client/console/rest/SAML2SPEntityRestClient.java
+++ b/client/am/console/src/main/java/org/apache/syncope/client/console/rest/SAML2SPEntityRestClient.java
@@ -18,8 +18,8 @@
  */
 package org.apache.syncope.client.console.rest;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.syncope.common.lib.to.SAML2SPEntityTO;
 import org.apache.syncope.common.rest.api.service.SAML2SPEntityService;
 
@@ -28,7 +28,7 @@ public class SAML2SPEntityRestClient extends BaseRestClient {
     private static final long serialVersionUID = -1392090291817187902L;
 
     public List<SAML2SPEntityTO> list() {
-        return getService(SAML2SPEntityService.class).list().stream().collect(Collectors.toList());
+        return new ArrayList<>(getService(SAML2SPEntityService.class).list());
     }
 
     public SAML2SPEntityTO get(final String key) {

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/rest/ConnectorRestClient.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/rest/ConnectorRestClient.java
@@ -82,7 +82,7 @@ public class ConnectorRestClient extends BaseRestClient {
                     getLanguage());
             if (connInstance != null) {
                 result.addAll(service.buildObjectClassInfo(connInstance, true).stream().
-                        map(ConnIdObjectClass::getType).collect(Collectors.toList()));
+                        map(ConnIdObjectClass::getType).toList());
             }
         } catch (Exception e) {
             LOG.error("While reading object classes for connector {}", connectorKey, e);

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/rest/ReconciliationRestClient.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/rest/ReconciliationRestClient.java
@@ -21,7 +21,6 @@ package org.apache.syncope.client.console.rest;
 import jakarta.ws.rs.core.Response;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.stream.Collectors;
 import org.apache.cxf.jaxrs.client.Client;
 import org.apache.cxf.jaxrs.client.WebClient;
 import org.apache.syncope.common.lib.to.ProvisioningReport;
@@ -68,8 +67,7 @@ public class ReconciliationRestClient extends BaseRestClient {
         Client client = WebClient.client(service);
         client.type(RESTHeaders.TEXT_CSV);
 
-        ArrayList<ProvisioningReport> result = service.pull(spec, csv).stream().
-                collect(Collectors.toCollection(ArrayList::new));
+        ArrayList<ProvisioningReport> result = new ArrayList<>(service.pull(spec, csv));
 
         resetClient(ReconciliationService.class);
 

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/status/AnyStatusDirectoryPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/status/AnyStatusDirectoryPanel.java
@@ -378,7 +378,7 @@ public class AnyStatusDirectoryPanel
                                     actual instanceof GroupTO);
                             statusBean.setLinked(false);
                             return statusBean;
-                        }).collect(Collectors.toList()));
+                        }).toList());
 
                 statusBeans.sort(comparator);
             }

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/status/ReconTaskPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/status/ReconTaskPanel.java
@@ -143,7 +143,7 @@ public class ReconTaskPanel extends MultilevelPanel.SecondLevel {
                                     ? RealmsUtils.buildRootQuery()
                                     : RealmsUtils.buildKeywordQuery(input)).getResult())
                             : List.<RealmTO>of()).stream().
-                            map(RealmTO::getFullPath).collect(Collectors.toList()).iterator();
+                            map(RealmTO::getFullPath).toList().iterator();
                 }
             };
 

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/status/ReconTaskPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/status/ReconTaskPanel.java
@@ -143,7 +143,7 @@ public class ReconTaskPanel extends MultilevelPanel.SecondLevel {
                                     ? RealmsUtils.buildRootQuery()
                                     : RealmsUtils.buildKeywordQuery(input)).getResult())
                             : List.<RealmTO>of()).stream().
-                            map(RealmTO::getFullPath).toList().iterator();
+                            map(RealmTO::getFullPath).iterator();
                 }
             };
 

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/status/ResourceStatusDirectoryPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/status/ResourceStatusDirectoryPanel.java
@@ -22,7 +22,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.syncope.client.console.commons.DirectoryDataProvider;
 import org.apache.syncope.client.console.commons.IdMConstants;
@@ -283,7 +282,7 @@ public class ResourceStatusDirectoryPanel
                 statusBeans.addAll(result.stream().map(any -> StatusUtils.getStatusBean(any,
                         resource.getKey(),
                         null,
-                        any instanceof GroupTO)).collect(Collectors.toList()));
+                        any instanceof GroupTO)).toList());
             }
 
             return statusBeans;

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/topology/Topology.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/topology/Topology.java
@@ -32,7 +32,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.cxf.jaxrs.client.WebClient;
@@ -366,7 +365,7 @@ public class Topology extends BasePage {
         // -----------------------------------------
         Collection<String> adminConns = new HashSet<>();
         connModel.getObject().values().forEach(connInstances -> adminConns.addAll(
-                connInstances.stream().map(ConnInstanceTO::getKey).collect(Collectors.toList())));
+                connInstances.stream().map(ConnInstanceTO::getKey).toList()));
 
         Set<String> adminRes = new HashSet<>();
         List<String> connToBeProcessed = new ArrayList<>();

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/any/LinkedAccountPlainAttrsPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/any/LinkedAccountPlainAttrsPanel.java
@@ -82,7 +82,7 @@ public class LinkedAccountPlainAttrsPanel extends AbstractAttrsWizardStep<PlainS
         this.linkedAccountTO = modelObject.getInnerObject();
         this.fixedAttrs.addAll(this.linkedAccountTO.getPlainAttrs().stream().
                 filter(attrTO -> checkIsReadonlyAttr(attrTO.getSchema())).
-                collect(Collectors.toList()));
+            toList());
         this.userTO = userTO;
 
         add(new Accordion("plainSchemas", List.of(new AbstractTab(
@@ -204,7 +204,7 @@ public class LinkedAccountPlainAttrsPanel extends AbstractAttrsWizardStep<PlainS
                     }
                     return attrTO;
                 }).
-                collect(Collectors.toList()));
+            toList());
 
         fixedAttrs.clear();
         fixedAttrs.addAll(attrs);

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/any/MergeLinkedAccountsReviewPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/any/MergeLinkedAccountsReviewPanel.java
@@ -134,7 +134,7 @@ public class MergeLinkedAccountsReviewPanel extends WizardStep {
                 String connObjectKeyValue = restClient.getConnObjectKeyValue(resource,
                         mergingUser.getType(), mergingUser.getKey());
                 return new LinkedAccountTO.Builder(resource, connObjectKeyValue).build();
-            }).collect(Collectors.toList()));
+            }).toList());
 
             // Move merging user into target/base user as a linked account
             String connObjectKeyValue = restClient.getConnObjectKeyValue(

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/resources/ConnectorDetailsPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/resources/ConnectorDetailsPanel.java
@@ -71,7 +71,7 @@ public class ConnectorDetailsPanel extends WizardStep {
                                 ? RealmsUtils.buildRootQuery()
                                 : RealmsUtils.buildKeywordQuery(input)).getResult())
                         : List.<RealmTO>of()).stream().
-                        map(RealmTO::getFullPath).toList().iterator();
+                        map(RealmTO::getFullPath).iterator();
             }
         };
         add(realm.addRequiredLabel().setOutputMarkupId(true));

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/resources/ConnectorDetailsPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/wizards/resources/ConnectorDetailsPanel.java
@@ -71,7 +71,7 @@ public class ConnectorDetailsPanel extends WizardStep {
                                 ? RealmsUtils.buildRootQuery()
                                 : RealmsUtils.buildKeywordQuery(input)).getResult())
                         : List.<RealmTO>of()).stream().
-                        map(RealmTO::getFullPath).collect(Collectors.toList()).iterator();
+                        map(RealmTO::getFullPath).toList().iterator();
             }
         };
         add(realm.addRequiredLabel().setOutputMarkupId(true));
@@ -123,7 +123,7 @@ public class ConnectorDetailsPanel extends WizardStep {
                 List<Pair<String, String>> connectors = bundles.stream().
                         filter(bundle -> bundle.getBundleName().equals(connInstanceTO.getBundleName())).
                         map(bundle -> Pair.of(bundle.getConnectorName(), bundle.getVersion())).
-                        collect(Collectors.toList());
+                    toList();
                 if (connectors.size() == 1) {
                     Pair<String, String> entry = connectors.get(0);
 

--- a/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/BaseLogin.java
+++ b/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/BaseLogin.java
@@ -25,7 +25,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.syncope.client.ui.commons.panels.NotificationPanel;
 import org.apache.syncope.common.keymaster.client.api.DomainOps;
@@ -85,7 +84,7 @@ public abstract class BaseLogin extends WebPage {
         @Override
         protected List<String> load() {
             List<String> current = new ArrayList<>();
-            current.addAll(domainOps.list().stream().map(Domain::getKey).sorted().collect(Collectors.toList()));
+            current.addAll(domainOps.list().stream().map(Domain::getKey).sorted().toList());
             current.add(0, SyncopeConstants.MASTER_DOMAIN);
             return current;
         }

--- a/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/SyncopeUIRequestCycleListener.java
+++ b/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/SyncopeUIRequestCycleListener.java
@@ -23,7 +23,6 @@ import jakarta.ws.rs.ForbiddenException;
 import jakarta.ws.rs.NotAuthorizedException;
 import jakarta.xml.ws.WebServiceException;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.syncope.common.lib.SyncopeClientException;
 import org.apache.syncope.common.lib.types.ClientExceptionType;
@@ -84,7 +83,7 @@ public abstract class SyncopeUIRequestCycleListener implements IRequestCycleList
         } else if (instanceOf(e, SyncopeClientException.class).isPresent()) {
             SyncopeClientException sce = instanceOf(e, SyncopeClientException.class).get();
             String errorMessage = sce.getType() == ClientExceptionType.Unknown
-                    ? sce.getElements().stream().collect(Collectors.joining())
+                    ? String.join("", sce.getElements())
                     : sce.getMessage();
             errorParameters.add("errorMessage", errorMessage);
             errorPage = getErrorPage(errorParameters);

--- a/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/markup/html/form/AjaxPalettePanel.java
+++ b/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/markup/html/form/AjaxPalettePanel.java
@@ -156,7 +156,7 @@ public class AjaxPalettePanel<T extends Serializable> extends AbstractFieldPanel
                         IChoiceRenderer<? super T> renderer = getChoiceRenderer();
                         Collection<? extends T> choices = getChoices();
 
-                        List<String> ids = builder.idExtractor.apply(getValue()).collect(Collectors.toList());
+                        List<String> ids = builder.idExtractor.apply(getValue()).toList();
                         List<T> unselected = new ArrayList<>(choices.size());
                         choices.forEach(choice -> {
                             if (!ids.contains(renderer.getIdValue(choice, 0))) {

--- a/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/panels/SyncopeFormPanel.java
+++ b/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/panels/SyncopeFormPanel.java
@@ -171,7 +171,7 @@ public class SyncopeFormPanel<F extends SyncopeForm> extends Panel {
                                 @Override
                                 public void setObject(final List<String> object) {
                                     prop.setValue(Optional.ofNullable(object).
-                                            map(v -> v.stream().collect(Collectors.joining(";"))).
+                                            map(v -> String.join(";", v)).
                                             orElse(null));
                                 }
                             }, new ListModel<>(prop.getDropdownValues().stream().

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/PreferenceManager.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/PreferenceManager.java
@@ -28,7 +28,6 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.wicket.util.cookies.CookieDefaults;
@@ -133,7 +132,7 @@ public final class PreferenceManager implements Serializable {
         }
 
         // after retrieved previous setting in order to overwrite the key ...
-        prefs.forEach((key, values) -> current.put(key, values.stream().collect(Collectors.joining(";"))));
+        prefs.forEach((key, values) -> current.put(key, String.join(";", values)));
 
         try {
             COOKIE_UTILS.save(COOKIE_NAME, Base64.getEncoder().encodeToString(setPrefs(current).getBytes()));
@@ -161,7 +160,7 @@ public final class PreferenceManager implements Serializable {
     }
 
     public static void setList(final String key, final List<String> values) {
-        set(key, values.stream().collect(Collectors.joining(";")));
+        set(key, String.join(";", values));
     }
 
     public static void setList(final Map<String, List<String>> prefs) {

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/SyncopeConsoleSession.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/SyncopeConsoleSession.java
@@ -137,7 +137,7 @@ public class SyncopeConsoleSession extends AuthenticatedWebSession implements Ba
     }
 
     protected String message(final SyncopeClientException sce) {
-        return sce.getType().name() + ": " + sce.getElements().stream().collect(Collectors.joining(", "));
+        return sce.getType().name() + ": " + String.join(", ", sce.getElements());
     }
 
     @Override

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/layout/AnyLayoutUtils.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/layout/AnyLayoutUtils.java
@@ -76,7 +76,7 @@ public final class AnyLayoutUtils {
         List<String> ownedRoles = Stream.concat(
                 SyncopeConsoleSession.get().getSelfTO().getRoles().stream(),
                 SyncopeConsoleSession.get().getSelfTO().getDynRoles().stream()).
-                distinct().collect(Collectors.toList());
+                distinct().toList();
         try {
             AnyLayout anyLayout = null;
             for (int i = 0; i < ownedRoles.size() && anyLayout == null; i++) {

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/notifications/NotificationWizardBuilder.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/notifications/NotificationWizardBuilder.java
@@ -412,11 +412,11 @@ public class NotificationWizardBuilder extends BaseAjaxWizardBuilder<Notificatio
         result.add(Constants.USERNAME_FIELD_NAME);
 
         result.addAll(schemaRestClient.<PlainSchemaTO>getSchemas(SchemaType.PLAIN, null, anyTypeClasses).
-                stream().map(PlainSchemaTO::getKey).collect(Collectors.toList()));
+                stream().map(PlainSchemaTO::getKey).toList());
         result.addAll(schemaRestClient.<DerSchemaTO>getSchemas(SchemaType.DERIVED, null, anyTypeClasses).
-                stream().map(DerSchemaTO::getKey).collect(Collectors.toList()));
+                stream().map(DerSchemaTO::getKey).toList());
         result.addAll(schemaRestClient.<VirSchemaTO>getSchemas(SchemaType.VIRTUAL, null, anyTypeClasses).
-                stream().map(VirSchemaTO::getKey).collect(Collectors.toList()));
+                stream().map(VirSchemaTO::getKey).toList());
 
         Collections.sort(result);
         return result;

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/ConfParam.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/ConfParam.java
@@ -22,7 +22,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class ConfParam implements Serializable {
 
@@ -60,7 +59,7 @@ public class ConfParam implements Serializable {
             this.values.addAll(((Collection<?>) value).stream().
                     filter(Serializable.class::isInstance).
                     map(Serializable.class::cast).
-                    collect(Collectors.toList()));
+                toList());
             this.multivalue = true;
         } else {
             this.values.add((Serializable) value);

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/RealmChoicePanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/RealmChoicePanel.java
@@ -123,8 +123,9 @@ public class RealmChoicePanel extends Panel {
                 Map<String, Pair<RealmTO, List<RealmTO>>> map = reloadRealmParentMap();
                 Stream<Pair<String, RealmTO>> full;
                 if (fullRealmsTree) {
-                    full = map.entrySet().stream().
-                            map(el -> Pair.of(el.getValue().getLeft().getFullPath(), el.getValue().getKey())).
+                    full = map.values().stream().
+                            map(realmTOListPair ->
+                                Pair.of(realmTOListPair.getLeft().getFullPath(), realmTOListPair.getKey())).
                             sorted(Comparator.comparing(Pair::getLeft));
                 } else {
                     full = map.entrySet().stream().

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/search/SearchClausePanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/search/SearchClausePanel.java
@@ -293,7 +293,7 @@ public class SearchClausePanel extends FieldPanel<SearchClause> {
                                     map(item -> Pair.of(
                                     item.getKey(),
                                     Optional.ofNullable(item.getValue().getLabel(locale)).orElse(item.getKey()))).
-                                    collect(Collectors.toList()));
+                                toList());
                         }
                         return names.stream().
                                 sorted(java.util.Comparator.comparing(name -> name.getValue().toLowerCase())).

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/policies/PolicyModalPanelBuilder.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/policies/PolicyModalPanelBuilder.java
@@ -20,10 +20,8 @@ package org.apache.syncope.client.console.policies;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.apache.syncope.client.console.SyncopeConsoleSession;
 import org.apache.syncope.client.console.SyncopeWebApplication;
 import org.apache.syncope.client.console.panels.AbstractModalPanel;
@@ -90,7 +88,7 @@ public class PolicyModalPanelBuilder<T extends PolicyTO> extends AbstractModalPa
             String[] split = backOffParamsModel.getObject().split(";");
             if (index < split.length) {
                 split[index] = object.toString();
-                backOffParamsModel.setObject(Arrays.stream(split).collect(Collectors.joining(";")));
+                backOffParamsModel.setObject(String.join(";", split));
             }
         }
     }

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/AbstractAttrsWizardStep.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/AbstractAttrsWizardStep.java
@@ -119,7 +119,7 @@ public abstract class AbstractAttrsWizardStep<S extends SchemaTO> extends Wizard
     protected List<Attr> loadAttrs() {
         List<String> classes = new ArrayList<>(anyTypeClasses);
         classes.addAll(anyTypeClassRestClient.list(anyTO.getAuxClasses()).stream().
-                map(AnyTypeClassTO::getKey).collect(Collectors.toList()));
+                map(AnyTypeClassTO::getKey).toList());
         setSchemas(classes);
         setAttrs();
         return getAttrsFromTO();

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/DerAttrs.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/DerAttrs.java
@@ -147,7 +147,7 @@ public class DerAttrs extends AbstractAttrs<DerSchemaTO> {
             }
 
             return attr;
-        }).collect(Collectors.toList());
+        }).toList();
 
         membershipTO.getDerAttrs().clear();
         membershipTO.getDerAttrs().addAll(derAttrs);

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/Details.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/Details.java
@@ -20,7 +20,6 @@ package org.apache.syncope.client.console.wizards.any;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.syncope.client.console.SyncopeConsoleSession;
 import org.apache.syncope.client.console.SyncopeWebApplication;
 import org.apache.syncope.client.console.commons.RealmsUtils;
@@ -98,9 +97,9 @@ public class Details<T extends AnyTO> extends WizardStep {
                             : (fullRealmsTree
                                     ? realmRestClient.search(RealmsUtils.buildRootQuery())
                                     : realmRestClient.search(RealmsUtils.buildKeywordQuery(input))).getResult()).
-                            stream().filter(realm -> authRealms.stream().anyMatch(
-                            authRealm -> realm.getFullPath().startsWith(authRealm))).
-                            map(RealmTO::getFullPath).collect(Collectors.toList()).iterator();
+                            stream().map(RealmTO::getFullPath).
+                        filter(fullPath -> authRealms.stream().anyMatch(
+                        authRealm -> fullPath.startsWith(authRealm))).toList().iterator();
                 }
             };
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/Details.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/Details.java
@@ -99,7 +99,7 @@ public class Details<T extends AnyTO> extends WizardStep {
                                     : realmRestClient.search(RealmsUtils.buildKeywordQuery(input))).getResult()).
                             stream().map(RealmTO::getFullPath).
                         filter(fullPath -> authRealms.stream().anyMatch(
-                        authRealm -> fullPath.startsWith(authRealm))).toList().iterator();
+                        authRealm -> fullPath.startsWith(authRealm))).iterator();
                 }
             };
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/Groups.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/Groups.java
@@ -269,7 +269,7 @@ public class Groups extends AbstractGroups {
                         -1,
                         -1,
                         new SortParam<>(Constants.NAME_FIELD_NAME, true),
-                        null).stream().map(GroupTO::getName).collect(Collectors.toList()));
+                        null).stream().map(GroupTO::getName).toList());
             }
         }
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/PlainAttrs.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/PlainAttrs.java
@@ -156,7 +156,7 @@ public class PlainAttrs extends AbstractAttrs<PlainSchemaTO> {
                 attr = attrMap.get(schema.getKey());
             }
             return attr;
-        }).collect(Collectors.toList());
+        }).toList();
 
         anyTO.getPlainAttrs().clear();
         anyTO.getPlainAttrs().addAll(plainAttrs);
@@ -177,7 +177,7 @@ public class PlainAttrs extends AbstractAttrs<PlainSchemaTO> {
                 attr.getValues().addAll(attrMap.get(schema.getKey()).getValues());
             }
             return attr;
-        }).collect(Collectors.toList());
+        }).toList();
 
         membershipTO.getPlainAttrs().clear();
         membershipTO.getPlainAttrs().addAll(plainAttrs);

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/TypeExtensionWizardBuilder.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/TypeExtensionWizardBuilder.java
@@ -100,7 +100,7 @@ public class TypeExtensionWizardBuilder extends BaseAjaxWizardBuilder<TypeExtens
                 List<String> anyTypes = anyTypeRestClient.list();
                 anyTypes.remove(AnyTypeKind.GROUP.name());
                 anyTypes.removeAll(anyTypes.stream().
-                        filter(anyType -> groupTO.getTypeExtension(anyType).isPresent()).collect(Collectors.toList()));
+                        filter(anyType -> groupTO.getTypeExtension(anyType).isPresent()).toList());
 
                 AjaxDropDownChoicePanel<String> anyTypeComponent = new AjaxDropDownChoicePanel<>(
                         "anyType.component", "anyType", new PropertyModel<>(typeExtensionTO, "anyType"));

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/VirAttrs.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/VirAttrs.java
@@ -133,7 +133,7 @@ public class VirAttrs extends AbstractAttrs<VirSchemaTO> {
                 attrTO.getValues().add(StringUtils.EMPTY);
             }
             return attrTO;
-        }).collect(Collectors.toList()));
+        }).toList());
 
         anyTO.getVirAttrs().clear();
         anyTO.getVirAttrs().addAll(virAttrs);
@@ -154,7 +154,7 @@ public class VirAttrs extends AbstractAttrs<VirSchemaTO> {
                 attr.getValues().addAll(attrMap.get(schema.getKey()).getValues());
             }
             return attr;
-        }).collect(Collectors.toList());
+        }).toList();
 
         membershipTO.getVirAttrs().clear();
         membershipTO.getVirAttrs().addAll(virAttrs);

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/role/RoleWizardBuilder.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/role/RoleWizardBuilder.java
@@ -191,7 +191,7 @@ public class RoleWizardBuilder extends BaseAjaxWizardBuilder<RoleWrapper> {
                     return realmRestClient.search(fullRealmsTree
                             ? RealmsUtils.buildRootQuery()
                             : RealmsUtils.buildKeywordQuery(input)).getResult().stream().
-                            map(RealmTO::getFullPath).collect(Collectors.toList()).iterator();
+                            map(RealmTO::getFullPath).toList().iterator();
                 }
             };
             add(new MultiFieldPanel.Builder<>(

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/role/RoleWizardBuilder.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/role/RoleWizardBuilder.java
@@ -191,7 +191,7 @@ public class RoleWizardBuilder extends BaseAjaxWizardBuilder<RoleWrapper> {
                     return realmRestClient.search(fullRealmsTree
                             ? RealmsUtils.buildRootQuery()
                             : RealmsUtils.buildKeywordQuery(input)).getResult().stream().
-                            map(RealmTO::getFullPath).toList().iterator();
+                            map(RealmTO::getFullPath).iterator();
                 }
             };
             add(new MultiFieldPanel.Builder<>(

--- a/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/PreferenceManager.java
+++ b/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/PreferenceManager.java
@@ -29,7 +29,6 @@ import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.apache.wicket.util.cookies.CookieDefaults;
@@ -134,7 +133,7 @@ public final class PreferenceManager implements Serializable {
         }
 
         // after retrieved previous setting in order to overwrite the key ...
-        prefs.forEach((key, values) -> current.put(key, values.stream().collect(Collectors.joining(";"))));
+        prefs.forEach((key, values) -> current.put(key, String.join(";", values)));
 
         try {
             COOKIE_UTILS.save(COOKIE_NAME, Base64.getEncoder().encodeToString(setPrefs(current).getBytes()));
@@ -162,7 +161,7 @@ public final class PreferenceManager implements Serializable {
     }
 
     public void setList(final String key, final List<String> values) {
-        set(key, values.stream().collect(Collectors.joining(";")));
+        set(key, String.join(";", values));
     }
 
     public void setList(final Map<String, List<String>> prefs) {

--- a/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/SyncopeEnduserSession.java
+++ b/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/SyncopeEnduserSession.java
@@ -114,7 +114,7 @@ public class SyncopeEnduserSession extends AuthenticatedWebSession implements Ba
             error = Error.INVALID_SECURITY_ANSWER;
         }
         if (error == null) {
-            return sce.getType().name() + ": " + sce.getElements().stream().collect(Collectors.joining(", "));
+            return sce.getType().name() + ": " + String.join(", ", sce.getElements());
         }
         return getApplication().getResourceSettings().getLocalizer().
                 getString(error.key(), null, null, null, null, error.fallback());

--- a/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/pages/Login.java
+++ b/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/pages/Login.java
@@ -60,7 +60,7 @@ public class Login extends BaseLogin {
     protected Collection<Component> getLanguageOnChangeComponents() {
         return Stream.concat(
                 super.getLanguageOnChangeComponents().stream(),
-                List.of(selfRegistration, selfPwdReset).stream()).
+                Stream.of(selfRegistration, selfPwdReset)).
                 collect(Collectors.toList());
     }
 

--- a/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/panels/any/DerAttrs.java
+++ b/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/panels/any/DerAttrs.java
@@ -137,7 +137,7 @@ public class DerAttrs extends AbstractAttrs<DerSchemaTO> {
             }
 
             return attr;
-        }).collect(Collectors.toList());
+        }).toList();
 
         membershipTO.getDerAttrs().clear();
         membershipTO.getDerAttrs().addAll(derAttrs);

--- a/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/panels/any/PlainAttrs.java
+++ b/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/panels/any/PlainAttrs.java
@@ -147,7 +147,7 @@ public class PlainAttrs extends AbstractAttrs<PlainSchemaTO> {
                 attrTO = attrMap.get(schema.getKey());
             }
             return attrTO;
-        }).collect(Collectors.toList()));
+        }).toList());
 
         userTO.getPlainAttrs().clear();
         userTO.getPlainAttrs().addAll(plainAttrs);
@@ -168,7 +168,7 @@ public class PlainAttrs extends AbstractAttrs<PlainSchemaTO> {
                 attr.getValues().addAll(attrMap.get(schema.getKey()).getValues());
             }
             return attr;
-        }).collect(Collectors.toList());
+        }).toList();
 
         membershipTO.getPlainAttrs().clear();
         membershipTO.getPlainAttrs().addAll(plainAttrs);

--- a/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/panels/any/VirAttrs.java
+++ b/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/panels/any/VirAttrs.java
@@ -117,7 +117,7 @@ public class VirAttrs extends AbstractAttrs<VirSchemaTO> {
                 attrTO.getValues().add(StringUtils.EMPTY);
             }
             return attrTO;
-        }).collect(Collectors.toList()));
+        }).toList());
 
         userTO.getVirAttrs().clear();
         userTO.getVirAttrs().addAll(virAttrs);
@@ -138,7 +138,7 @@ public class VirAttrs extends AbstractAttrs<VirSchemaTO> {
                 attr.getValues().addAll(attrMap.get(schema.getKey()).getValues());
             }
             return attr;
-        }).collect(Collectors.toList());
+        }).toList();
 
         membershipTO.getVirAttrs().clear();
         membershipTO.getVirAttrs().addAll(virAttrs);
@@ -166,8 +166,7 @@ public class VirAttrs extends AbstractAttrs<VirSchemaTO> {
                     Attr attrTO = item.getModelObject();
 
                     // set default values, if any
-                    if (attrTO.getValues().stream().filter(StringUtils::isNotBlank)
-                            .collect(Collectors.toList()).isEmpty()) {
+                    if (attrTO.getValues().stream().filter(StringUtils::isNotBlank).count() == 0) {
                         attrTO.getValues().clear();
                         attrTO.getValues().addAll(getDefaultValues(attrTO.getSchema(), groupName));
                     }

--- a/common/idrepo/lib/src/main/java/org/apache/syncope/common/lib/AnyOperations.java
+++ b/common/idrepo/lib/src/main/java/org/apache/syncope/common/lib/AnyOperations.java
@@ -320,8 +320,8 @@ public final class AnyOperations {
         Map<Pair<String, String>, LinkedAccountTO> originalAccounts =
                 EntityTOUtils.buildLinkedAccountMap(original.getLinkedAccounts());
 
-        updatedAccounts.entrySet().stream().
-                forEachOrdered(entry -> {
+        updatedAccounts.entrySet().
+            forEach(entry -> {
                     result.getLinkedAccounts().add(new LinkedAccountUR.Builder().
                             operation(PatchOperation.ADD_REPLACE).
                             linkedAccountTO(entry.getValue()).build());

--- a/core/idm/logic/src/main/java/org/apache/syncope/core/logic/ConnectorLogic.java
+++ b/core/idm/logic/src/main/java/org/apache/syncope/core/logic/ConnectorLogic.java
@@ -81,7 +81,7 @@ public class ConnectorLogic extends AbstractTransactionalLogic<ConnInstanceTO> {
     }
 
     protected void securityChecks(final Set<String> effectiveRealms, final String realm, final String key) {
-        if (!effectiveRealms.stream().anyMatch(realm::startsWith)) {
+        if (effectiveRealms.stream().noneMatch(realm::startsWith)) {
             throw new DelegatedAdministrationException(realm, ConnInstance.class.getSimpleName(), key);
         }
     }

--- a/core/persistence-common/src/main/java/org/apache/syncope/core/persistence/common/dao/AbstractAnySearchDAO.java
+++ b/core/persistence-common/src/main/java/org/apache/syncope/core/persistence/common/dao/AbstractAnySearchDAO.java
@@ -381,7 +381,7 @@ public abstract class AbstractAnySearchDAO implements AnySearchDAO {
         List<Any> anys = anyUtilsFactory.getInstance(kind).dao().findByKeys(keys).stream().
                 sorted(Comparator.comparing(any -> keys.indexOf(any.getKey()))).toList();
 
-        keys.stream().filter(key -> !anys.stream().anyMatch(any -> key.equals(any.getKey()))).
+        keys.stream().filter(key -> anys.stream().noneMatch(any -> key.equals(any.getKey()))).
                 forEach(key -> LOG.error("Could not find {} with id {}, even if returned by native query", kind, key));
 
         return (List<T>) anys;

--- a/core/persistence-common/src/main/java/org/apache/syncope/core/persistence/common/entity/DefaultAnyUtils.java
+++ b/core/persistence-common/src/main/java/org/apache/syncope/core/persistence/common/entity/DefaultAnyUtils.java
@@ -304,7 +304,7 @@ public class DefaultAnyUtils implements AnyUtils {
         Set<AnyTypeClass> typeOwnClasses = new HashSet<>();
         typeOwnClasses.addAll(any.getType().getClasses());
         typeOwnClasses.addAll(any.getAuxClasses());
-        if (!typeOwnClasses.stream().anyMatch(clazz -> clazz.getPlainSchemas().contains(schema))) {
+        if (typeOwnClasses.stream().noneMatch(clazz -> clazz.getPlainSchemas().contains(schema))) {
             LOG.warn("Schema {} not allowed for {}, ignoring", schema, any);
             return;
         }

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/content/XMLContentExporter.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/content/XMLContentExporter.java
@@ -92,7 +92,7 @@ public class XMLContentExporter extends AbstractXMLContentExporter {
 
     protected static boolean isTableAllowed(final String tableName) {
         return TABLE_PREFIXES_TO_BE_EXCLUDED.stream().
-                allMatch(prefix -> !tableName.toUpperCase().startsWith(prefix.toUpperCase()));
+            noneMatch(prefix -> tableName.toUpperCase().startsWith(prefix.toUpperCase()));
     }
 
     protected static String getValues(final ResultSet rs, final String columnName, final Integer columnType)
@@ -171,7 +171,7 @@ public class XMLContentExporter extends AbstractXMLContentExporter {
     protected static Map<String, Pair<String, String>> relationTables(final BidiMap<String, EntityType<?>> entities) {
         Map<String, Pair<String, String>> relationTables = new HashMap<>();
 
-        entities.values().stream().forEach(e -> e.getAttributes().stream().
+        entities.values().forEach(e -> e.getAttributes().stream().
                 filter(a -> a.getPersistentAttributeType() != Attribute.PersistentAttributeType.BASIC).
                 forEach(a -> {
                     Field field = (Field) a.getJavaMember();

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/repo/AbstractAnyRepoExt.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/repo/AbstractAnyRepoExt.java
@@ -182,20 +182,19 @@ public abstract class AbstractAnyRepoExt<A extends Any> implements AnyRepoExt<A>
             }
         }
 
-        typeExtensionClasses.entrySet().stream().map(entry -> {
-            result.getForMemberships().put(entry.getKey(), new HashSet<>());
-            return entry;
-        }).forEach(entry -> entry.getValue().forEach(typeClass -> {
-            if (reference.equals(PlainSchema.class)) {
-                result.getForMemberships().get(entry.getKey()).
-                        addAll((Collection<? extends S>) typeClass.getPlainSchemas());
-            } else if (reference.equals(DerSchema.class)) {
-                result.getForMemberships().get(entry.getKey()).
-                        addAll((Collection<? extends S>) typeClass.getDerSchemas());
-            } else if (reference.equals(VirSchema.class)) {
-                result.getForMemberships().get(entry.getKey()).
-                        addAll((Collection<? extends S>) typeClass.getVirSchemas());
-            }
+        typeExtensionClasses.entrySet().stream().peek(
+            entry -> result.getForMemberships().put(entry.getKey(), new HashSet<>())).
+                forEach(entry -> entry.getValue().forEach(typeClass -> {
+                    if (reference.equals(PlainSchema.class)) {
+                        result.getForMemberships().get(entry.getKey()).
+                                addAll((Collection<? extends S>) typeClass.getPlainSchemas());
+                    } else if (reference.equals(DerSchema.class)) {
+                        result.getForMemberships().get(entry.getKey()).
+                                addAll((Collection<? extends S>) typeClass.getDerSchemas());
+                    } else if (reference.equals(VirSchema.class)) {
+                        result.getForMemberships().get(entry.getKey()).
+                                addAll((Collection<? extends S>) typeClass.getVirSchemas());
+                    }
         }));
 
         return result;

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/repo/AbstractSchemaRepoExt.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/repo/AbstractSchemaRepoExt.java
@@ -23,7 +23,6 @@ import jakarta.persistence.TypedQuery;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.syncope.core.persistence.api.entity.AnyTypeClass;
 import org.apache.syncope.core.persistence.api.entity.Schema;
 
@@ -52,7 +51,7 @@ public abstract class AbstractSchemaRepoExt {
             parameters.add(anyTypeClass.getKey());
             clausesIdx++;
         }
-        queryString.append(clauses.stream().collect(Collectors.joining(" OR ")));
+        queryString.append(String.join(" OR ", clauses));
 
         TypedQuery<S> query = entityManager.createQuery(queryString.toString(), reference);
         for (int i = 0; i < parameters.size(); i++) {

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/repo/ConnInstanceRepoExtImpl.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/repo/ConnInstanceRepoExtImpl.java
@@ -52,7 +52,7 @@ public class ConnInstanceRepoExtImpl implements ConnInstanceRepoExt {
 
         Set<String> authRealms = AuthContextUtils.getAuthorizations().get(IdMEntitlement.CONNECTOR_READ);
         if (authRealms == null || authRealms.isEmpty()
-                || !authRealms.stream().anyMatch(
+                || authRealms.stream().noneMatch(
                         realm -> connInstance.getAdminRealm().getFullPath().startsWith(realm))) {
 
             throw new DelegatedAdministrationException(

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/repo/ExternalResourceRepoExtImpl.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/repo/ExternalResourceRepoExtImpl.java
@@ -87,7 +87,7 @@ public class ExternalResourceRepoExtImpl implements ExternalResourceRepoExt {
 
         Set<String> authRealms = AuthContextUtils.getAuthorizations().get(IdMEntitlement.RESOURCE_READ);
         if (authRealms == null || authRealms.isEmpty()
-                || !authRealms.stream().anyMatch(realm -> resource.getConnector() != null
+                || authRealms.stream().noneMatch(realm -> resource.getConnector() != null
                 && resource.getConnector().getAdminRealm().getFullPath().startsWith(realm))) {
 
             throw new DelegatedAdministrationException(

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/repo/RelationshipTypeRepoExtImpl.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/repo/RelationshipTypeRepoExtImpl.java
@@ -76,7 +76,7 @@ public class RelationshipTypeRepoExtImpl implements RelationshipTypeRepoExt {
             return;
         }
 
-        findRelationshipsByType(type).stream().map(relationship -> {
+        findRelationshipsByType(type).stream().peek(relationship -> {
             switch (relationship) {
                 case URelationship uRelationship ->
                     uRelationship.getLeftEnd().getRelationships().remove(uRelationship);
@@ -90,7 +90,6 @@ public class RelationshipTypeRepoExtImpl implements RelationshipTypeRepoExt {
                 }
             }
             relationship.setLeftEnd(null);
-            return relationship;
         }).forEach(entityManager::remove);
 
         entityManager.remove(type);

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/entity/JSONEntityListener.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/entity/JSONEntityListener.java
@@ -39,10 +39,9 @@ public abstract class JSONEntityListener<A extends Any> {
             entity.getPlainAttrsList().clear();
         }
         if (entity.getPlainAttrsJSON() != null) {
-            getAttrs(entity.getPlainAttrsJSON()).stream().filter(PlainAttr::isValid).map(attr -> {
+            getAttrs(entity.getPlainAttrsJSON()).stream().filter(PlainAttr::isValid).peek(attr -> {
                 attr.getValues().forEach(value -> value.setAttr(attr));
                 Optional.ofNullable(attr.getUniqueValue()).ifPresent(value -> value.setAttr(attr));
-                return attr;
             }).forEach(attr -> entity.add(attr));
         }
     }

--- a/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/outer/GroupTest.java
+++ b/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/outer/GroupTest.java
@@ -122,7 +122,7 @@ public class GroupTest extends AbstractTest {
 
         assertEquals(
                 memberships.stream().map(m -> m.getLeftEnd().getKey()).collect(Collectors.toSet()),
-                groupDAO.findUMembers("37d15e4c-cdc1-460b-a591-8505c8133806").stream().collect(Collectors.toSet()));
+            new HashSet<>(groupDAO.findUMembers("37d15e4c-cdc1-460b-a591-8505c8133806")));
 
         assertTrue(groupDAO.existsUMembership(
                 "74cd8ece-715a-44a4-a736-e17b46c4e7e6", "37d15e4c-cdc1-460b-a591-8505c8133806"));

--- a/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/outer/ResourceTest.java
+++ b/core/persistence-jpa/src/test/java/org/apache/syncope/core/persistence/jpa/outer/ResourceTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -117,7 +118,7 @@ public class ResourceTest extends AbstractTest {
         assertEquals(
                 Set.of(resourceDAO.findById("resource-testdb2").orElseThrow(),
                         resourceDAO.findById("resource-ldap").orElseThrow()),
-                resourceDAO.findByPropagationActionsContaining(impl).stream().collect(Collectors.toSet()));
+            new HashSet<>(resourceDAO.findByPropagationActionsContaining(impl)));
     }
 
     @Test

--- a/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/content/ContentLoaderHandler.java
+++ b/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/content/ContentLoaderHandler.java
@@ -181,8 +181,8 @@ public class ContentLoaderHandler extends AbstractContentLoaderHandler {
                 props.put("id", originalValue);
             } else {
                 String name = nodeDesc.getGraphProperties().stream().
-                        filter(prop -> prop.getPropertyName().equalsIgnoreCase(originalName)).
-                        map(GraphPropertyDescription::getPropertyName).
+                    map(GraphPropertyDescription::getPropertyName).
+                    filter(propertyName -> propertyName.equalsIgnoreCase(originalName)).
                         findFirst().orElseGet(() -> originalName.startsWith("plainAttrs.") ? originalName : null);
                 if (name == null) {
                     LOG.error("Property {} not matching for {}", originalName, nodeDesc.getPrimaryLabel());
@@ -309,8 +309,8 @@ public class ContentLoaderHandler extends AbstractContentLoaderHandler {
         } else {
             query = parseNode(mappingContext.getNodeDescription(qName), atts).map(node -> {
                 StringBuilder q = new StringBuilder("CREATE (n:").append(nodelabels(qName)).append(" {");
-                q.append(node.props().entrySet().stream().
-                        map(e -> "`" + e.getKey() + "`" + ": $" + escape(e.getKey())).
+                q.append(node.props().keySet().stream().
+                        map(o -> "`" + o + "`" + ": $" + escape(o)).
                         collect(Collectors.joining(", ")));
                 q.append("})");
                 return new Query(q.toString(), node.props().entrySet().stream().

--- a/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/dao/Neo4jAnySearchDAO.java
+++ b/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/dao/Neo4jAnySearchDAO.java
@@ -1025,7 +1025,7 @@ public class Neo4jAnySearchDAO extends AbstractAnySearchDAO {
             TextStringBuilder query = queryInfo.query();
 
             List<String> orderBy = parseOrderBy(kind, pageable.getSort());
-            String orderByStmt = orderBy.stream().collect(Collectors.joining(", "));
+            String orderByStmt = String.join(", ", orderBy);
 
             // 3. include membership plain attr queries
             membershipAttrConds(query, queryInfo, orderBy, kind);

--- a/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/dao/Neo4jTaskDAO.java
+++ b/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/dao/Neo4jTaskDAO.java
@@ -340,7 +340,7 @@ public class Neo4jTaskDAO extends AbstractDAO implements TaskDAO {
         properties.addAll(relationships.stream().filter(r -> r.getRight() != null).map(Pair::getRight).toList());
 
         if (!properties.isEmpty()) {
-            query.append(" WHERE ").append(properties.stream().collect(Collectors.joining(" AND ")));
+            query.append(" WHERE ").append(String.join(" AND ", properties));
         }
 
         return query;

--- a/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/dao/repo/AbstractAnyRepoExt.java
+++ b/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/dao/repo/AbstractAnyRepoExt.java
@@ -245,26 +245,25 @@ public abstract class AbstractAnyRepoExt<A extends Any, N extends AbstractAny>
             }
         }
 
-        typeExtensionClasses.entrySet().stream().map(entry -> {
-            result.getForMemberships().put(entry.getKey(), new HashSet<>());
-            return entry;
-        }).forEach(entry -> entry.getValue().forEach(atc -> {
-            if (reference.equals(PlainSchema.class)) {
-                atc.getPlainSchemas().stream().
-                        map(schema -> plainSchemaDAO.findById(schema.getKey())).
-                        flatMap(Optional::stream).
-                        forEach(schema -> result.getForMemberships().get(entry.getKey()).add((S) schema));
-            } else if (reference.equals(DerSchema.class)) {
-                atc.getDerSchemas().stream().
-                        map(schema -> derSchemaDAO.findById(schema.getKey())).
-                        flatMap(Optional::stream).
-                        forEach(schema -> result.getForMemberships().get(entry.getKey()).add((S) schema));
-            } else if (reference.equals(VirSchema.class)) {
-                atc.getVirSchemas().stream().
-                        map(schema -> virSchemaDAO.findById(schema.getKey())).
-                        flatMap(Optional::stream).
-                        forEach(schema -> result.getForMemberships().get(entry.getKey()).add((S) schema));
-            }
+        typeExtensionClasses.entrySet().stream().peek(
+            entry -> result.getForMemberships().put(entry.getKey(), new HashSet<>()))
+                .forEach(entry -> entry.getValue().forEach(atc -> {
+                    if (reference.equals(PlainSchema.class)) {
+                        atc.getPlainSchemas().stream().
+                                map(schema -> plainSchemaDAO.findById(schema.getKey())).
+                                flatMap(Optional::stream).
+                                forEach(schema -> result.getForMemberships().get(entry.getKey()).add((S) schema));
+                    } else if (reference.equals(DerSchema.class)) {
+                        atc.getDerSchemas().stream().
+                                map(schema -> derSchemaDAO.findById(schema.getKey())).
+                                flatMap(Optional::stream).
+                                forEach(schema -> result.getForMemberships().get(entry.getKey()).add((S) schema));
+                    } else if (reference.equals(VirSchema.class)) {
+                        atc.getVirSchemas().stream().
+                                map(schema -> virSchemaDAO.findById(schema.getKey())).
+                                flatMap(Optional::stream).
+                                forEach(schema -> result.getForMemberships().get(entry.getKey()).add((S) schema));
+                    }
         }));
 
         return result;

--- a/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/dao/repo/AbstractSchemaRepoExt.java
+++ b/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/dao/repo/AbstractSchemaRepoExt.java
@@ -23,7 +23,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import javax.cache.Cache;
 import org.apache.syncope.core.persistence.api.entity.AnyTypeClass;
 import org.apache.syncope.core.persistence.api.entity.Schema;
@@ -99,7 +98,7 @@ public abstract class AbstractSchemaRepoExt extends AbstractDAO {
 
         return toList(neo4jClient.query(
                 "MATCH (n:" + label + ")-[:" + relationship + "]-(a:" + Neo4jAnyTypeClass.NODE + ") "
-                + "WHERE (" + clauses.stream().collect(Collectors.joining(" OR ")) + ") "
+                + "WHERE (" + String.join(" OR ", clauses) + ") "
                 + "RETURN n.id").bindAll(parameters).fetch().all(),
                 "n.id",
                 domainType,

--- a/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/dao/repo/ConnInstanceRepoExtImpl.java
+++ b/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/dao/repo/ConnInstanceRepoExtImpl.java
@@ -59,7 +59,7 @@ public class ConnInstanceRepoExtImpl implements ConnInstanceRepoExt {
 
         Set<String> authRealms = AuthContextUtils.getAuthorizations().get(IdMEntitlement.CONNECTOR_READ);
         if (authRealms == null || authRealms.isEmpty()
-                || !authRealms.stream().anyMatch(
+                || authRealms.stream().noneMatch(
                         realm -> connInstance.getAdminRealm().getFullPath().startsWith(realm))) {
 
             throw new DelegatedAdministrationException(

--- a/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/dao/repo/ExternalResourceRepoExtImpl.java
+++ b/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/dao/repo/ExternalResourceRepoExtImpl.java
@@ -115,7 +115,7 @@ public class ExternalResourceRepoExtImpl extends AbstractDAO implements External
 
         Set<String> authRealms = AuthContextUtils.getAuthorizations().get(IdMEntitlement.RESOURCE_READ);
         if (authRealms == null || authRealms.isEmpty()
-                || !authRealms.stream().anyMatch(realm -> resource.getConnector() != null
+                || authRealms.stream().noneMatch(realm -> resource.getConnector() != null
                 && resource.getConnector().getAdminRealm().getFullPath().startsWith(realm))) {
 
             throw new DelegatedAdministrationException(

--- a/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/dao/repo/RelationshipTypeRepoExtImpl.java
+++ b/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/dao/repo/RelationshipTypeRepoExtImpl.java
@@ -63,7 +63,7 @@ public class RelationshipTypeRepoExtImpl extends AbstractDAO implements Relation
     @Override
     public void deleteById(final String key) {
         neo4jTemplate.findById(key, Neo4jRelationshipType.class).ifPresent(type -> {
-            findRelationshipsByType(type).stream().map(relationship -> {
+            findRelationshipsByType(type).stream().peek(relationship -> {
                 switch (relationship) {
                     case URelationship uRelationship ->
                         uRelationship.getLeftEnd().getRelationships().remove(uRelationship);
@@ -77,7 +77,6 @@ public class RelationshipTypeRepoExtImpl extends AbstractDAO implements Relation
                     }
                 }
                 relationship.setLeftEnd(null);
-                return relationship;
             }).forEach(r -> neo4jTemplate.deleteById(r.getKey(), r.getClass()));
 
             neo4jTemplate.deleteById(key, Neo4jRelationshipType.class);

--- a/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/dao/repo/RemediationRepoExtImpl.java
+++ b/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/dao/repo/RemediationRepoExtImpl.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import org.apache.commons.text.TextStringBuilder;
 import org.apache.commons.text.matcher.StringMatcherFactory;
 import org.apache.syncope.core.persistence.api.entity.AnyType;
@@ -85,7 +84,7 @@ public class RemediationRepoExtImpl extends AbstractDAO implements RemediationRe
         }
 
         if (!conditions.isEmpty()) {
-            query.append("WHERE ").append(conditions.stream().collect(Collectors.joining(" AND ")));
+            query.append("WHERE ").append(String.join(" AND ", conditions));
         }
 
         return query;

--- a/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/GroupTest.java
+++ b/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/GroupTest.java
@@ -120,7 +120,7 @@ public class GroupTest extends AbstractTest {
 
         assertEquals(
                 memberships.stream().map(m -> m.getLeftEnd().getKey()).collect(Collectors.toSet()),
-                groupDAO.findUMembers("37d15e4c-cdc1-460b-a591-8505c8133806").stream().collect(Collectors.toSet()));
+            new HashSet<>(groupDAO.findUMembers("37d15e4c-cdc1-460b-a591-8505c8133806")));
 
         assertTrue(groupDAO.existsUMembership(
                 "74cd8ece-715a-44a4-a736-e17b46c4e7e6", "37d15e4c-cdc1-460b-a591-8505c8133806"));

--- a/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/ResourceTest.java
+++ b/core/persistence-neo4j/src/test/java/org/apache/syncope/core/persistence/neo4j/outer/ResourceTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -114,7 +115,7 @@ public class ResourceTest extends AbstractTest {
         assertEquals(
                 Set.of(resourceDAO.findById("resource-testdb2").orElseThrow(),
                         resourceDAO.findById("resource-ldap").orElseThrow()),
-                resourceDAO.findByPropagationActionsContaining(impl).stream().collect(Collectors.toSet()));
+            new HashSet<>(resourceDAO.findByPropagationActionsContaining(impl)));
     }
 
     @Test

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/DefaultConnIdBundleManager.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/DefaultConnIdBundleManager.java
@@ -196,11 +196,10 @@ public class DefaultConnIdBundleManager implements ConnIdBundleManager {
         }
 
         if (LOG.isDebugEnabled()) {
-            connInfoManagers.entrySet().stream().map(entry -> {
-                LOG.debug("Connector bundles found at {}", entry.getKey());
-                return entry;
-            }).forEach(entry -> entry.getValue().getConnectorInfos().forEach(
-                    connInfo -> LOG.debug("\t{}", connInfo.getConnectorDisplayName())));
+            connInfoManagers.entrySet().stream().peek(
+                entry -> LOG.debug("Connector bundles found at {}", entry.getKey())).
+                        forEach(entry -> entry.getValue().getConnectorInfos().forEach(
+                        connInfo -> LOG.debug("\t{}", connInfo.getConnectorDisplayName())));
         }
 
         return connInfoManagers;

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/DelegationDataBinderImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/DelegationDataBinderImpl.java
@@ -94,7 +94,7 @@ public class DelegationDataBinderImpl implements DelegationDataBinder {
         // 2. remove all roles not contained in the TO
         for (Iterator<? extends Role> itor = delegation.getRoles().iterator(); itor.hasNext();) {
             Role role = itor.next();
-            if (!delegationTO.getRoles().stream().anyMatch(roleKey -> roleKey.equals(role.getKey()))) {
+            if (delegationTO.getRoles().stream().noneMatch(roleKey -> roleKey.equals(role.getKey()))) {
                 itor.remove();
             }
         }

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/ReportDataBinderImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/ReportDataBinderImpl.java
@@ -100,7 +100,7 @@ public class ReportDataBinderImpl extends AbstractExecutableDatabinder implement
 
         reportTO.getExecutions().addAll(report.getExecs().stream().map(this::getExecTO).toList());
 
-        reportTO.getExecutions().stream().sorted(Comparator.comparing(ExecTO::getStart).reversed()).findFirst().
+        reportTO.getExecutions().stream().max(Comparator.comparing(ExecTO::getStart)).
                 map(ExecTO::getStart).ifPresent(reportTO::setLastExec);
 
         scheduler.getNextTrigger(AuthContextUtils.getDomain(), JobNamer.getJobName(report)).

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/TaskDataBinderImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/TaskDataBinderImpl.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.syncope.common.lib.SyncopeClientException;
 import org.apache.syncope.common.lib.command.CommandArgs;
@@ -470,7 +469,7 @@ public class TaskDataBinderImpl extends AbstractExecutableDatabinder implements 
         schedTaskTO.setActive(schedTask.isActive());
         schedTaskTO.setJobDelegate(schedTask.getJobDelegate().getKey());
 
-        schedTaskTO.getExecutions().stream().sorted(Comparator.comparing(ExecTO::getStart).reversed()).findFirst().
+        schedTaskTO.getExecutions().stream().max(Comparator.comparing(ExecTO::getStart)).
                 map(ExecTO::getStart).ifPresentOrElse(
                 schedTaskTO::setLastExec,
                 () -> schedTaskTO.setLastExec(schedTaskTO.getStart()));
@@ -713,7 +712,7 @@ public class TaskDataBinderImpl extends AbstractExecutableDatabinder implements 
                 }
             }
             return prop;
-        }).collect(Collectors.toList()));
+        }).toList());
 
         return form;
     }

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/UserDataBinderImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/UserDataBinderImpl.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.commons.lang3.BooleanUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -652,7 +651,7 @@ public class UserDataBinderImpl extends AbstractAnyDataBinder implements UserDat
                             Pair.of(account.getResource().getKey(), account.getConnObjectKeyValue()));
                 }
 
-                account.getPlainAttrs().stream().collect(Collectors.toSet()).forEach(account::remove);
+                new HashSet<>(account.getPlainAttrs()).forEach(account::remove);
             });
             if (patch.getOperation() == PatchOperation.ADD_REPLACE) {
                 linkedAccount(

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/LDAPMembershipPullActions.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/pushpull/LDAPMembershipPullActions.java
@@ -214,7 +214,7 @@ public class LDAPMembershipPullActions implements InboundActions {
             userUR.setKey(user);
             updateReqs.add(userUR);
 
-            groups.stream().forEach(group -> {
+            groups.forEach(group -> {
                 Set<String> before = membershipsBefore.get(user);
                 if (before == null || !before.contains(group)) {
                     userUR.getMemberships().add(new MembershipUR.Builder(group).

--- a/core/provisioning-java/src/test/java/org/apache/syncope/core/provisioning/java/pushpull/stream/StreamPullJobDelegateTest.java
+++ b/core/provisioning-java/src/test/java/org/apache/syncope/core/provisioning/java/pushpull/stream/StreamPullJobDelegateTest.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.syncope.common.lib.SyncopeConstants;
 import org.apache.syncope.common.lib.to.ProvisioningReport;
 import org.apache.syncope.common.lib.to.PullTaskTO;
@@ -78,7 +77,7 @@ public class StreamPullJobDelegateTest extends AbstractTest {
                 "userId");
 
         StringBuilder csv = new StringBuilder();
-        csv.append(columns.stream().collect(Collectors.joining(",")));
+        csv.append(String.join(",", columns));
         csv.append('\n');
         csv.append("donizetti,");
         csv.append("donizetti@apache.org,");

--- a/core/spring/src/main/java/org/apache/syncope/core/spring/policy/DefaultPasswordRule.java
+++ b/core/spring/src/main/java/org/apache/syncope/core/spring/policy/DefaultPasswordRule.java
@@ -153,8 +153,7 @@ public class DefaultPasswordRule implements PasswordRule {
         RuleResult result = passwordValidator.validate(
                 username == null ? new PasswordData(clear) : new PasswordData(username, clear));
         if (!result.isValid()) {
-            throw new PasswordPolicyException(passwordValidator.getMessages(result).
-                    stream().collect(Collectors.joining(",")));
+            throw new PasswordPolicyException(String.join(",", passwordValidator.getMessages(result)));
         }
 
         // check words not permitted

--- a/core/spring/src/main/java/org/apache/syncope/core/spring/security/DefaultPasswordGenerator.java
+++ b/core/spring/src/main/java/org/apache/syncope/core/spring/security/DefaultPasswordGenerator.java
@@ -93,7 +93,7 @@ public class DefaultPasswordGenerator implements PasswordGenerator {
     public String generate(final List<PasswordPolicy> policies) {
         List<DefaultPasswordRuleConf> ruleConfs = new ArrayList<>();
 
-        policies.stream().forEach(policy -> getPasswordRules(policy).stream().
+        policies.forEach(policy -> getPasswordRules(policy).stream().
                 filter(rule -> rule.getConf() instanceof DefaultPasswordRuleConf).
                 forEach(rule -> ruleConfs.add((DefaultPasswordRuleConf) rule.getConf())));
 

--- a/core/workflow-java/src/main/java/org/apache/syncope/core/workflow/java/AbstractAnyObjectWorkflowAdapter.java
+++ b/core/workflow-java/src/main/java/org/apache/syncope/core/workflow/java/AbstractAnyObjectWorkflowAdapter.java
@@ -78,7 +78,7 @@ public abstract class AbstractAnyObjectWorkflowAdapter
                 orElseThrow(() -> new IllegalStateException("Could not find the AnyObject just created"));
 
         // finally publish events for all groups affected by this operation, via membership
-        anyObject.getMemberships().stream().forEach(m -> publisher.publishEvent(
+        anyObject.getMemberships().forEach(m -> publisher.publishEvent(
                 new EntityLifecycleEvent<>(this, SyncDeltaType.UPDATE, m.getRightEnd(), AuthContextUtils.getDomain())));
 
         return result;

--- a/core/workflow-java/src/main/java/org/apache/syncope/core/workflow/java/AbstractUserWorkflowAdapter.java
+++ b/core/workflow-java/src/main/java/org/apache/syncope/core/workflow/java/AbstractUserWorkflowAdapter.java
@@ -253,7 +253,7 @@ public abstract class AbstractUserWorkflowAdapter extends AbstractWorkflowAdapte
         user = userDAO.save(user);
 
         // finally publish events for all groups affected by this operation, via membership
-        user.getMemberships().stream().forEach(m -> publisher.publishEvent(
+        user.getMemberships().forEach(m -> publisher.publishEvent(
                 new EntityLifecycleEvent<>(this, SyncDeltaType.UPDATE, m.getRightEnd(), AuthContextUtils.getDomain())));
 
         return result;

--- a/ext/flowable/logic/src/main/java/org/apache/syncope/core/logic/UserRequestLogic.java
+++ b/ext/flowable/logic/src/main/java/org/apache/syncope/core/logic/UserRequestLogic.java
@@ -130,8 +130,8 @@ public class UserRequestLogic extends AbstractTransactionalLogic<EntityTO> {
 
     protected static void securityChecks(final String username, final String entitlement, final String errorMessage) {
         if (!AuthContextUtils.getUsername().equals(username)
-                && !AuthContextUtils.getAuthorities().stream().
-                        anyMatch(auth -> entitlement.equals(auth.getAuthority()))) {
+                && AuthContextUtils.getAuthorities().stream().
+            noneMatch(auth -> entitlement.equals(auth.getAuthority()))) {
 
             SyncopeClientException sce = SyncopeClientException.build(ClientExceptionType.DelegatedAdministration);
             sce.getElements().add(errorMessage);

--- a/ext/oidcc4ui/logic/src/main/java/org/apache/syncope/core/logic/oidc/OIDCClientCache.java
+++ b/ext/oidcc4ui/logic/src/main/java/org/apache/syncope/core/logic/oidc/OIDCClientCache.java
@@ -33,7 +33,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import org.apache.syncope.common.lib.to.OIDCC4UIProviderTO;
 import org.apache.syncope.core.persistence.api.entity.OIDCC4UIProvider;
 import org.pac4j.core.http.callback.NoParameterCallbackUrlResolver;
@@ -105,7 +104,7 @@ public class OIDCClientCache {
         cfg.setDiscoveryURI(DISCOVERY_URI.apply(op.getIssuer()));
         cfg.setPreferredJwsAlgorithm(JWSAlgorithm.HS256);
         cfg.setOpMetadataResolver(new StaticOidcOpMetadataResolver(cfg, metadata));
-        cfg.setScope(op.getScopes().stream().collect(Collectors.joining(" ")));
+        cfg.setScope(String.join(" ", op.getScopes()));
         cfg.setUseNonce(false);
 
         OidcClient client = new OidcClient(cfg);

--- a/ext/oidcc4ui/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/entity/JPAOIDCC4UIProvider.java
+++ b/ext/oidcc4ui/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/entity/JPAOIDCC4UIProvider.java
@@ -40,7 +40,6 @@ import jakarta.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.syncope.common.lib.to.Item;
 import org.apache.syncope.common.lib.types.OIDCClientImplementationType;
@@ -218,7 +217,7 @@ public class JPAOIDCC4UIProvider extends AbstractGeneratedKeyEntity implements O
     public void setScopes(final List<String> scopes) {
         this.scopes = CollectionUtils.isEmpty(scopes)
                 ? ""
-                : scopes.stream().collect(Collectors.joining(" "));
+                : String.join(" ", scopes);
     }
 
     @Override

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AbstractTaskITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AbstractTaskITCase.java
@@ -96,8 +96,7 @@ public abstract class AbstractTaskITCase extends AbstractITCase {
             }
         });
 
-        return taskTO.get().getExecutions().stream().
-                sorted(Comparator.comparing(ExecTO::getStart).reversed()).findFirst().orElseThrow();
+        return taskTO.get().getExecutions().stream().max(Comparator.comparing(ExecTO::getStart)).orElseThrow();
     }
 
     public static ExecTO execSchedTask(

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/PullTaskITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/PullTaskITCase.java
@@ -1230,8 +1230,7 @@ public class PullTaskITCase extends AbstractTaskITCase {
         assertEquals(1, executed.getExecutions().size());
 
         // assert for just one match
-        assertTrue(executed.getExecutions().stream().
-                sorted(Comparator.comparing(ExecTO::getStart).reversed()).findFirst().orElseThrow().
+        assertTrue(executed.getExecutions().stream().max(Comparator.comparing(ExecTO::getStart)).orElseThrow().
                 getMessage().contains("[updated/failures]: 1/0"));
     }
 

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/ReportITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/ReportITCase.java
@@ -67,8 +67,7 @@ public class ReportITCase extends AbstractITCase {
             }
         });
 
-        ExecTO exec = reportTO.get().getExecutions().stream().
-                sorted(Comparator.comparing(ExecTO::getStart).reversed()).findFirst().orElseThrow();
+        ExecTO exec = reportTO.get().getExecutions().stream().max(Comparator.comparing(ExecTO::getStart)).orElseThrow();
         assertEquals(ReportJob.Status.SUCCESS.name(), exec.getStatus());
         return exec.getKey();
     }

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/SearchITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/SearchITCase.java
@@ -79,7 +79,7 @@ public class SearchITCase extends AbstractITCase {
                                 is("fullname").equalTo("*o*").and("fullname").equalTo("*i*").query()).build());
         assertNotNull(matchingUsers);
         assertFalse(matchingUsers.getResult().isEmpty());
-        matchingUsers.getResult().stream().forEach(Assertions::assertNotNull);
+        matchingUsers.getResult().forEach(Assertions::assertNotNull);
 
         // ISNULL
         matchingUsers = USER_SERVICE.search(new AnyQuery.Builder().realm(SyncopeConstants.ROOT_REALM).

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/UserIssuesITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/UserIssuesITCase.java
@@ -42,7 +42,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 import javax.naming.NamingException;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.cxf.helpers.IOUtils;
@@ -1885,7 +1884,7 @@ public class UserIssuesITCase extends AbstractITCase {
                         .resource(RESOURCE_NAME_LDAP)
                         .entityKey("c9b2dec2-00a7-4855-97c0-d854842b4b24").build())
                         .getResult().stream().map(PropagationTaskTO.class::cast)
-                        .collect(Collectors.toList()).stream().noneMatch(pt -> ResourceOperation.DELETE == pt.
+                        .toList().stream().noneMatch(pt -> ResourceOperation.DELETE == pt.
                         getOperation()));
         GROUP_SERVICE.delete(dGroupForPropagation.getKey());
         await().atMost(MAX_WAIT_SECONDS, TimeUnit.SECONDS).until(
@@ -1894,7 +1893,7 @@ public class UserIssuesITCase extends AbstractITCase {
                         .resource(RESOURCE_NAME_LDAP)
                         .entityKey("b3cbc78d-32e6-4bd4-92e0-bbe07566a2ee").build())
                         .getResult().stream().map(PropagationTaskTO.class::cast)
-                        .collect(Collectors.toList()).stream().anyMatch(pt -> ResourceOperation.DELETE == pt.
+                        .toList().stream().anyMatch(pt -> ResourceOperation.DELETE == pt.
                         getOperation()));
     }
 }

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/wa/WAConfigITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/wa/WAConfigITCase.java
@@ -46,7 +46,7 @@ public class WAConfigITCase extends AbstractITCase {
         WA_CONFIG_SERVICE.set(config);
 
         Attr updatedTO = WA_CONFIG_SERVICE.get(config.getSchema());
-        updatedTO.getValues().stream().allMatch(((Collection) updatedValue)::contains);
+        ((Collection) updatedValue).containsAll(updatedTO.getValues());
         return updatedTO;
     }
 

--- a/wa/bootstrap/src/main/java/org/apache/syncope/wa/bootstrap/WAPropertySourceLocator.java
+++ b/wa/bootstrap/src/main/java/org/apache/syncope/wa/bootstrap/WAPropertySourceLocator.java
@@ -151,11 +151,11 @@ public class WAPropertySourceLocator implements PropertySourceLocator {
                     Stream.concat(new OidcDiscoveryProperties().getClaims().stream(), customClaims.stream()).
                             collect(Collectors.joining(",")));
             properties.put("cas.authn.oidc.core.user-defined-scopes.syncope",
-                    customClaims.stream().collect(Collectors.joining(",")));
+                String.join(",", customClaims));
         }
 
         syncopeClient.getService(WAConfigService.class).list().forEach(attr -> properties.put(
-                attr.getSchema(), attr.getValues().stream().collect(Collectors.joining(","))));
+                attr.getSchema(), String.join(",", attr.getValues())));
 
         LOG.debug("Collected WA properties: {}", properties);
         Map<String, Object> decodedProperties = configurationCipher.decode(properties, ArrayUtils.EMPTY_OBJECT_ARRAY);

--- a/wa/starter/src/main/java/org/apache/syncope/wa/starter/mapping/DefaultAuthMapper.java
+++ b/wa/starter/src/main/java/org/apache/syncope/wa/starter/mapping/DefaultAuthMapper.java
@@ -79,8 +79,8 @@ public class DefaultAuthMapper implements AuthMapper {
         if (!authHandlers.isEmpty()) {
             mfaAuthHandlers.addAll(authEventExecPlan.getObject().getAuthenticationHandlers().stream().
                     filter(MultifactorAuthenticationHandler.class::isInstance).
-                    filter(mfaAuthHander -> policyConf.getAuthModules().contains(mfaAuthHander.getName())).
-                    map(AuthenticationHandler::getName).
+                map(AuthenticationHandler::getName).
+                filter(name -> policyConf.getAuthModules().contains(name)).
                     collect(Collectors.toSet()));
             authHandlers.removeAll(mfaAuthHandlers);
 

--- a/wa/starter/src/main/java/org/apache/syncope/wa/starter/mapping/SAML2SPClientAppTOMapper.java
+++ b/wa/starter/src/main/java/org/apache/syncope/wa/starter/mapping/SAML2SPClientAppTOMapper.java
@@ -19,7 +19,6 @@
 package org.apache.syncope.wa.starter.mapping;
 
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.apache.syncope.common.lib.to.ClientAppTO;
 import org.apache.syncope.common.lib.to.SAML2SPClientAppTO;
 import org.apache.syncope.common.lib.wa.WAClientApp;
@@ -71,7 +70,7 @@ public class SAML2SPClientAppTOMapper extends AbstractClientAppMapper {
         service.setSkewAllowance(Optional.ofNullable(sp.getSkewAllowance()).orElse(0));
         service.setNameIdQualifier(sp.getNameIdQualifier());
         if (!sp.getAssertionAudiences().isEmpty()) {
-            service.setAssertionAudiences(sp.getAssertionAudiences().stream().collect(Collectors.joining(",")));
+            service.setAssertionAudiences(String.join(",", sp.getAssertionAudiences()));
         }
         service.setServiceProviderNameIdQualifier(sp.getServiceProviderNameIdQualifier());
 


### PR DESCRIPTION
Update relevant stream API calls and chains use `noneMatch`, `peek` and simplified versions of `forEach` and collectors. 