### PR TITLE
[SYNCOPE-1980] Fix empty audit history diff under Jackson 3

### DIFF
--- a/client/idrepo/console/src/main/java/org/apache/syncope/client/console/audit/AuditHistoryDetails.java
+++ b/client/idrepo/console/src/main/java/org/apache/syncope/client/console/audit/AuditHistoryDetails.java
@@ -341,7 +341,8 @@ public abstract class AuditHistoryDetails<T extends Serializable> extends Panel 
                 return Model.of();
             }
 
-            T entity = MAPPER.reader().
+            @SuppressWarnings("unchecked")
+            T entity = (T) MAPPER.readerFor(currentEntity.getClass()).
                     with(StreamReadFeature.STRICT_DUPLICATE_DETECTION).
                     readValue(content);
             if (entity instanceof UserTO userTO) {


### PR DESCRIPTION
[SYNCOPE-1980](https://issues.apache.org/jira/browse/SYNCOPE-1980)

### Problem
In the admin console, the per-entity "Audit History" modal (User / Group / Any Object / Realm / Policy → View Audit History) never renders a JSON diff: both the "previous" and "after" panes are always empty, for any selected versions.

### Root cause
`AuditHistoryDetails#toJSON` deserializes the audited entity with an untyped reader:

```java
T entity = MAPPER.reader().
        with(StreamReadFeature.STRICT_DUPLICATE_DETECTION).
        readValue(content);
```

Under Jackson 3 an `ObjectReader` with no configured value type throws `InvalidDefinitionException: No value type configured for ObjectReader`. The exception is swallowed by the surrounding `try/catch` and `toJSON` returns an empty `Model`, so the failure is silent in the UI and only visible in the console log. This is a regression from the Jackson 2 → 3 migration (`tools.jackson.*`): Jackson 2's `mapper.reader()` tolerated a missing root type, Jackson 3 requires one.

### Fix
Read into the concrete type of the entity, which the panel already holds as `currentEntity`:

```java
@SuppressWarnings("unchecked")
T entity = (T) MAPPER.readerFor(currentEntity.getClass()).
        with(StreamReadFeature.STRICT_DUPLICATE_DETECTION).
        readValue(content);
```

The JSON's `_class` is then consumed as an ordinary property and the entity deserializes correctly for User/Group/AnyObject/Realm/Policy.

### Testing
Verified locally against the standalone (H2) distribution: the diff renders and the `InvalidDefinitionException` no longer appears in the console log. Full reactor test suite passes.