### PR TITLE
Tighten auth failure lockout threshold

### DIFF
--- a/core/workflow-java/src/main/java/org/apache/syncope/core/workflow/java/AbstractUserWorkflowAdapter.java
+++ b/core/workflow-java/src/main/java/org/apache/syncope/core/workflow/java/AbstractUserWorkflowAdapter.java
@@ -211,7 +211,7 @@ public abstract class AbstractUserWorkflowAdapter extends AbstractWorkflowAdapte
                     });
 
                     suspend |= user.getFailedLogins() != null && policy.getMaxAuthenticationAttempts() > 0
-                            && user.getFailedLogins() > policy.getMaxAuthenticationAttempts() && !user.isSuspended();
+                            && user.getFailedLogins() >= policy.getMaxAuthenticationAttempts() && !user.isSuspended();
                     propagateSuspension |= policy.isPropagateSuspension();
                 }
             }
@@ -380,10 +380,7 @@ public abstract class AbstractUserWorkflowAdapter extends AbstractWorkflowAdapte
 
         Pair<Boolean, Boolean> enforce = enforcePolicies(user, true, null);
         if (enforce.getKey()) {
-            LOG.debug("User {} {} is over the max failed logins", user.getKey(), user.getUsername());
-
-            // reduce failed logins number to avoid multiple request       
-            user.setFailedLogins(user.getFailedLogins() - 1);
+            LOG.debug("User {} {} reached the max failed logins", user.getKey(), user.getUsername());
 
             // set suspended flag
             user.setSuspended(Boolean.TRUE);

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AuthenticationITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AuthenticationITCase.java
@@ -20,6 +20,7 @@ package org.apache.syncope.fit.core;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
@@ -333,13 +334,7 @@ public class AuthenticationITCase extends AbstractITCase {
 
         assertEquals(0, USER_SERVICE.read(userKey).getFailedLogins());
 
-        // authentications failed ...
-        try {
-            CLIENT_FACTORY.create(userTO.getUsername(), "wrongpwd1");
-            fail("This should not happen");
-        } catch (NotAuthorizedException e) {
-            assertNotNull(e);
-        }
+        // /odd has an account policy with maxAuthenticationAttempts = 3.
         try {
             CLIENT_FACTORY.create(userTO.getUsername(), "wrongpwd1");
             fail("This should not happen");
@@ -353,9 +348,10 @@ public class AuthenticationITCase extends AbstractITCase {
             assertNotNull(e);
         }
 
-        assertEquals(3, USER_SERVICE.read(userKey).getFailedLogins());
+        userTO = USER_SERVICE.read(userTO.getKey());
+        assertEquals(2, userTO.getFailedLogins().intValue());
+        assertNotEquals("suspended", userTO.getStatus());
 
-        // last authentication before suspension
         try {
             CLIENT_FACTORY.create(userTO.getUsername(), "wrongpwd1");
             fail("This should not happen");


### PR DESCRIPTION
Before this change, the account policy threshold was enforced on attempt N + 1: with maxAuthenticationAttempts = 3, the user was still active after 3 failures and suspended only on the 4th failure. 

The old test encoded this by asserting failedLogins == 3 before executing one more failed login.