### PR TITLE
Separate membership attribute on __ACCOUNT__ and ldapGroups attribute for connector

### DIFF
--- a/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/propagation/LDAPMembershipPropagationActions.java
+++ b/core/provisioning-java/src/main/java/org/apache/syncope/core/provisioning/java/propagation/LDAPMembershipPropagationActions.java
@@ -133,7 +133,7 @@ public class LDAPMembershipPropagationActions implements PropagationActions {
                     orElseThrow(() -> new NotFoundException("User " + taskInfo.getEntityKey()));
             Set<String> groups = new HashSet<>();
 
-            // for each user group assigned to the resource of this task, compute and add the group's 
+            // for each user group assigned to the resource of this task, compute and add the group's
             // connector object link
             userDAO.findAllGroupKeys(user).stream().
                     map(groupDAO::findById).flatMap(Optional::stream).
@@ -162,16 +162,16 @@ public class LDAPMembershipPropagationActions implements PropagationActions {
             LOG.debug("Group connObjectLinks after including the ones from mapping: {}", groups);
 
             // take groups already assigned from beforeObj and include them too
+            Set<String> connObjectLinks = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
+            buildManagedGroupConnObjectLinks(
+                    taskInfo.getResource(),
+                    mapping.getConnObjectLink(),
+                    connObjectLinks);
+
             taskInfo.getBeforeObj().
                     map(beforeObj -> beforeObj.getAttributeByName(getGroupMembershipAttrName())).
                     filter(Objects::nonNull).
                     ifPresent(beforeLdapGroups -> {
-                        Set<String> connObjectLinks = new TreeSet<>(String.CASE_INSENSITIVE_ORDER);
-                        buildManagedGroupConnObjectLinks(
-                                taskInfo.getResource(),
-                                mapping.getConnObjectLink(),
-                                connObjectLinks);
-
                         LOG.debug("Memberships not managed by Syncope: {}", beforeLdapGroups);
                         beforeLdapGroups.getValue().stream().
                                 filter(value -> !connObjectLinks.contains(String.valueOf(value))).


### PR DESCRIPTION
Currently LDAPMembershipPropagationActions uses the same attribute for writing the result into the propagation data and fetching the preexisting group memberships of the user object in LDAP. This leads to the beforeObj.getAttributeByName() call never returning any groups in the default case and therefore Syncope trying to edit groups it doesn't own/control.

This is fixed in this pull request by separating the attribute name used into one which the connector receives, containing all the group memberships after the execution, and the attribute name which is used to get all current memberships from the LDAP object.

Furthermore I added a performance optimization by searching for the groups managed by Syncope only once and not potentially hundreds of times.