### PR TITLE
Chore: remove explicit type args where possible

### DIFF
--- a/client/am/console/src/main/java/org/apache/syncope/client/console/panels/SRARouteFilterPanel.java
+++ b/client/am/console/src/main/java/org/apache/syncope/client/console/panels/SRARouteFilterPanel.java
@@ -54,7 +54,7 @@ public class SRARouteFilterPanel extends Panel {
         add(filterContainer);
 
         filterContainer.add(new Label("factoryInfo", Model.of()).add(new PopoverBehavior(
-                Model.<String>of(),
+                Model.of(),
                 Model.of(getString("factoryInfo.help")),
                 new PopoverConfig().withHtml(true).withPlacement(TooltipConfig.Placement.right)) {
 

--- a/client/am/console/src/main/java/org/apache/syncope/client/console/panels/SRARoutePredicatePanel.java
+++ b/client/am/console/src/main/java/org/apache/syncope/client/console/panels/SRARoutePredicatePanel.java
@@ -56,7 +56,7 @@ public class SRARoutePredicatePanel extends Panel {
         add(predicateContainer);
 
         predicateContainer.add(new Label("factoryInfo", Model.of()).add(new PopoverBehavior(
-                Model.<String>of(),
+                Model.of(),
                 Model.of(getString("factoryInfo.help")),
                 new PopoverConfig().withHtml(true).withPlacement(TooltipConfig.Placement.right)) {
 

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/panels/ConnObjectDetails.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/panels/ConnObjectDetails.java
@@ -21,7 +21,6 @@ package org.apache.syncope.client.console.panels;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.syncope.client.console.wizards.any.ConnObjectPanel;
 import org.apache.syncope.common.lib.to.ConnObject;
-import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 
 public class ConnObjectDetails extends MultilevelPanel.SecondLevel {
@@ -34,7 +33,7 @@ public class ConnObjectDetails extends MultilevelPanel.SecondLevel {
         MultilevelPanel mlp = new MultilevelPanel("details");
         mlp.setFirstLevel(new ConnObjectPanel(
                 MultilevelPanel.FIRST_LEVEL_ID,
-                Pair.<IModel<?>, IModel<?>>of(Model.of(), Model.of()),
+                Pair.of(Model.of(), Model.of()),
                 Pair.of((ConnObject) null, connObjectTO),
                 true));
         add(mlp);

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/status/LinkedAccountStatusPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/status/LinkedAccountStatusPanel.java
@@ -25,7 +25,6 @@ import org.apache.syncope.client.console.wizards.any.ConnObjectPanel;
 import org.apache.syncope.client.ui.commons.Constants;
 import org.apache.syncope.common.lib.to.ConnObject;
 import org.apache.syncope.common.lib.to.ReconStatus;
-import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.ResourceModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
@@ -54,7 +53,7 @@ public class LinkedAccountStatusPanel extends RemoteObjectPanel {
 
         add(new ConnObjectPanel(
                 REMOTE_OBJECT_PANEL_ID,
-                Pair.<IModel<?>, IModel<?>>of(Model.of(Constants.SYNCOPE), new ResourceModel("resource")),
+                Pair.of(Model.of(Constants.SYNCOPE), new ResourceModel("resource")),
                 getConnObjectTOs(),
                 false));
     }

--- a/client/idm/console/src/main/java/org/apache/syncope/client/console/status/ReconStatusPanel.java
+++ b/client/idm/console/src/main/java/org/apache/syncope/client/console/status/ReconStatusPanel.java
@@ -25,7 +25,6 @@ import org.apache.syncope.client.console.wizards.any.ConnObjectPanel;
 import org.apache.syncope.client.ui.commons.Constants;
 import org.apache.syncope.common.lib.to.ConnObject;
 import org.apache.syncope.common.lib.to.ReconStatus;
-import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.Model;
 import org.apache.wicket.model.ResourceModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
@@ -54,7 +53,7 @@ public class ReconStatusPanel extends RemoteObjectPanel {
 
         add(new ConnObjectPanel(
                 REMOTE_OBJECT_PANEL_ID,
-                Pair.<IModel<?>, IModel<?>>of(Model.of(Constants.SYNCOPE), new ResourceModel("resource")),
+                Pair.of(Model.of(Constants.SYNCOPE), new ResourceModel("resource")),
                 getConnObjectTOs(),
                 false));
     }

--- a/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/Constants.java
+++ b/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/Constants.java
@@ -149,7 +149,7 @@ public final class Constants {
                 append("</a>");
 
         return new Label("jexlInfo", Model.of()).add(new PopoverBehavior(
-                Model.<String>of(),
+                Model.of(),
                 Model.of(body.toString()),
                 new PopoverConfig().withHtml(true).withPlacement(placement)) {
 

--- a/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/markup/html/form/FieldPanel.java
+++ b/client/idrepo/common-ui/src/main/java/org/apache/syncope/client/ui/commons/markup/html/form/FieldPanel.java
@@ -71,8 +71,8 @@ public abstract class FieldPanel<T extends Serializable> extends AbstractFieldPa
     public FieldPanel<T> setTitle(final String title, final boolean html) {
         this.title = title;
         field.add(new PopoverBehavior(
-                Model.<String>of(),
-                Optional.ofNullable(title).map(Model::of).orElseGet(Model::<String>of),
+                Model.of(),
+                Optional.ofNullable(title).map(Model::of).orElseGet(Model::of),
                 new PopoverConfig().withHtml(html).withHoverTrigger().withPlacement(
                         index.getObject() != null && index.getObject() == 0
                         ? TooltipConfig.Placement.bottom

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/notifications/NotificationWizardBuilder.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/notifications/NotificationWizardBuilder.java
@@ -303,7 +303,7 @@ public class NotificationWizardBuilder extends BaseAjaxWizardBuilder<Notificatio
 
                 @Override
                 protected Pair<String, List<SearchClause>> newModelObject() {
-                    return Pair.<String, List<SearchClause>>of(AnyTypeKind.USER.name(), new ArrayList<>());
+                    return Pair.of(AnyTypeKind.USER.name(), new ArrayList<>());
                 }
 
                 @Override

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/BeanPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/BeanPanel.java
@@ -149,7 +149,7 @@ public class BeanPanel<T extends Serializable> extends Panel {
             private void setDescription(final ListItem<Field> item, final String description) {
                 Fragment fragment = new Fragment("description", "descriptionFragment", this);
                 fragment.add(new Label("descriptionLabel", Model.of()).add(new PopoverBehavior(
-                        Model.<String>of(),
+                        Model.of(),
                         Model.of(description),
                         new PopoverConfig().withPlacement(TooltipConfig.Placement.right)) {
 

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/Realm.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/Realm.java
@@ -56,7 +56,6 @@ import org.apache.wicket.extensions.markup.html.tabs.ITab;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.html.basic.Label;
 import org.apache.wicket.markup.html.panel.Panel;
-import org.apache.wicket.model.IModel;
 import org.apache.wicket.model.ResourceModel;
 import org.apache.wicket.spring.injection.annot.SpringBean;
 import org.slf4j.Logger;
@@ -251,7 +250,7 @@ public abstract class Realm extends WizardMgtPanel<RealmTO> {
             this.bean = bean;
             add(new ConnObjectPanel(
                     REMOTE_OBJECT_PANEL_ID,
-                    Pair.<IModel<?>, IModel<?>>of(new ResourceModel("before"), new ResourceModel("after")),
+                    Pair.of(new ResourceModel("before"), new ResourceModel("after")),
                     getConnObjectTOs(),
                     false));
         }

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/RealmChoicePanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/panels/RealmChoicePanel.java
@@ -469,7 +469,7 @@ public class RealmChoicePanel extends Panel {
 
         realms.forEach(realm -> {
             List<RealmTO> children = new ArrayList<>();
-            tree.put(realm.getKey(), Pair.<RealmTO, List<RealmTO>>of(realm, children));
+            tree.put(realm.getKey(), Pair.of(realm, children));
 
             if (cache.containsKey(realm.getKey())) {
                 children.addAll(cache.get(realm.getKey()));

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/rest/SchemaRestClient.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/rest/SchemaRestClient.java
@@ -77,7 +77,7 @@ public class SchemaRestClient extends BaseRestClient {
 
         List<T> schemas = new ArrayList<>();
         try {
-            schemas.addAll(getService(SchemaService.class).<T>search(builder.build()));
+            schemas.addAll(getService(SchemaService.class).search(builder.build()));
         } catch (SyncopeClientException e) {
             LOG.error("While getting all {} schemas for {}", schemaType, anyTypeClasses, e);
         }

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wicket/extensions/markup/html/repeater/data/table/AjaxFallbackDataTable.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wicket/extensions/markup/html/repeater/data/table/AjaxFallbackDataTable.java
@@ -145,7 +145,7 @@ public class AjaxFallbackDataTable<T extends Serializable, S> extends DataTable<
                             togglePanel.toggleWithContent(target, getActions(model), model.getObject());
                         } else {
                             final AjaxDataTablePanel<?, ?> parent = findParent(AjaxDataTablePanel.class);
-                            final Model<Boolean> isCheck = Model.<Boolean>of(Boolean.FALSE);
+                            final Model<Boolean> isCheck = Model.of(Boolean.FALSE);
 
                             parent.visitChildren(CheckGroupSelector.class, (selector, ivisit) -> {
                                 if (selector.getMarkupId().equalsIgnoreCase(lastFocussedElementId)) {

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/widgets/JobActionPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/widgets/JobActionPanel.java
@@ -71,7 +71,7 @@ public class JobActionPanel extends WizardMgtPanel<Serializable> {
         if (jobTO.isRunning()) {
             controls = new Fragment("controls", "runningFragment", this);
             controls.add(new Label("status", Model.of()).add(new PopoverBehavior(
-                    Model.<String>of(),
+                    Model.of(),
                     Model.of("<pre>" + (jobTO.getStatus() == null ? StringUtils.EMPTY : jobTO.getStatus()) + "</pre>"),
                     new PopoverConfig().withAnimation(true).withHoverTrigger().withHtml(true).
                             withPlacement(TooltipConfig.Placement.left))));

--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/StatusPanel.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/wizards/any/StatusPanel.java
@@ -230,7 +230,7 @@ public class StatusPanel extends Panel {
 
             add(new ConnObjectPanel(
                     REMOTE_OBJECT_PANEL_ID,
-                    Pair.<IModel<?>, IModel<?>>of(new ResourceModel("before"), new ResourceModel("after")),
+                    Pair.of(new ResourceModel("before"), new ResourceModel("after")),
                     getConnObjectTOs(),
                     false));
         }

--- a/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/rest/SchemaRestClient.java
+++ b/client/idrepo/enduser/src/main/java/org/apache/syncope/client/enduser/rest/SchemaRestClient.java
@@ -75,7 +75,7 @@ public class SchemaRestClient extends BaseRestClient {
 
         List<T> schemas = new ArrayList<>();
         try {
-            schemas.addAll(getService(SchemaService.class).<T>search(builder.build()));
+            schemas.addAll(getService(SchemaService.class).search(builder.build()));
         } catch (SyncopeClientException e) {
             LOG.error("While getting all {} schemas for {}", schemaType, anyTypeClasses, e);
         }

--- a/common/idrepo/lib/src/main/java/org/apache/syncope/common/lib/AnyOperations.java
+++ b/common/idrepo/lib/src/main/java/org/apache/syncope/common/lib/AnyOperations.java
@@ -320,12 +320,10 @@ public final class AnyOperations {
         Map<Pair<String, String>, LinkedAccountTO> originalAccounts =
                 EntityTOUtils.buildLinkedAccountMap(original.getLinkedAccounts());
 
-        updatedAccounts.entrySet().
-            forEach(entry -> {
-                    result.getLinkedAccounts().add(new LinkedAccountUR.Builder().
-                            operation(PatchOperation.ADD_REPLACE).
-                            linkedAccountTO(entry.getValue()).build());
-                });
+        updatedAccounts.forEach((key, value) ->
+            result.getLinkedAccounts().add(new LinkedAccountUR.Builder().
+                operation(PatchOperation.ADD_REPLACE).
+                linkedAccountTO(value).build()));
 
         if (!incremental) {
             originalAccounts.keySet().stream().filter(account -> !updatedAccounts.containsKey(account)).

--- a/common/idrepo/lib/src/main/java/org/apache/syncope/common/lib/search/AnyObjectFiqlSearchConditionBuilder.java
+++ b/common/idrepo/lib/src/main/java/org/apache/syncope/common/lib/search/AnyObjectFiqlSearchConditionBuilder.java
@@ -46,7 +46,7 @@ public class AnyObjectFiqlSearchConditionBuilder extends AbstractFiqlSearchCondi
 
     @Override
     public String query() {
-        return new FiqlSearchConditionBuilder.Builder(Collections.<String, String>emptyMap()).
+        return new FiqlSearchConditionBuilder.Builder(Collections.emptyMap()).
                 is(SpecialAttr.TYPE.toString()).equalTo(type).query();
     }
 

--- a/core/idrepo/logic/src/main/java/org/apache/syncope/core/logic/AccessTokenLogic.java
+++ b/core/idrepo/logic/src/main/java/org/apache/syncope/core/logic/AccessTokenLogic.java
@@ -84,7 +84,7 @@ public class AccessTokenLogic extends AbstractTransactionalLogic<AccessTokenTO> 
 
         return binder.create(
                 AuthContextUtils.getUsername(),
-                Collections.<String, Object>emptyMap(),
+                Collections.emptyMap(),
                 getAuthorities(),
                 false);
     }

--- a/core/persistence-common/src/main/java/org/apache/syncope/core/persistence/common/attrvalue/EmailAddressValidator.java
+++ b/core/persistence-common/src/main/java/org/apache/syncope/core/persistence/common/attrvalue/EmailAddressValidator.java
@@ -30,7 +30,7 @@ public class EmailAddressValidator extends AbstractValidator {
 
     @Override
     protected void doValidate(final PlainSchema schema, final PlainAttrValue attrValue) {
-        Matcher matcher = Entity.EMAIL_PATTERN.matcher(attrValue.<CharSequence>getValue());
+        Matcher matcher = Entity.EMAIL_PATTERN.matcher(attrValue.getValue());
         if (!matcher.matches()) {
             throw new InvalidPlainAttrValueException("\"" + attrValue.getValue() + "\" is not a valid email address");
         }

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/AnyObjectDataBinderImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/AnyObjectDataBinderImpl.java
@@ -138,7 +138,7 @@ public class AnyObjectDataBinderImpl extends AbstractAnyDataBinder implements An
 
         Map<VirSchema, List<String>> virAttrValues = details
                 ? virAttrHandler.getValues(anyObject)
-                : Collections.<VirSchema, List<String>>emptyMap();
+                : Collections.emptyMap();
         fillTO(anyObjectTO,
                 anyObject.getRealm().getFullPath(),
                 anyObject.getAuxClasses(),

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/GroupDataBinderImpl.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/data/GroupDataBinderImpl.java
@@ -510,7 +510,7 @@ public class GroupDataBinderImpl extends AbstractAnyDataBinder implements GroupD
         Map<DerSchema, String> derAttrValues = derAttrHandler.getValues(group);
         Map<VirSchema, List<String>> virAttrValues = details
                 ? virAttrHandler.getValues(group)
-                : Collections.<VirSchema, List<String>>emptyMap();
+                : Collections.emptyMap();
         fillTO(groupTO,
                 group.getRealm().getFullPath(),
                 group.getAuxClasses(),

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/job/DefaultJobManager.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/job/DefaultJobManager.java
@@ -251,11 +251,11 @@ public class DefaultJobManager implements JobManager, SyncopeCoreLoader {
     public void load(final String domain) {
         AuthContextUtils.runAsAdmin(domain, () -> {
             // 1. jobs for SchedTasks
-            Set<SchedTask> tasks = new HashSet<>(taskDAO.<SchedTask>findAll(TaskType.SCHEDULED));
-            tasks.addAll(taskDAO.<SchedTask>findAll(TaskType.PULL));
-            tasks.addAll(taskDAO.<SchedTask>findAll(TaskType.PUSH));
-            tasks.addAll(taskDAO.<SchedTask>findAll(TaskType.MACRO));
-            tasks.addAll(taskDAO.<SchedTask>findAll(TaskType.LIVE_SYNC));
+            Set<SchedTask> tasks = new HashSet<>(taskDAO.findAll(TaskType.SCHEDULED));
+            tasks.addAll(taskDAO.findAll(TaskType.PULL));
+            tasks.addAll(taskDAO.findAll(TaskType.PUSH));
+            tasks.addAll(taskDAO.findAll(TaskType.MACRO));
+            tasks.addAll(taskDAO.findAll(TaskType.LIVE_SYNC));
 
             boolean loadException = false;
             for (Iterator<SchedTask> it = tasks.iterator(); it.hasNext() && !loadException;) {
@@ -356,11 +356,11 @@ public class DefaultJobManager implements JobManager, SyncopeCoreLoader {
     public void unload(final String domain) {
         AuthContextUtils.runAsAdmin(domain, () -> {
             // 1. jobs for SchedTasks
-            Set<SchedTask> tasks = new HashSet<>(taskDAO.<SchedTask>findAll(TaskType.SCHEDULED));
-            tasks.addAll(taskDAO.<SchedTask>findAll(TaskType.PULL));
-            tasks.addAll(taskDAO.<SchedTask>findAll(TaskType.PUSH));
-            tasks.addAll(taskDAO.<SchedTask>findAll(TaskType.MACRO));
-            tasks.addAll(taskDAO.<SchedTask>findAll(TaskType.LIVE_SYNC));
+            Set<SchedTask> tasks = new HashSet<>(taskDAO.findAll(TaskType.SCHEDULED));
+            tasks.addAll(taskDAO.findAll(TaskType.PULL));
+            tasks.addAll(taskDAO.findAll(TaskType.PUSH));
+            tasks.addAll(taskDAO.findAll(TaskType.MACRO));
+            tasks.addAll(taskDAO.findAll(TaskType.LIVE_SYNC));
 
             tasks.forEach(task -> {
                 LOG.debug("Unloading job for {} Task {} {}",

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/job/notification/AbstractNotificationJobDelegate.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/job/notification/AbstractNotificationJobDelegate.java
@@ -166,7 +166,7 @@ public abstract class AbstractNotificationJobDelegate implements NotificationJob
     @Transactional
     @Override
     public void execute(final String executor) {
-        List<NotificationTask> tasks = taskDAO.<NotificationTask>findToExec(TaskType.NOTIFICATION);
+        List<NotificationTask> tasks = taskDAO.findToExec(TaskType.NOTIFICATION);
 
         setStatus("Sending out " + tasks.size() + " notifications");
 

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/notification/DefaultNotificationManager.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/notification/DefaultNotificationManager.java
@@ -189,7 +189,7 @@ public class DefaultNotificationManager implements NotificationManager {
         List<User> recipients = new ArrayList<>();
 
         Optional.ofNullable(notification.getRecipientsFIQL()).
-                ifPresent(fiql -> recipients.addAll(anySearchDAO.<User>search(
+                ifPresent(fiql -> recipients.addAll(anySearchDAO.search(
                 SearchCondConverter.convert(searchCondVisitor, fiql), List.of(), AnyTypeKind.USER)));
 
         if (notification.isSelfAsRecipient() && any instanceof final User user) {

--- a/ext/flowable/client-enduser/src/main/java/org/apache/syncope/client/enduser/pages/Flowable.java
+++ b/ext/flowable/client-enduser/src/main/java/org/apache/syncope/client/enduser/pages/Flowable.java
@@ -38,7 +38,6 @@ import org.apache.wicket.ajax.markup.html.AjaxLink;
 import org.apache.wicket.ajax.markup.html.navigation.paging.AjaxPagingNavigator;
 import org.apache.wicket.extensions.markup.html.repeater.util.SortParam;
 import org.apache.wicket.extensions.markup.html.tabs.AbstractTab;
-import org.apache.wicket.extensions.markup.html.tabs.ITab;
 import org.apache.wicket.markup.html.WebMarkupContainer;
 import org.apache.wicket.markup.repeater.Item;
 import org.apache.wicket.markup.repeater.data.DataView;
@@ -84,7 +83,7 @@ public class Flowable extends BaseExtPage {
             @Override
             protected void populateItem(final Item<UserRequest> item) {
                 final UserRequest userRequest = item.getModelObject();
-                item.add(new Accordion("userRequestDetails", Collections.<ITab>singletonList(new AbstractTab(
+                item.add(new Accordion("userRequestDetails", Collections.singletonList(new AbstractTab(
                         new StringResourceModel("user.requests.accordion", container, Model.of(userRequest))) {
 
                     private static final long serialVersionUID = 1037272333056449378L;

--- a/ext/flowable/logic/src/main/java/org/apache/syncope/core/logic/UserWorkflowTaskLogic.java
+++ b/ext/flowable/logic/src/main/java/org/apache/syncope/core/logic/UserWorkflowTaskLogic.java
@@ -80,7 +80,7 @@ public class UserWorkflowTaskLogic extends AbstractTransactionalLogic<EntityTO> 
 
         List<PropagationTaskInfo> taskInfos = propagationManager.getUserUpdateTasks(
                 new UserWorkflowResult<>(
-                        Pair.<UserUR, Boolean>of(userUR, null),
+                        Pair.of(userUR, null),
                         updated.getPropByRes(),
                         updated.getPropByLinkedAccount(),
                         updated.getPerformedTasks()));

--- a/ext/openfga/client-openfga/src/test/java/org/apache/syncope/ext/openfga/client/OpenFGAClientTest.java
+++ b/ext/openfga/client-openfga/src/test/java/org/apache/syncope/ext/openfga/client/OpenFGAClientTest.java
@@ -239,7 +239,7 @@ class OpenFGAClientTest {
                     try {
                         return client.read(request).getTuples();
                     } catch (Exception e) {
-                        return List.<Tuple>of();
+                        return List.of();
                     }
                 }, list -> !list.isEmpty());
 

--- a/ext/saml2sp4ui/client-console/src/main/java/org/apache/syncope/client/console/wizards/mapping/SAML2IdPMappingPanel.java
+++ b/ext/saml2sp4ui/client-console/src/main/java/org/apache/syncope/client/console/wizards/mapping/SAML2IdPMappingPanel.java
@@ -72,7 +72,7 @@ public class SAML2IdPMappingPanel extends AbstractMappingPanel {
 
     @Override
     protected IModel<List<String>> getExtAttrNames() {
-        return Model.ofList(Collections.<String>singletonList("NameID"));
+        return Model.ofList(Collections.singletonList("NameID"));
     }
 
     @Override

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/MacroTaskITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/MacroTaskITCase.java
@@ -213,7 +213,7 @@ public class MacroTaskITCase extends AbstractITCase {
         Response response = TASK_SERVICE.create(TaskType.MACRO, task);
         String newTaskKey = response.getHeaderString(RESTHeaders.RESOURCE_KEY);
 
-        task = TASK_SERVICE.<MacroTaskTO>read(TaskType.MACRO, newTaskKey, false);
+        task = TASK_SERVICE.read(TaskType.MACRO, newTaskKey, false);
         assertEquals(3, task.getCommands().size());
         assertEquals("GroovyCommand", task.getCommands().get(0).getKey());
         assertEquals(TestCommand.class.getSimpleName(), task.getCommands().get(1).getKey());
@@ -228,7 +228,7 @@ public class MacroTaskITCase extends AbstractITCase {
 
         TASK_SERVICE.update(TaskType.MACRO, task);
 
-        task = TASK_SERVICE.<MacroTaskTO>read(TaskType.MACRO, newTaskKey, false);
+        task = TASK_SERVICE.read(TaskType.MACRO, newTaskKey, false);
         assertEquals(4, task.getCommands().size());
         assertEquals("GroovyCommand", task.getCommands().get(0).getKey());
         assertEquals(TestCommand.class.getSimpleName(), task.getCommands().get(1).getKey());

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/PushTaskITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/PushTaskITCase.java
@@ -77,7 +77,7 @@ public class PushTaskITCase extends AbstractTaskITCase {
 
     @Test
     public void read() {
-        PushTaskTO pushTaskTO = TASK_SERVICE.<PushTaskTO>read(
+        PushTaskTO pushTaskTO = TASK_SERVICE.read(
                 TaskType.PUSH, "0bc11a19-6454-45c2-a4e3-ceef84e5d79b", true);
         assertEquals(UnmatchingRule.ASSIGN, pushTaskTO.getUnmatchingRule());
         assertEquals(MatchingRule.UPDATE, pushTaskTO.getMatchingRule());

--- a/sra/src/main/java/org/apache/syncope/sra/security/cas/CASAuthenticationWebFilter.java
+++ b/sra/src/main/java/org/apache/syncope/sra/security/cas/CASAuthenticationWebFilter.java
@@ -18,7 +18,6 @@
  */
 package org.apache.syncope.sra.security.cas;
 
-import java.net.URI;
 import org.apache.syncope.sra.security.web.server.DoNothingIfCommittedServerRedirectStrategy;
 import org.apache.syncope.sra.session.SessionUtils;
 import org.apereo.cas.client.Protocol;
@@ -97,7 +96,7 @@ public class CASAuthenticationWebFilter extends AuthenticationWebFilter {
                 return webFilterExchange.getExchange().getSession().
                         flatMap(session -> redirectStrategy.sendRedirect(
                         webFilterExchange.getExchange(),
-                        session.<URI>getRequiredAttribute(SessionUtils.INITIAL_REQUEST_URI)));
+                        session.getRequiredAttribute(SessionUtils.INITIAL_REQUEST_URI)));
             }
         };
     }


### PR DESCRIPTION
Removes explicit type args where possible so that `Model.<String>of()` becomes `Model.of()`