### PR TITLE
[SYNCOPE-1981] Search audit events by who

### DIFF
--- a/common/idrepo/rest-api/src/main/java/org/apache/syncope/common/rest/api/beans/AuditQuery.java
+++ b/common/idrepo/rest-api/src/main/java/org/apache/syncope/common/rest/api/beans/AuditQuery.java
@@ -19,8 +19,11 @@
 package org.apache.syncope.common.rest.api.beans;
 
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.ws.rs.QueryParam;
+import java.util.HashSet;
+import java.util.Set;
 import org.apache.syncope.common.lib.types.OpEvent;
 import org.apache.syncope.common.rest.api.service.JAXRSService;
 
@@ -37,6 +40,11 @@ public class AuditQuery extends AbstractTimeframeQuery {
 
         public Builder entityKey(final String entityKey) {
             getInstance().setEntityKey(entityKey);
+            return this;
+        }
+
+        public Builder who(final String who) {
+            getInstance().getWho().add(who);
             return this;
         }
 
@@ -68,6 +76,8 @@ public class AuditQuery extends AbstractTimeframeQuery {
 
     private String entityKey;
 
+    private Set<String> who = new HashSet<>();
+
     private OpEvent.CategoryType type;
 
     private String category;
@@ -87,6 +97,18 @@ public class AuditQuery extends AbstractTimeframeQuery {
     @QueryParam(JAXRSService.PARAM_ENTITY_KEY)
     public void setEntityKey(final String entityKey) {
         this.entityKey = entityKey;
+    }
+
+    @Parameter(name = "who", description = "audit event author(s) (username) to match; "
+            + "may be repeated to match any of the given values", array =
+            @ArraySchema(schema = @Schema(implementation = String.class)))
+    public Set<String> getWho() {
+        return who;
+    }
+
+    @QueryParam("who")
+    public void setWho(final Set<String> who) {
+        this.who = who;
     }
 
     @Parameter(name = "type", description = "audit type to match", schema =

--- a/core/idrepo/logic/src/main/java/org/apache/syncope/core/logic/AuditLogic.java
+++ b/core/idrepo/logic/src/main/java/org/apache/syncope/core/logic/AuditLogic.java
@@ -275,6 +275,7 @@ public class AuditLogic extends AbstractTransactionalLogic<AuditConfTO> {
     @Transactional(readOnly = true)
     public Page<AuditEventTO> search(
             final String entityKey,
+            final Set<String> who,
             final OpEvent.CategoryType type,
             final String category,
             final String subcategory,
@@ -284,10 +285,10 @@ public class AuditLogic extends AbstractTransactionalLogic<AuditConfTO> {
             final OffsetDateTime after,
             final Pageable pageable) {
 
-        long count = auditEventDAO.count(entityKey, type, category, subcategory, op, result, before, after);
+        long count = auditEventDAO.count(entityKey, who, type, category, subcategory, op, result, before, after);
 
         List<AuditEventTO> matching = auditEventDAO.search(
-                entityKey, type, category, subcategory, op, result, before, after, pageable);
+                entityKey, who, type, category, subcategory, op, result, before, after, pageable);
 
         return new SyncopePage<>(matching, pageable, count);
     }

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AuditServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AuditServiceImpl.java
@@ -70,6 +70,7 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
     public PagedResult<AuditEventTO> search(final AuditQuery auditQuery) {
         Page<AuditEventTO> result = logic.search(
                 auditQuery.getEntityKey(),
+                auditQuery.getWho(),
                 auditQuery.getType(),
                 auditQuery.getCategory(),
                 auditQuery.getSubcategory(),

--- a/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/dao/AuditEventDAO.java
+++ b/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/dao/AuditEventDAO.java
@@ -20,6 +20,7 @@ package org.apache.syncope.core.persistence.api.dao;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Set;
 import org.apache.syncope.common.lib.to.AuditEventTO;
 import org.apache.syncope.common.lib.types.OpEvent;
 import org.apache.syncope.core.persistence.api.entity.AuditEvent;
@@ -31,6 +32,7 @@ public interface AuditEventDAO {
 
     long count(
             String entityKey,
+            Set<String> who,
             OpEvent.CategoryType type,
             String category,
             String subcategory,
@@ -54,6 +56,7 @@ public interface AuditEventDAO {
 
     List<AuditEventTO> search(
             String entityKey,
+            Set<String> who,
             OpEvent.CategoryType type,
             String category,
             String subcategory,

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/JPAAuditEventDAO.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/JPAAuditEventDAO.java
@@ -24,6 +24,7 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.syncope.common.lib.to.AuditEventTO;
 import org.apache.syncope.common.lib.types.OpEvent;
@@ -32,6 +33,7 @@ import org.apache.syncope.core.persistence.api.entity.AuditEvent;
 import org.apache.syncope.core.persistence.jpa.entity.JPAAuditEvent;
 import org.springframework.data.domain.Pageable;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 
 public class JPAAuditEventDAO implements AuditEventDAO {
 
@@ -55,6 +57,17 @@ public class JPAAuditEventDAO implements AuditEventDAO {
                         append("inputs LIKE '%\"key\":\"").append(entityKey).append("\"%' OR ").
                         append("output LIKE '%\"key\":\"").append(entityKey).append("\"%' OR ").
                         append("throwable LIKE '%\"key\":\"").append(entityKey).append("\"%')");
+            }
+            return this;
+        }
+
+        public AuditEventCriteriaBuilder who(final Set<String> who, final List<Object> parameters) {
+            if (!CollectionUtils.isEmpty(who)) {
+                query.append(andIfNeeded()).append("who IN (").
+                        append(who.stream().
+                                map(value -> "?" + setParameter(parameters, value)).
+                                collect(Collectors.joining(", "))).
+                        append(")");
             }
             return this;
         }
@@ -125,6 +138,7 @@ public class JPAAuditEventDAO implements AuditEventDAO {
     @Override
     public long count(
             final String entityKey,
+            final Set<String> who,
             final OpEvent.CategoryType type,
             final String category,
             final String subcategory,
@@ -137,6 +151,7 @@ public class JPAAuditEventDAO implements AuditEventDAO {
         String queryString = "SELECT COUNT(0)"
                 + " FROM " + JPAAuditEvent.TABLE
                 + " WHERE" + criteriaBuilder(entityKey).
+                        who(who, parameters).
                         opEvent(type, category, subcategory, op, outcome).
                         before(before, parameters).
                         after(after, parameters).
@@ -151,6 +166,7 @@ public class JPAAuditEventDAO implements AuditEventDAO {
     @Override
     public List<AuditEventTO> search(
             final String entityKey,
+            final Set<String> who,
             final OpEvent.CategoryType type,
             final String category,
             final String subcategory,
@@ -164,6 +180,7 @@ public class JPAAuditEventDAO implements AuditEventDAO {
         String queryString = "SELECT id"
                 + " FROM " + JPAAuditEvent.TABLE
                 + " WHERE" + criteriaBuilder(entityKey).
+                        who(who, parameters).
                         opEvent(type, category, subcategory, op, outcome).
                         before(before, parameters).
                         after(after, parameters).

--- a/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/dao/Neo4jAuditEventDAO.java
+++ b/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/dao/Neo4jAuditEventDAO.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.syncope.common.lib.to.AuditEventTO;
 import org.apache.syncope.common.lib.types.OpEvent;
@@ -36,6 +37,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.neo4j.core.Neo4jClient;
 import org.springframework.data.neo4j.core.Neo4jTemplate;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.CollectionUtils;
 
 public class Neo4jAuditEventDAO implements AuditEventDAO {
 
@@ -56,6 +58,14 @@ public class Neo4jAuditEventDAO implements AuditEventDAO {
                         append("n.inputs =~ '.*key.*").append(entityKey).append(".*' OR ").
                         append("n.output =~ '.*key.*").append(entityKey).append(".*' OR ").
                         append("n.throwable =~ '.*key.*").append(entityKey).append(".*')");
+            }
+            return this;
+        }
+
+        public AuditEventCriteriaBuilder who(final Set<String> who, final Map<String, Object> parameters) {
+            if (!CollectionUtils.isEmpty(who)) {
+                parameters.put("who", List.copyOf(who));
+                query.append(andIfNeeded()).append("n.who IN $who");
             }
             return this;
         }
@@ -127,6 +137,7 @@ public class Neo4jAuditEventDAO implements AuditEventDAO {
     @Override
     public long count(
             final String entityKey,
+            final Set<String> who,
             final OpEvent.CategoryType type,
             final String category,
             final String subcategory,
@@ -138,6 +149,7 @@ public class Neo4jAuditEventDAO implements AuditEventDAO {
         Map<String, Object> parameters = new HashMap<>();
         String query = "MATCH (n:" + Neo4jAuditEvent.NODE + ") "
                 + " WHERE " + criteriaBuilder(entityKey).
+                        who(who, parameters).
                         opEvent(type, category, subcategory, op, outcome).
                         before(before, parameters).
                         after(after, parameters).
@@ -150,6 +162,7 @@ public class Neo4jAuditEventDAO implements AuditEventDAO {
     @Override
     public List<AuditEventTO> search(
             final String entityKey,
+            final Set<String> who,
             final OpEvent.CategoryType type,
             final String category,
             final String subcategory,
@@ -163,6 +176,7 @@ public class Neo4jAuditEventDAO implements AuditEventDAO {
 
         StringBuilder query = new StringBuilder("MATCH (n:" + Neo4jAuditEvent.NODE + ") "
                 + "WHERE " + criteriaBuilder(entityKey).
+                        who(who, parameters).
                         opEvent(type, category, subcategory, op, outcome).
                         before(before, parameters).
                         after(after, parameters).

--- a/ext/elasticsearch/persistence/src/main/java/org/apache/syncope/core/persistence/elasticsearch/dao/ElasticsearchAuditEventDAO.java
+++ b/ext/elasticsearch/persistence/src/main/java/org/apache/syncope/core/persistence/elasticsearch/dao/ElasticsearchAuditEventDAO.java
@@ -35,6 +35,7 @@ import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.apache.syncope.common.lib.to.AuditEventTO;
 import org.apache.syncope.common.lib.types.OpEvent;
@@ -81,6 +82,7 @@ public class ElasticsearchAuditEventDAO implements AuditEventDAO {
 
     protected Query getQuery(
             final String entityKey,
+            final Set<String> who,
             final OpEvent.CategoryType type,
             final String category,
             final String subcategory,
@@ -97,6 +99,14 @@ public class ElasticsearchAuditEventDAO implements AuditEventDAO {
                             fields("before", "inputs", "output", "throwable").
                             type(TextQueryType.Phrase).
                             query("\"key\":\"" + entityKey + "\"").build()).build());
+        }
+
+        if (!CollectionUtils.isEmpty(who)) {
+            List<Query> whoQueries = who.stream().map(value -> new Query.Builder().
+                    term(QueryBuilders.term().field("who").value(value).build()).build()).
+                    toList();
+            queries.add(new Query.Builder().
+                    bool(QueryBuilders.bool().should(whoQueries).minimumShouldMatch("1").build()).build());
         }
 
         queries.add(new Query.Builder().regexp(QueryBuilders.regexp().
@@ -127,6 +137,7 @@ public class ElasticsearchAuditEventDAO implements AuditEventDAO {
     @Override
     public long count(
             final String entityKey,
+            final Set<String> who,
             final OpEvent.CategoryType type,
             final String category,
             final String subcategory,
@@ -137,7 +148,7 @@ public class ElasticsearchAuditEventDAO implements AuditEventDAO {
 
         CountRequest request = new CountRequest.Builder().
                 index(ElasticsearchUtils.getAuditIndex(AuthContextUtils.getDomain())).
-                query(getQuery(entityKey, type, category, subcategory, op, outcome, before, after)).
+                query(getQuery(entityKey, who, type, category, subcategory, op, outcome, before, after)).
                 build();
         LOG.debug("Count request: {}", request);
 
@@ -161,6 +172,7 @@ public class ElasticsearchAuditEventDAO implements AuditEventDAO {
     @Override
     public List<AuditEventTO> search(
             final String entityKey,
+            final Set<String> who,
             final OpEvent.CategoryType type,
             final String category,
             final String subcategory,
@@ -173,7 +185,7 @@ public class ElasticsearchAuditEventDAO implements AuditEventDAO {
         SearchRequest request = new SearchRequest.Builder().
                 index(ElasticsearchUtils.getAuditIndex(AuthContextUtils.getDomain())).
                 searchType(SearchType.QueryThenFetch).
-                query(getQuery(entityKey, type, category, subcategory, op, outcome, before, after)).
+                query(getQuery(entityKey, who, type, category, subcategory, op, outcome, before, after)).
                 from(pageable.isUnpaged() ? 0 : pageable.getPageSize() * pageable.getPageNumber()).
                 size(pageable.isUnpaged() ? indexMaxResultWindow : pageable.getPageSize()).
                 sort(sortBuilders(pageable.getSort().get())).

--- a/ext/opensearch/persistence/src/main/java/org/apache/syncope/core/persistence/opensearch/dao/OpenSearchAuditEventDAO.java
+++ b/ext/opensearch/persistence/src/main/java/org/apache/syncope/core/persistence/opensearch/dao/OpenSearchAuditEventDAO.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.apache.syncope.common.lib.to.AuditEventTO;
 import org.apache.syncope.common.lib.types.OpEvent;
@@ -80,6 +81,7 @@ public class OpenSearchAuditEventDAO implements AuditEventDAO {
 
     protected Query getQuery(
             final String entityKey,
+            final Set<String> who,
             final OpEvent.CategoryType type,
             final String category,
             final String subcategory,
@@ -96,6 +98,14 @@ public class OpenSearchAuditEventDAO implements AuditEventDAO {
                             fields("before", "inputs", "output", "throwable").
                             type(TextQueryType.Phrase).
                             query("\"key\":\"" + entityKey + "\"").build()).build());
+        }
+
+        if (!CollectionUtils.isEmpty(who)) {
+            List<Query> whoQueries = who.stream().map(value -> new Query.Builder().
+                    term(QueryBuilders.term().field("who").value(v -> v.stringValue(value)).build()).build()).
+                    toList();
+            queries.add(new Query.Builder().
+                    bool(QueryBuilders.bool().should(whoQueries).minimumShouldMatch("1").build()).build());
         }
 
         queries.add(new Query.Builder().regexp(QueryBuilders.regexp().
@@ -126,6 +136,7 @@ public class OpenSearchAuditEventDAO implements AuditEventDAO {
     @Override
     public long count(
             final String entityKey,
+            final Set<String> who,
             final OpEvent.CategoryType type,
             final String category,
             final String subcategory,
@@ -136,7 +147,7 @@ public class OpenSearchAuditEventDAO implements AuditEventDAO {
 
         CountRequest request = new CountRequest.Builder().
                 index(OpenSearchUtils.getAuditIndex(AuthContextUtils.getDomain())).
-                query(getQuery(entityKey, type, category, subcategory, op, outcome, before, after)).
+                query(getQuery(entityKey, who, type, category, subcategory, op, outcome, before, after)).
                 build();
         LOG.debug("Count request: {}", request);
 
@@ -160,6 +171,7 @@ public class OpenSearchAuditEventDAO implements AuditEventDAO {
     @Override
     public List<AuditEventTO> search(
             final String entityKey,
+            final Set<String> who,
             final OpEvent.CategoryType type,
             final String category,
             final String subcategory,
@@ -172,7 +184,7 @@ public class OpenSearchAuditEventDAO implements AuditEventDAO {
         SearchRequest request = new SearchRequest.Builder().
                 index(OpenSearchUtils.getAuditIndex(AuthContextUtils.getDomain())).
                 searchType(SearchType.QueryThenFetch).
-                query(getQuery(entityKey, type, category, subcategory, op, outcome, before, after)).
+                query(getQuery(entityKey, who, type, category, subcategory, op, outcome, before, after)).
                 from(pageable.isUnpaged() ? 0 : pageable.getPageSize() * pageable.getPageNumber()).
                 size(pageable.isUnpaged() ? indexMaxResultWindow : pageable.getPageSize()).
                 sort(sortBuilders(pageable.getSort().get())).

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AuditITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AuditITCase.java
@@ -162,6 +162,78 @@ public class AuditITCase extends AbstractITCase {
     }
 
     @Test
+    public void findByWho() {
+        UserTO userTO = createUser(UserITCase.getUniqueSample("audit-who@syncope.org")).getEntity();
+        assertNotNull(userTO.getKey());
+
+        // exact match on the author of the just-created user's create event
+        AuditQuery exact = new AuditQuery.Builder().
+                entityKey(userTO.getKey()).
+                who(ADMIN_UNAME).
+                type(OpEvent.CategoryType.LOGIC).
+                category(UserLogic.class.getSimpleName()).
+                op("create").
+                outcome(OpEvent.Outcome.SUCCESS).
+                build();
+        assertFalse(query(exact, MAX_WAIT_SECONDS).isEmpty());
+
+        // multiple who values are OR'ed: admin still matches alongside an unrelated author
+        AuditQuery multiple = new AuditQuery.Builder().
+                entityKey(userTO.getKey()).
+                who(ADMIN_UNAME).
+                who("non-existent-" + UUID.randomUUID()).
+                type(OpEvent.CategoryType.LOGIC).
+                category(UserLogic.class.getSimpleName()).
+                op("create").
+                outcome(OpEvent.Outcome.SUCCESS).
+                build();
+        assertFalse(AUDIT_SERVICE.search(multiple).getResult().isEmpty());
+
+        // the who filter excludes non-matching authors
+        AuditQuery noMatch = new AuditQuery.Builder().
+                entityKey(userTO.getKey()).
+                who("non-existent-" + UUID.randomUUID()).
+                type(OpEvent.CategoryType.LOGIC).
+                category(UserLogic.class.getSimpleName()).
+                op("create").
+                outcome(OpEvent.Outcome.SUCCESS).
+                build();
+        assertTrue(AUDIT_SERVICE.search(noMatch).getResult().isEmpty());
+
+        USER_SERVICE.delete(userTO.getKey());
+    }
+
+    @Test
+    public void findByWhoIsExactMatch() {
+        UserTO userTO = createUser(UserITCase.getUniqueSample("audit-who-exact@syncope.org")).getEntity();
+        assertNotNull(userTO.getKey());
+
+        // make sure the create event is there (matched exactly by the admin author)
+        AuditQuery exact = new AuditQuery.Builder().
+                entityKey(userTO.getKey()).
+                who(ADMIN_UNAME).
+                type(OpEvent.CategoryType.LOGIC).
+                category(UserLogic.class.getSimpleName()).
+                op("create").
+                outcome(OpEvent.Outcome.SUCCESS).
+                build();
+        assertFalse(query(exact, MAX_WAIT_SECONDS).isEmpty());
+
+        // who matches exactly: a '*' is treated literally, not as a wildcard
+        AuditQuery wildcard = new AuditQuery.Builder().
+                entityKey(userTO.getKey()).
+                who(ADMIN_UNAME.substring(0, 3) + '*').
+                type(OpEvent.CategoryType.LOGIC).
+                category(UserLogic.class.getSimpleName()).
+                op("create").
+                outcome(OpEvent.Outcome.SUCCESS).
+                build();
+        assertTrue(AUDIT_SERVICE.search(wildcard).getResult().isEmpty());
+
+        USER_SERVICE.delete(userTO.getKey());
+    }
+
+    @Test
     public void findByGroup() {
         GroupTO groupTO = createGroup(GroupITCase.getBasicSample("AuditGroup")).getEntity();
         assertNotNull(groupTO.getKey());


### PR DESCRIPTION
[SYNCOPE-1981](https://issues.apache.org/jira/browse/SYNCOPE-1981)

> Split out from [SYNCOPE-1978](https://issues.apache.org/jira/browse/SYNCOPE-1978) per review: this PR adds searching by **who performed** the action. Matching audit events by the **username of the affected entity** (the actual subject of SYNCOPE-1978) will be addressed separately.

### What
Adds the ability to search audit events by the principal that performed them. A new `who` query parameter on `AuditQuery` matches the `AuditEvent.who` column by **exact value** and may be **repeated to match any of the given values** (OR):

- single — `?who=jsmith`
- multiple, OR-ed — `?who=jsmith&who=admin`

It composes (AND) with the existing audit search filters (`entityKey`, `type`, `category`, `op`, `outcome`, `before`/`after`).

### Why
There is no way to answer "what did administrator _X_ do". This is useful to retrieve all actions performed by a given principal — in particular when that account has since been deleted and its entity key is no longer available. Syncope 3.0 allowed an approximation by abusing `entityKey=<username>`; the 4.0 audit refactor correctly made `entityKey` match only the affected entity's UUID, removing that side effect.

### Implementation
The filter is threaded through `AuditServiceImpl` → `AuditLogic` → the `AuditEventDAO` interface and all of its implementations: JPA, Neo4j, Elasticsearch and OpenSearch.

- JPA: `who IN (?, ...)` with bound parameters;
- Neo4j: `n.who IN $who` with a bound list parameter;
- Elasticsearch / OpenSearch: a `term` query per value, OR-ed via `bool`/`should`.

All values are bound as query parameters (SQL/Cypher) or passed as structured term queries (Elasticsearch/OpenSearch), so there is no injection surface.

### Tests
New integration tests in `AuditITCase` cover exact match, multiple values (OR), no-match, and that the match is exact (a `*` is treated literally, not as a wildcard), composed with the other filters. Manually verified end-to-end against embedded PostgreSQL and Neo4j.
