### PR TITLE
[SYNCOPE-1888] Change required property for specific inputs in policy configuration

### DIFF
--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/policies/PolicyModalPanelBuilder.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/policies/PolicyModalPanelBuilder.java
@@ -147,11 +147,11 @@ public class PolicyModalPanelBuilder<T extends PolicyTO> extends AbstractModalPa
 
             switch (type) {
                 case ACCOUNT:
-                    fields.add(new AjaxNumberFieldPanel.Builder<Integer>().min(1).build(
+                    fields.add(new AjaxNumberFieldPanel.Builder<Integer>().min(0).build(
                             "field",
                             "maxAuthenticationAttempts",
                             Integer.class,
-                            new PropertyModel<>(policyTO, "maxAuthenticationAttempts")));
+                            new PropertyModel<>(policyTO, "maxAuthenticationAttempts")).setRequired(true));
 
                     fields.add(new AjaxCheckBoxPanel(
                             "field",
@@ -161,11 +161,11 @@ public class PolicyModalPanelBuilder<T extends PolicyTO> extends AbstractModalPa
                     break;
 
                 case PASSWORD:
-                    fields.add(new AjaxNumberFieldPanel.Builder<Integer>().min(1).build(
+                    fields.add(new AjaxNumberFieldPanel.Builder<Integer>().min(0).build(
                             "field",
                             "historyLength",
                             Integer.class,
-                            new PropertyModel<>(policyTO, "historyLength")));
+                            new PropertyModel<>(policyTO, "historyLength")).setRequired(true));
 
                     fields.add(new AjaxCheckBoxPanel(
                             "field",
@@ -191,7 +191,7 @@ public class PolicyModalPanelBuilder<T extends PolicyTO> extends AbstractModalPa
                             "field",
                             "maxAttempts",
                             Integer.class,
-                            new PropertyModel<>(policyTO, "maxAttempts")));
+                            new PropertyModel<>(policyTO, "maxAttempts")).setRequired(true));
                     AjaxDropDownChoicePanel<Serializable> backOffStrategy = new AjaxDropDownChoicePanel<>(
                             "field",
                             "backOffStrategy",


### PR DESCRIPTION
**Account policy**: set input for `maxAuthenticationAttempts` required and with min value set to 0
**Password policy**: set input for `historyLength` required and with min value set to 0
**Propagation policy**: set input for `maxAttempts` required