### PR TITLE
Chore: remove service annotation from spring beans

### DIFF
--- a/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AttrRepoServiceImpl.java
+++ b/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AttrRepoServiceImpl.java
@@ -25,9 +25,7 @@ import org.apache.syncope.common.lib.to.AttrRepoTO;
 import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.common.rest.api.service.AttrRepoService;
 import org.apache.syncope.core.logic.AttrRepoLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class AttrRepoServiceImpl extends AbstractService implements AttrRepoService {
 
     protected final AttrRepoLogic logic;

--- a/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AuthModuleServiceImpl.java
+++ b/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AuthModuleServiceImpl.java
@@ -25,9 +25,7 @@ import org.apache.syncope.common.lib.to.AuthModuleTO;
 import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.common.rest.api.service.AuthModuleService;
 import org.apache.syncope.core.logic.AuthModuleLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class AuthModuleServiceImpl extends AbstractService implements AuthModuleService {
 
     protected final AuthModuleLogic logic;

--- a/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AuthProfileServiceImpl.java
+++ b/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AuthProfileServiceImpl.java
@@ -27,9 +27,7 @@ import org.apache.syncope.common.rest.api.service.AuthProfileService;
 import org.apache.syncope.core.logic.AuthProfileLogic;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.stereotype.Service;
 
-@Service
 public class AuthProfileServiceImpl extends AbstractService implements AuthProfileService {
 
     protected final AuthProfileLogic logic;

--- a/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/ClientAppServiceImpl.java
+++ b/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/ClientAppServiceImpl.java
@@ -26,9 +26,7 @@ import org.apache.syncope.common.lib.types.ClientAppType;
 import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.common.rest.api.service.ClientAppService;
 import org.apache.syncope.core.logic.ClientAppLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class ClientAppServiceImpl extends AbstractService implements ClientAppService {
 
     protected final ClientAppLogic logic;

--- a/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/OIDCJWKSServiceImpl.java
+++ b/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/OIDCJWKSServiceImpl.java
@@ -23,9 +23,7 @@ import java.net.URI;
 import org.apache.syncope.common.lib.to.OIDCJWKSTO;
 import org.apache.syncope.common.rest.api.service.OIDCJWKSService;
 import org.apache.syncope.core.logic.OIDCJWKSLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class OIDCJWKSServiceImpl extends AbstractService implements OIDCJWKSService {
 
     protected final OIDCJWKSLogic logic;

--- a/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/SAML2IdPEntityServiceImpl.java
+++ b/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/SAML2IdPEntityServiceImpl.java
@@ -22,9 +22,7 @@ import java.util.List;
 import org.apache.syncope.common.lib.to.SAML2IdPEntityTO;
 import org.apache.syncope.common.rest.api.service.SAML2IdPEntityService;
 import org.apache.syncope.core.logic.SAML2IdPEntityLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class SAML2IdPEntityServiceImpl extends AbstractService implements SAML2IdPEntityService {
 
     protected final SAML2IdPEntityLogic logic;

--- a/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/SAML2SPEntityServiceImpl.java
+++ b/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/SAML2SPEntityServiceImpl.java
@@ -22,9 +22,7 @@ import java.util.List;
 import org.apache.syncope.common.lib.to.SAML2SPEntityTO;
 import org.apache.syncope.common.rest.api.service.SAML2SPEntityService;
 import org.apache.syncope.core.logic.SAML2SPEntityLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class SAML2SPEntityServiceImpl extends AbstractService implements SAML2SPEntityService {
 
     protected final SAML2SPEntityLogic logic;

--- a/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/SRARouteServiceImpl.java
+++ b/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/SRARouteServiceImpl.java
@@ -25,9 +25,7 @@ import org.apache.syncope.common.lib.to.SRARouteTO;
 import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.common.rest.api.service.SRARouteService;
 import org.apache.syncope.core.logic.SRARouteLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class SRARouteServiceImpl extends AbstractService implements SRARouteService {
 
     protected final SRARouteLogic logic;

--- a/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/wa/GoogleMfaAuthAccountServiceImpl.java
+++ b/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/wa/GoogleMfaAuthAccountServiceImpl.java
@@ -24,9 +24,7 @@ import org.apache.syncope.common.lib.wa.GoogleMfaAuthAccount;
 import org.apache.syncope.common.rest.api.service.wa.GoogleMfaAuthAccountService;
 import org.apache.syncope.core.logic.wa.GoogleMfaAuthAccountLogic;
 import org.apache.syncope.core.rest.cxf.service.AbstractService;
-import org.springframework.stereotype.Service;
 
-@Service
 public class GoogleMfaAuthAccountServiceImpl extends AbstractService implements GoogleMfaAuthAccountService {
 
     protected final GoogleMfaAuthAccountLogic logic;

--- a/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/wa/GoogleMfaAuthTokenServiceImpl.java
+++ b/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/wa/GoogleMfaAuthTokenServiceImpl.java
@@ -25,9 +25,7 @@ import org.apache.syncope.common.lib.wa.GoogleMfaAuthToken;
 import org.apache.syncope.common.rest.api.service.wa.GoogleMfaAuthTokenService;
 import org.apache.syncope.core.logic.wa.GoogleMfaAuthTokenLogic;
 import org.apache.syncope.core.rest.cxf.service.AbstractService;
-import org.springframework.stereotype.Service;
 
-@Service
 public class GoogleMfaAuthTokenServiceImpl extends AbstractService implements GoogleMfaAuthTokenService {
 
     protected final GoogleMfaAuthTokenLogic logic;

--- a/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/wa/ImpersonationServiceImpl.java
+++ b/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/wa/ImpersonationServiceImpl.java
@@ -23,9 +23,7 @@ import org.apache.syncope.common.lib.wa.ImpersonationAccount;
 import org.apache.syncope.common.rest.api.service.wa.ImpersonationService;
 import org.apache.syncope.core.logic.wa.ImpersonationLogic;
 import org.apache.syncope.core.rest.cxf.service.AbstractService;
-import org.springframework.stereotype.Service;
 
-@Service
 public class ImpersonationServiceImpl extends AbstractService implements ImpersonationService {
 
     protected final ImpersonationLogic logic;

--- a/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/wa/MfaTrustStorageServiceImpl.java
+++ b/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/wa/MfaTrustStorageServiceImpl.java
@@ -25,9 +25,7 @@ import org.apache.syncope.common.rest.api.service.wa.MfaTrustStorageService;
 import org.apache.syncope.core.logic.wa.MfaTrusStorageLogic;
 import org.apache.syncope.core.rest.cxf.service.AbstractService;
 import org.springframework.data.domain.Page;
-import org.springframework.stereotype.Service;
 
-@Service
 public class MfaTrustStorageServiceImpl extends AbstractService implements MfaTrustStorageService {
 
     protected final MfaTrusStorageLogic logic;

--- a/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/wa/WAClientAppServiceImpl.java
+++ b/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/wa/WAClientAppServiceImpl.java
@@ -24,9 +24,7 @@ import org.apache.syncope.common.lib.wa.WAClientApp;
 import org.apache.syncope.common.rest.api.service.wa.WAClientAppService;
 import org.apache.syncope.core.logic.wa.WAClientAppLogic;
 import org.apache.syncope.core.rest.cxf.service.AbstractService;
-import org.springframework.stereotype.Service;
 
-@Service
 public class WAClientAppServiceImpl extends AbstractService implements WAClientAppService {
 
     protected final WAClientAppLogic logic;

--- a/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/wa/WAConfigServiceImpl.java
+++ b/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/wa/WAConfigServiceImpl.java
@@ -23,9 +23,7 @@ import org.apache.syncope.common.lib.Attr;
 import org.apache.syncope.common.rest.api.service.wa.WAConfigService;
 import org.apache.syncope.core.logic.wa.WAConfigLogic;
 import org.apache.syncope.core.rest.cxf.service.AbstractService;
-import org.springframework.stereotype.Service;
 
-@Service
 public class WAConfigServiceImpl extends AbstractService implements WAConfigService {
 
     protected final WAConfigLogic logic;

--- a/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/wa/WebAuthnRegistrationServiceImpl.java
+++ b/core/am/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/wa/WebAuthnRegistrationServiceImpl.java
@@ -23,9 +23,7 @@ import org.apache.syncope.common.lib.wa.WebAuthnAccount;
 import org.apache.syncope.common.rest.api.service.wa.WebAuthnRegistrationService;
 import org.apache.syncope.core.logic.wa.WebAuthnRegistrationLogic;
 import org.apache.syncope.core.rest.cxf.service.AbstractService;
-import org.springframework.stereotype.Service;
 
-@Service
 public class WebAuthnRegistrationServiceImpl extends AbstractService implements WebAuthnRegistrationService {
 
     protected final WebAuthnRegistrationLogic logic;

--- a/core/idm/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/ConnectorServiceImpl.java
+++ b/core/idm/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/ConnectorServiceImpl.java
@@ -27,9 +27,7 @@ import org.apache.syncope.common.lib.to.ConnInstanceTO;
 import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.common.rest.api.service.ConnectorService;
 import org.apache.syncope.core.logic.ConnectorLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class ConnectorServiceImpl extends AbstractService implements ConnectorService {
 
     protected final ConnectorLogic logic;

--- a/core/idm/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/ReconciliationServiceImpl.java
+++ b/core/idm/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/ReconciliationServiceImpl.java
@@ -51,9 +51,7 @@ import org.apache.syncope.core.persistence.api.search.FilterVisitor;
 import org.apache.syncope.core.persistence.api.search.SearchCondVisitor;
 import org.apache.syncope.core.spring.security.AuthContextUtils;
 import org.identityconnectors.framework.common.objects.filter.Filter;
-import org.springframework.stereotype.Service;
 
-@Service
 public class ReconciliationServiceImpl extends AbstractSearchService implements ReconciliationService {
 
     protected final ReconciliationLogic logic;

--- a/core/idm/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/RemediationServiceImpl.java
+++ b/core/idm/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/RemediationServiceImpl.java
@@ -32,9 +32,7 @@ import org.apache.syncope.core.logic.RemediationLogic;
 import org.apache.syncope.core.persistence.api.dao.NotFoundException;
 import org.apache.syncope.core.persistence.api.entity.AnyUtilsFactory;
 import org.springframework.data.domain.Page;
-import org.springframework.stereotype.Service;
 
-@Service
 public class RemediationServiceImpl extends AbstractService implements RemediationService {
 
     protected final RemediationLogic logic;

--- a/core/idm/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/ResourceServiceImpl.java
+++ b/core/idm/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/ResourceServiceImpl.java
@@ -45,9 +45,7 @@ import org.apache.syncope.core.persistence.api.search.FilterVisitor;
 import org.identityconnectors.framework.common.objects.SearchResult;
 import org.identityconnectors.framework.common.objects.filter.Filter;
 import org.springframework.data.domain.Sort;
-import org.springframework.stereotype.Service;
 
-@Service
 public class ResourceServiceImpl extends AbstractService implements ResourceService {
 
     protected final ResourceLogic logic;

--- a/core/self-keymaster-starter/src/main/java/org/apache/syncope/core/keymaster/rest/cxf/service/ConfParamServiceImpl.java
+++ b/core/self-keymaster-starter/src/main/java/org/apache/syncope/core/keymaster/rest/cxf/service/ConfParamServiceImpl.java
@@ -28,9 +28,7 @@ import org.apache.syncope.common.keymaster.rest.api.service.ConfParamService;
 import org.apache.syncope.core.logic.ConfParamLogic;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
 
-@Service
 public class ConfParamServiceImpl implements ConfParamService {
 
     private static final long serialVersionUID = 3954522705963997651L;

--- a/core/self-keymaster-starter/src/main/java/org/apache/syncope/core/keymaster/rest/cxf/service/DomainServiceImpl.java
+++ b/core/self-keymaster-starter/src/main/java/org/apache/syncope/core/keymaster/rest/cxf/service/DomainServiceImpl.java
@@ -28,9 +28,7 @@ import org.apache.syncope.common.keymaster.rest.api.service.DomainService;
 import org.apache.syncope.common.lib.types.CipherAlgorithm;
 import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.core.logic.DomainLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class DomainServiceImpl implements DomainService {
 
     private static final long serialVersionUID = -375255764389240615L;

--- a/core/self-keymaster-starter/src/main/java/org/apache/syncope/core/keymaster/rest/cxf/service/NetworkServiceServiceImpl.java
+++ b/core/self-keymaster-starter/src/main/java/org/apache/syncope/core/keymaster/rest/cxf/service/NetworkServiceServiceImpl.java
@@ -22,9 +22,7 @@ import java.util.List;
 import org.apache.syncope.common.keymaster.client.api.model.NetworkService;
 import org.apache.syncope.common.keymaster.rest.api.service.NetworkServiceService;
 import org.apache.syncope.core.logic.NetworkServiceLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class NetworkServiceServiceImpl implements NetworkServiceService {
 
     private static final long serialVersionUID = 4160287655489345100L;

--- a/ext/flowable/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/BpmnProcessServiceImpl.java
+++ b/ext/flowable/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/BpmnProcessServiceImpl.java
@@ -27,9 +27,7 @@ import org.apache.syncope.common.lib.types.BpmnProcessFormat;
 import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.common.rest.api.service.BpmnProcessService;
 import org.apache.syncope.core.logic.BpmnProcessLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class BpmnProcessServiceImpl extends AbstractService implements BpmnProcessService {
 
     protected final BpmnProcessLogic logic;

--- a/ext/flowable/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/UserRequestServiceImpl.java
+++ b/ext/flowable/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/UserRequestServiceImpl.java
@@ -30,9 +30,7 @@ import org.apache.syncope.common.rest.api.service.UserRequestService;
 import org.apache.syncope.core.logic.UserRequestLogic;
 import org.apache.syncope.core.persistence.api.dao.UserDAO;
 import org.springframework.data.domain.Page;
-import org.springframework.stereotype.Service;
 
-@Service
 public class UserRequestServiceImpl extends AbstractService implements UserRequestService {
 
     protected final UserRequestLogic logic;

--- a/ext/flowable/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/UserWorkflowTaskServiceImpl.java
+++ b/ext/flowable/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/UserWorkflowTaskServiceImpl.java
@@ -24,9 +24,7 @@ import org.apache.syncope.common.lib.to.WorkflowTask;
 import org.apache.syncope.common.lib.to.WorkflowTaskExecInput;
 import org.apache.syncope.common.rest.api.service.UserWorkflowTaskService;
 import org.apache.syncope.core.logic.UserWorkflowTaskLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class UserWorkflowTaskServiceImpl extends AbstractService implements UserWorkflowTaskService {
 
     protected final UserWorkflowTaskLogic logic;

--- a/ext/oidcc4ui/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/OIDCC4UIProviderServiceImpl.java
+++ b/ext/oidcc4ui/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/OIDCC4UIProviderServiceImpl.java
@@ -25,9 +25,7 @@ import org.apache.syncope.common.lib.to.OIDCC4UIProviderTO;
 import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.common.rest.api.service.OIDCC4UIProviderService;
 import org.apache.syncope.core.logic.OIDCC4UIProviderLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class OIDCC4UIProviderServiceImpl extends AbstractService implements OIDCC4UIProviderService {
 
     protected final OIDCC4UIProviderLogic logic;

--- a/ext/oidcc4ui/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/OIDCC4UIServiceImpl.java
+++ b/ext/oidcc4ui/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/OIDCC4UIServiceImpl.java
@@ -24,9 +24,7 @@ import org.apache.syncope.common.lib.oidc.OIDCLoginResponse;
 import org.apache.syncope.common.lib.oidc.OIDCRequest;
 import org.apache.syncope.common.rest.api.service.OIDCC4UIService;
 import org.apache.syncope.core.logic.OIDCC4UILogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class OIDCC4UIServiceImpl extends AbstractService implements OIDCC4UIService {
 
     protected final OIDCC4UILogic logic;

--- a/ext/saml2sp4ui/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/SAML2SP4UIIdPServiceImpl.java
+++ b/ext/saml2sp4ui/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/SAML2SP4UIIdPServiceImpl.java
@@ -25,9 +25,7 @@ import org.apache.syncope.common.lib.to.SAML2SP4UIIdPTO;
 import org.apache.syncope.common.rest.api.RESTHeaders;
 import org.apache.syncope.common.rest.api.service.SAML2SP4UIIdPService;
 import org.apache.syncope.core.logic.SAML2SP4UIIdPLogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class SAML2SP4UIIdPServiceImpl extends AbstractService implements SAML2SP4UIIdPService {
 
     protected final SAML2SP4UIIdPLogic logic;

--- a/ext/saml2sp4ui/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/SAML2SP4UIServiceImpl.java
+++ b/ext/saml2sp4ui/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/SAML2SP4UIServiceImpl.java
@@ -29,9 +29,7 @@ import org.apache.syncope.common.lib.saml2.SAML2Request;
 import org.apache.syncope.common.lib.saml2.SAML2Response;
 import org.apache.syncope.common.rest.api.service.SAML2SP4UIService;
 import org.apache.syncope.core.logic.SAML2SP4UILogic;
-import org.springframework.stereotype.Service;
 
-@Service
 public class SAML2SP4UIServiceImpl extends AbstractService implements SAML2SP4UIService {
 
     protected final SAML2SP4UILogic logic;


### PR DESCRIPTION
This is a 2nd continuation of https://github.com/apache/syncope/pull/1001, where @Service annotations are removed in favor of explicit bean definitions.