### PR TITLE
Chore: update redundant collection ops (contains, add)

### DIFF
--- a/core/idrepo/logic/src/main/java/org/apache/syncope/core/logic/DelegationLogic.java
+++ b/core/idrepo/logic/src/main/java/org/apache/syncope/core/logic/DelegationLogic.java
@@ -55,7 +55,7 @@ public class DelegationLogic extends AbstractTransactionalLogic<DelegationTO> {
     }
 
     protected void securityChecks(final String delegating, final String entitlement) {
-        if (!AuthContextUtils.getAuthorizations().keySet().contains(entitlement)
+        if (!AuthContextUtils.getAuthorizations().containsKey(entitlement)
                 && (delegating == null || !delegating.equals(userDAO.findKey(AuthContextUtils.getUsername()).
                         orElseThrow(() -> new NotFoundException("Could not find authenticated user"))))) {
 
@@ -80,7 +80,7 @@ public class DelegationLogic extends AbstractTransactionalLogic<DelegationTO> {
     public List<DelegationTO> list() {
         Stream<DelegationTO> delegations = delegationDAO.findAll().stream().map(binder::getDelegationTO);
 
-        if (!AuthContextUtils.getAuthorizations().keySet().contains(IdRepoEntitlement.DELEGATION_LIST)) {
+        if (!AuthContextUtils.getAuthorizations().containsKey(IdRepoEntitlement.DELEGATION_LIST)) {
             String authUserKey = userDAO.findKey(AuthContextUtils.getUsername()).orElse(null);
             delegations = delegations.filter(delegation -> delegation.getDelegating().equals(authUserKey));
         }

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/content/XMLContentExporter.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/content/XMLContentExporter.java
@@ -241,9 +241,7 @@ public class XMLContentExporter extends AbstractXMLContentExporter {
 
                         pkNode.addChild(node);
 
-                        if (roots.contains(node)) {
-                            roots.remove(node);
-                        }
+                        roots.remove(node);
                     });
         }
 

--- a/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/content/XMLContentExporter.java
+++ b/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/content/XMLContentExporter.java
@@ -118,9 +118,7 @@ public class XMLContentExporter extends AbstractXMLContentExporter {
 
                         pkNode.addChild(node);
 
-                        if (roots.contains(node)) {
-                            roots.remove(node);
-                        }
+                        roots.remove(node);
                     });
         });
 

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/utils/TemplateUtils.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/utils/TemplateUtils.java
@@ -237,8 +237,8 @@ public class TemplateUtils {
                 fillRelationships((GroupableRelatableTO) realmMember, ((GroupableRelatableTO) template));
                 fillMemberships((GroupableRelatableTO) realmMember, ((GroupableRelatableTO) template));
 
-                userTO.getRoles()
-                    .forEach(role -> {
+                userTO.getRoles().
+                    forEach(role -> {
                         if (realmMember instanceof UserTO urm) {
                             urm.getRoles().add(role);
                         } else if (realmMember instanceof UserCR urm) {

--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/utils/TemplateUtils.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/utils/TemplateUtils.java
@@ -237,12 +237,13 @@ public class TemplateUtils {
                 fillRelationships((GroupableRelatableTO) realmMember, ((GroupableRelatableTO) template));
                 fillMemberships((GroupableRelatableTO) realmMember, ((GroupableRelatableTO) template));
 
-                userTO.getRoles().forEach(role -> {
-                    if (realmMember instanceof UserTO urm && !urm.getRoles().contains(role)) {
-                        urm.getRoles().add(role);
-                    } else if (realmMember instanceof UserCR urm && !urm.getRoles().contains(role)) {
-                        urm.getRoles().add(role);
-                    }
+                userTO.getRoles()
+                    .forEach(role -> {
+                        if (realmMember instanceof UserTO urm) {
+                            urm.getRoles().add(role);
+                        } else if (realmMember instanceof UserCR urm) {
+                            urm.getRoles().add(role);
+                        }
                 });
 
                 userTO.getLinkedAccounts().forEach(account -> {

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AuthenticationITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AuthenticationITCase.java
@@ -85,21 +85,21 @@ public class AuthenticationITCase extends AbstractITCase {
         // 1. as anonymous
         Triple<Map<String, Set<String>>, List<String>, UserTO> self = ANONYMOUS_CLIENT.self();
         assertEquals(1, self.getLeft().size());
-        assertTrue(self.getLeft().keySet().contains(IdRepoEntitlement.ANONYMOUS));
+        assertTrue(self.getLeft().containsKey(IdRepoEntitlement.ANONYMOUS));
         assertEquals(List.of(), self.getMiddle());
         assertEquals(ANONYMOUS_UNAME, self.getRight().getUsername());
 
         // 3. as admin
         self = ADMIN_CLIENT.self();
         assertEquals(ANONYMOUS_CLIENT.platform().getEntitlements().size(), self.getLeft().size());
-        assertFalse(self.getLeft().keySet().contains(IdRepoEntitlement.ANONYMOUS));
+        assertFalse(self.getLeft().containsKey(IdRepoEntitlement.ANONYMOUS));
         assertEquals(List.of(), self.getMiddle());
         assertEquals(ADMIN_UNAME, self.getRight().getUsername());
 
         // 4. as user
         self = CLIENT_FACTORY.create("bellini", ADMIN_PWD).self();
         assertFalse(self.getLeft().isEmpty());
-        assertFalse(self.getLeft().keySet().contains(IdRepoEntitlement.ANONYMOUS));
+        assertFalse(self.getLeft().containsKey(IdRepoEntitlement.ANONYMOUS));
         assertEquals(List.of(), self.getMiddle());
         assertEquals("bellini", self.getRight().getUsername());
     }

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/RealmITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/RealmITCase.java
@@ -193,7 +193,7 @@ public class RealmITCase extends AbstractITCase {
     public void deletingAuthPolicy() {
         // 1. create authentication policy
         DefaultAuthPolicyConf ruleConf = new DefaultAuthPolicyConf();
-        ruleConf.getAuthModules().addAll(List.of("LdapAuthentication1"));
+        ruleConf.getAuthModules().add("LdapAuthentication1");
 
         AuthPolicyTO policy = new AuthPolicyTO();
         policy.setName("Test Authentication policy");


### PR DESCRIPTION
- Updates instances where a `containsKey` can be directly used on a `Map` instead of its `entrySet()`
- Removes `contains` calls on `Set` collections prior to adding elements; `contains` is implied and sets ignore duplicate elements.