### PR TITLE
[SYNCOPE-1978] Search audit events by username

### DIFF
--- a/common/idrepo/rest-api/src/main/java/org/apache/syncope/common/rest/api/beans/AuditQuery.java
+++ b/common/idrepo/rest-api/src/main/java/org/apache/syncope/common/rest/api/beans/AuditQuery.java
@@ -43,6 +43,11 @@ public class AuditQuery extends AbstractTimeframeQuery {
             return this;
         }
 
+        public Builder username(final String username) {
+            getInstance().getUsername().add(username);
+            return this;
+        }
+
         public Builder who(final String who) {
             getInstance().getWho().add(who);
             return this;
@@ -76,6 +81,8 @@ public class AuditQuery extends AbstractTimeframeQuery {
 
     private String entityKey;
 
+    private Set<String> username = new HashSet<>();
+
     private Set<String> who = new HashSet<>();
 
     private OpEvent.CategoryType type;
@@ -97,6 +104,19 @@ public class AuditQuery extends AbstractTimeframeQuery {
     @QueryParam(JAXRSService.PARAM_ENTITY_KEY)
     public void setEntityKey(final String entityKey) {
         this.entityKey = entityKey;
+    }
+
+    @Parameter(name = "username", description = "username(s) embedded in the audited payload to match "
+            + "(the affected entity, as opposed to the 'who' author); "
+            + "may be repeated to match any of the given values", array =
+            @ArraySchema(schema = @Schema(implementation = String.class)))
+    public Set<String> getUsername() {
+        return username;
+    }
+
+    @QueryParam("username")
+    public void setUsername(final Set<String> username) {
+        this.username = username;
     }
 
     @Parameter(name = "who", description = "audit event author(s) (username) to match; "

--- a/core/idrepo/logic/src/main/java/org/apache/syncope/core/logic/AuditLogic.java
+++ b/core/idrepo/logic/src/main/java/org/apache/syncope/core/logic/AuditLogic.java
@@ -275,6 +275,7 @@ public class AuditLogic extends AbstractTransactionalLogic<AuditConfTO> {
     @Transactional(readOnly = true)
     public Page<AuditEventTO> search(
             final String entityKey,
+            final Set<String> username,
             final Set<String> who,
             final OpEvent.CategoryType type,
             final String category,
@@ -285,10 +286,11 @@ public class AuditLogic extends AbstractTransactionalLogic<AuditConfTO> {
             final OffsetDateTime after,
             final Pageable pageable) {
 
-        long count = auditEventDAO.count(entityKey, who, type, category, subcategory, op, result, before, after);
+        long count = auditEventDAO.count(
+                entityKey, username, who, type, category, subcategory, op, result, before, after);
 
         List<AuditEventTO> matching = auditEventDAO.search(
-                entityKey, who, type, category, subcategory, op, result, before, after, pageable);
+                entityKey, username, who, type, category, subcategory, op, result, before, after, pageable);
 
         return new SyncopePage<>(matching, pageable, count);
     }

--- a/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AuditServiceImpl.java
+++ b/core/idrepo/rest-cxf/src/main/java/org/apache/syncope/core/rest/cxf/service/AuditServiceImpl.java
@@ -70,6 +70,7 @@ public class AuditServiceImpl extends AbstractService implements AuditService {
     public PagedResult<AuditEventTO> search(final AuditQuery auditQuery) {
         Page<AuditEventTO> result = logic.search(
                 auditQuery.getEntityKey(),
+                auditQuery.getUsername(),
                 auditQuery.getWho(),
                 auditQuery.getType(),
                 auditQuery.getCategory(),

--- a/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/dao/AuditEventDAO.java
+++ b/core/persistence-api/src/main/java/org/apache/syncope/core/persistence/api/dao/AuditEventDAO.java
@@ -32,6 +32,7 @@ public interface AuditEventDAO {
 
     long count(
             String entityKey,
+            Set<String> username,
             Set<String> who,
             OpEvent.CategoryType type,
             String category,
@@ -56,6 +57,7 @@ public interface AuditEventDAO {
 
     List<AuditEventTO> search(
             String entityKey,
+            Set<String> username,
             Set<String> who,
             OpEvent.CategoryType type,
             String category,

--- a/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/JPAAuditEventDAO.java
+++ b/core/persistence-jpa/src/main/java/org/apache/syncope/core/persistence/jpa/dao/JPAAuditEventDAO.java
@@ -63,6 +63,31 @@ public class JPAAuditEventDAO extends AbstractAuditEventDAO implements AuditEven
             return this;
         }
 
+        // Unlike the entityKey predicate above (a constrained UUID, concatenated), the free-form username
+        // is bound as a query parameter and its LIKE metacharacters are escaped, so '%'/'_' in a username
+        // match literally and there is no injection surface.
+        // '#' is used as the LIKE escape char (instead of '\') and applied uniformly: a single '\' in
+        // native SQL is mishandled by MySQL/MariaDB and Oracle has no default LIKE escape, whereas '#'
+        // works across every supported database (this DAO is not subclassed per-database).
+        protected static String escapeForLike(final String value) {
+            return value.replace("#", "##").replace("%", "#%").replace("_", "#_");
+        }
+
+        public AuditEventCriteriaBuilder username(final Set<String> username, final List<Object> parameters) {
+            if (!CollectionUtils.isEmpty(username)) {
+                query.append(andIfNeeded()).append("(").
+                        append(username.stream().map(value -> {
+                            String pattern = "%\"username\":\"" + escapeForLike(value) + "\"%";
+                            return "(beforeValue LIKE ?" + setParameter(parameters, pattern) + " ESCAPE '#'"
+                                    + " OR inputs LIKE ?" + setParameter(parameters, pattern) + " ESCAPE '#'"
+                                    + " OR output LIKE ?" + setParameter(parameters, pattern) + " ESCAPE '#'"
+                                    + " OR throwable LIKE ?" + setParameter(parameters, pattern) + " ESCAPE '#')";
+                        }).collect(Collectors.joining(" OR "))).
+                        append(")");
+            }
+            return this;
+        }
+
         public AuditEventCriteriaBuilder who(final Set<String> who, final List<Object> parameters) {
             if (!CollectionUtils.isEmpty(who)) {
                 query.append(andIfNeeded()).append("who IN (").
@@ -140,6 +165,7 @@ public class JPAAuditEventDAO extends AbstractAuditEventDAO implements AuditEven
     @Override
     public long count(
             final String entityKey,
+            final Set<String> username,
             final Set<String> who,
             final OpEvent.CategoryType type,
             final String category,
@@ -153,6 +179,7 @@ public class JPAAuditEventDAO extends AbstractAuditEventDAO implements AuditEven
         String queryString = "SELECT COUNT(0)"
                 + " FROM " + JPAAuditEvent.TABLE
                 + " WHERE" + criteriaBuilder(entityKey).
+                        username(username, parameters).
                         who(who, parameters).
                         opEvent(type, category, subcategory, op, outcome).
                         before(before, parameters).
@@ -168,6 +195,7 @@ public class JPAAuditEventDAO extends AbstractAuditEventDAO implements AuditEven
     @Override
     public List<AuditEventTO> search(
             final String entityKey,
+            final Set<String> username,
             final Set<String> who,
             final OpEvent.CategoryType type,
             final String category,
@@ -182,6 +210,7 @@ public class JPAAuditEventDAO extends AbstractAuditEventDAO implements AuditEven
         String queryString = "SELECT id"
                 + " FROM " + JPAAuditEvent.TABLE
                 + " WHERE" + criteriaBuilder(entityKey).
+                        username(username, parameters).
                         who(who, parameters).
                         opEvent(type, category, subcategory, op, outcome).
                         before(before, parameters).

--- a/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/dao/Neo4jAuditEventDAO.java
+++ b/core/persistence-neo4j/src/main/java/org/apache/syncope/core/persistence/neo4j/dao/Neo4jAuditEventDAO.java
@@ -60,6 +60,16 @@ public class Neo4jAuditEventDAO extends AbstractAuditEventDAO implements AuditEv
             return this;
         }
 
+        public AuditEventCriteriaBuilder username(final Set<String> username, final Map<String, Object> parameters) {
+            if (!CollectionUtils.isEmpty(username)) {
+                parameters.put("usernames", username.stream().map(value -> "\"username\":\"" + value + "\"").toList());
+                query.append(andIfNeeded()).
+                        append("ANY(u IN $usernames WHERE n.before CONTAINS u OR n.inputs CONTAINS u "
+                                + "OR n.output CONTAINS u OR n.throwable CONTAINS u)");
+            }
+            return this;
+        }
+
         public AuditEventCriteriaBuilder who(final Set<String> who, final Map<String, Object> parameters) {
             if (!CollectionUtils.isEmpty(who)) {
                 parameters.put("who", List.copyOf(who));
@@ -135,6 +145,7 @@ public class Neo4jAuditEventDAO extends AbstractAuditEventDAO implements AuditEv
     @Override
     public long count(
             final String entityKey,
+            final Set<String> username,
             final Set<String> who,
             final OpEvent.CategoryType type,
             final String category,
@@ -147,6 +158,7 @@ public class Neo4jAuditEventDAO extends AbstractAuditEventDAO implements AuditEv
         Map<String, Object> parameters = new HashMap<>();
         String query = "MATCH (n:" + Neo4jAuditEvent.NODE + ") "
                 + " WHERE " + criteriaBuilder(entityKey).
+                        username(username, parameters).
                         who(who, parameters).
                         opEvent(type, category, subcategory, op, outcome).
                         before(before, parameters).
@@ -160,6 +172,7 @@ public class Neo4jAuditEventDAO extends AbstractAuditEventDAO implements AuditEv
     @Override
     public List<AuditEventTO> search(
             final String entityKey,
+            final Set<String> username,
             final Set<String> who,
             final OpEvent.CategoryType type,
             final String category,
@@ -174,6 +187,7 @@ public class Neo4jAuditEventDAO extends AbstractAuditEventDAO implements AuditEv
 
         StringBuilder query = new StringBuilder("MATCH (n:" + Neo4jAuditEvent.NODE + ") "
                 + "WHERE " + criteriaBuilder(entityKey).
+                        username(username, parameters).
                         who(who, parameters).
                         opEvent(type, category, subcategory, op, outcome).
                         before(before, parameters).

--- a/ext/elasticsearch/persistence/src/main/java/org/apache/syncope/core/persistence/elasticsearch/dao/ElasticsearchAuditEventDAO.java
+++ b/ext/elasticsearch/persistence/src/main/java/org/apache/syncope/core/persistence/elasticsearch/dao/ElasticsearchAuditEventDAO.java
@@ -82,6 +82,7 @@ public class ElasticsearchAuditEventDAO implements AuditEventDAO {
 
     protected Query getQuery(
             final String entityKey,
+            final Set<String> username,
             final Set<String> who,
             final OpEvent.CategoryType type,
             final String category,
@@ -99,6 +100,17 @@ public class ElasticsearchAuditEventDAO implements AuditEventDAO {
                             fields("before", "inputs", "output", "throwable").
                             type(TextQueryType.Phrase).
                             query("\"key\":\"" + entityKey + "\"").build()).build());
+        }
+
+        if (!CollectionUtils.isEmpty(username)) {
+            List<Query> usernameQueries = username.stream().map(value -> new Query.Builder().
+                    multiMatch(QueryBuilders.multiMatch().
+                            fields("before", "inputs", "output", "throwable").
+                            type(TextQueryType.Phrase).
+                            query("\"username\":\"" + value + "\"").build()).build()).
+                    toList();
+            queries.add(new Query.Builder().
+                    bool(QueryBuilders.bool().should(usernameQueries).minimumShouldMatch("1").build()).build());
         }
 
         if (!CollectionUtils.isEmpty(who)) {
@@ -137,6 +149,7 @@ public class ElasticsearchAuditEventDAO implements AuditEventDAO {
     @Override
     public long count(
             final String entityKey,
+            final Set<String> username,
             final Set<String> who,
             final OpEvent.CategoryType type,
             final String category,
@@ -148,7 +161,7 @@ public class ElasticsearchAuditEventDAO implements AuditEventDAO {
 
         CountRequest request = new CountRequest.Builder().
                 index(ElasticsearchUtils.getAuditIndex(AuthContextUtils.getDomain())).
-                query(getQuery(entityKey, who, type, category, subcategory, op, outcome, before, after)).
+                query(getQuery(entityKey, username, who, type, category, subcategory, op, outcome, before, after)).
                 build();
         LOG.debug("Count request: {}", request);
 
@@ -172,6 +185,7 @@ public class ElasticsearchAuditEventDAO implements AuditEventDAO {
     @Override
     public List<AuditEventTO> search(
             final String entityKey,
+            final Set<String> username,
             final Set<String> who,
             final OpEvent.CategoryType type,
             final String category,
@@ -185,7 +199,7 @@ public class ElasticsearchAuditEventDAO implements AuditEventDAO {
         SearchRequest request = new SearchRequest.Builder().
                 index(ElasticsearchUtils.getAuditIndex(AuthContextUtils.getDomain())).
                 searchType(SearchType.QueryThenFetch).
-                query(getQuery(entityKey, who, type, category, subcategory, op, outcome, before, after)).
+                query(getQuery(entityKey, username, who, type, category, subcategory, op, outcome, before, after)).
                 from(pageable.isUnpaged() ? 0 : pageable.getPageSize() * pageable.getPageNumber()).
                 size(pageable.isUnpaged() ? indexMaxResultWindow : pageable.getPageSize()).
                 sort(sortBuilders(pageable.getSort().get())).

--- a/ext/opensearch/persistence/src/main/java/org/apache/syncope/core/persistence/opensearch/dao/OpenSearchAuditEventDAO.java
+++ b/ext/opensearch/persistence/src/main/java/org/apache/syncope/core/persistence/opensearch/dao/OpenSearchAuditEventDAO.java
@@ -81,6 +81,7 @@ public class OpenSearchAuditEventDAO implements AuditEventDAO {
 
     protected Query getQuery(
             final String entityKey,
+            final Set<String> username,
             final Set<String> who,
             final OpEvent.CategoryType type,
             final String category,
@@ -98,6 +99,17 @@ public class OpenSearchAuditEventDAO implements AuditEventDAO {
                             fields("before", "inputs", "output", "throwable").
                             type(TextQueryType.Phrase).
                             query("\"key\":\"" + entityKey + "\"").build()).build());
+        }
+
+        if (!CollectionUtils.isEmpty(username)) {
+            List<Query> usernameQueries = username.stream().map(value -> new Query.Builder().
+                    multiMatch(QueryBuilders.multiMatch().
+                            fields("before", "inputs", "output", "throwable").
+                            type(TextQueryType.Phrase).
+                            query("\"username\":\"" + value + "\"").build()).build()).
+                    toList();
+            queries.add(new Query.Builder().
+                    bool(QueryBuilders.bool().should(usernameQueries).minimumShouldMatch("1").build()).build());
         }
 
         if (!CollectionUtils.isEmpty(who)) {
@@ -136,6 +148,7 @@ public class OpenSearchAuditEventDAO implements AuditEventDAO {
     @Override
     public long count(
             final String entityKey,
+            final Set<String> username,
             final Set<String> who,
             final OpEvent.CategoryType type,
             final String category,
@@ -147,7 +160,7 @@ public class OpenSearchAuditEventDAO implements AuditEventDAO {
 
         CountRequest request = new CountRequest.Builder().
                 index(OpenSearchUtils.getAuditIndex(AuthContextUtils.getDomain())).
-                query(getQuery(entityKey, who, type, category, subcategory, op, outcome, before, after)).
+                query(getQuery(entityKey, username, who, type, category, subcategory, op, outcome, before, after)).
                 build();
         LOG.debug("Count request: {}", request);
 
@@ -171,6 +184,7 @@ public class OpenSearchAuditEventDAO implements AuditEventDAO {
     @Override
     public List<AuditEventTO> search(
             final String entityKey,
+            final Set<String> username,
             final Set<String> who,
             final OpEvent.CategoryType type,
             final String category,
@@ -184,7 +198,7 @@ public class OpenSearchAuditEventDAO implements AuditEventDAO {
         SearchRequest request = new SearchRequest.Builder().
                 index(OpenSearchUtils.getAuditIndex(AuthContextUtils.getDomain())).
                 searchType(SearchType.QueryThenFetch).
-                query(getQuery(entityKey, who, type, category, subcategory, op, outcome, before, after)).
+                query(getQuery(entityKey, username, who, type, category, subcategory, op, outcome, before, after)).
                 from(pageable.isUnpaged() ? 0 : pageable.getPageSize() * pageable.getPageNumber()).
                 size(pageable.isUnpaged() ? indexMaxResultWindow : pageable.getPageSize()).
                 sort(sortBuilders(pageable.getSort().get())).

--- a/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AuditITCase.java
+++ b/fit/core-reference/src/test/java/org/apache/syncope/fit/core/AuditITCase.java
@@ -234,6 +234,87 @@ public class AuditITCase extends AbstractITCase {
     }
 
     @Test
+    public void findByUsername() {
+        UserTO userTO = createUser(UserITCase.getUniqueSample("audit-username@syncope.org")).getEntity();
+        assertNotNull(userTO.getKey());
+
+        // exact match on the username whose payload was logged for the create event
+        AuditQuery exact = new AuditQuery.Builder().
+                username(userTO.getUsername()).
+                type(OpEvent.CategoryType.LOGIC).
+                category(UserLogic.class.getSimpleName()).
+                op("create").
+                outcome(OpEvent.Outcome.SUCCESS).
+                build();
+        List<AuditEventTO> exactResult = query(exact, MAX_WAIT_SECONDS);
+        assertFalse(exactResult.isEmpty());
+        // the matched event genuinely carries this username in its payload (not matched by chance)
+        assertTrue(exactResult.stream().anyMatch(event -> (event.getOutput() != null
+                && event.getOutput().contains("\"username\":\"" + userTO.getUsername() + "\""))
+                || (event.getBefore() != null
+                && event.getBefore().contains("\"username\":\"" + userTO.getUsername() + "\""))));
+
+        // multiple username values are OR'ed
+        AuditQuery multiple = new AuditQuery.Builder().
+                username(userTO.getUsername()).
+                username("non-existent-" + UUID.randomUUID()).
+                type(OpEvent.CategoryType.LOGIC).
+                category(UserLogic.class.getSimpleName()).
+                op("create").
+                outcome(OpEvent.Outcome.SUCCESS).
+                build();
+        assertFalse(AUDIT_SERVICE.search(multiple).getResult().isEmpty());
+
+        // a non-matching username excludes the event
+        AuditQuery noMatch = new AuditQuery.Builder().
+                username("non-existent-" + UUID.randomUUID()).
+                type(OpEvent.CategoryType.LOGIC).
+                category(UserLogic.class.getSimpleName()).
+                op("create").
+                outcome(OpEvent.Outcome.SUCCESS).
+                build();
+        assertTrue(AUDIT_SERVICE.search(noMatch).getResult().isEmpty());
+
+        // the match is exact: a strict prefix of the username does not match
+        AuditQuery prefix = new AuditQuery.Builder().
+                username(userTO.getUsername().substring(0, userTO.getUsername().length() - 1)).
+                type(OpEvent.CategoryType.LOGIC).
+                category(UserLogic.class.getSimpleName()).
+                op("create").
+                outcome(OpEvent.Outcome.SUCCESS).
+                build();
+        assertTrue(AUDIT_SERVICE.search(prefix).getResult().isEmpty());
+
+        USER_SERVICE.delete(userTO.getKey());
+    }
+
+    @Test
+    public void findDeletedUserByUsername() {
+        UserTO userTO = createUser(UserITCase.getUniqueSample("audit-username-deleted@syncope.org")).getEntity();
+        String username = userTO.getUsername();
+        assertNotNull(userTO.getKey());
+
+        AuditQuery deleteQuery = new AuditQuery.Builder().
+                username(username).
+                type(OpEvent.CategoryType.LOGIC).
+                category(UserLogic.class.getSimpleName()).
+                op("delete").
+                outcome(OpEvent.Outcome.SUCCESS).
+                build();
+        try {
+            AUDIT_SERVICE.setConf(buildAuditConf("[LOGIC]:[UserLogic]:[]:[delete]:[SUCCESS]", true));
+
+            USER_SERVICE.delete(userTO.getKey());
+
+            // the user is gone (its key can no longer be resolved), but the delete event's "before"
+            // snapshot still carries the username, so it remains searchable by username
+            assertFalse(query(deleteQuery, MAX_WAIT_SECONDS).isEmpty());
+        } finally {
+            AUDIT_SERVICE.setConf(buildAuditConf("[LOGIC]:[UserLogic]:[]:[delete]:[SUCCESS]", false));
+        }
+    }
+
+    @Test
     public void findByGroup() {
         GroupTO groupTO = createGroup(GroupITCase.getBasicSample("AuditGroup")).getEntity();
         assertNotNull(groupTO.getKey());


### PR DESCRIPTION
[SYNCOPE-1978](https://issues.apache.org/jira/browse/SYNCOPE-1978)

### What
Restores the ability to search audit events by the **username of the entity whose payload was logged**, complementing the existing `entityKey` (UUID) match. A new repeatable `username` query parameter on `AuditQuery` matches the token `"username":"<value>"` embedded in the serialized audit payload (`before`, `inputs`, `output`, `throwable`):

- single — `?username=jdoe`
- multiple, OR-ed — `?username=jdoe&username=asmith`

It is an **exact** match (no wildcards) and composes (AND) with the existing audit search filters (`entityKey`, `who`, `type`, `category`, `op`, `outcome`, `before`/`after`).

### Why
Today an audit search can be pinned to a specific user only via `entityKey`, which requires the user's UUID. That UUID is unavailable once the user has been deleted, so there is no way to retrieve a deleted user's audit trail. The username, however, is preserved inside the `before` snapshot of the relevant audit events, so matching by username makes that trail searchable — and saves a resolve-then-query round-trip for live users.

Syncope 3.0 allowed an approximation by abusing `entityKey=<username>` (an imprecise `LIKE '%key%<value>%'`); the 4.0 audit refactor correctly tightened `entityKey` to match only the UUID, which removed that side effect. This change reintroduces the capability deliberately and precisely, as a dedicated filter rather than re-loosening `entityKey`.

### Implementation
The filter is threaded through `AuditServiceImpl` → `AuditLogic` → the `AuditEventDAO` interface and all of its implementations:

- **JPA**: per value, `(beforeValue/inputs/output/throwable LIKE ? ESCAPE '#')` matching `%"username":"<value>"%`, OR-ed; the value is **bound as a parameter** and its `LIKE` metacharacters are escaped (so `%`/`_` in a username match literally);
- **Neo4j**: `ANY(u IN $usernames WHERE n.before CONTAINS u OR ...)` — a literal `CONTAINS` with a bound list parameter (no regex);
- **Elasticsearch / OpenSearch**: a `multi_match` phrase query of `"username":"<value>"` over the payload fields, OR-ed via `bool`/`should`.

All values are bound as query parameters (SQL/Cypher) or passed as structured phrase queries (Elasticsearch/OpenSearch), so there is no injection surface; the pre-existing `entityKey` predicate is intentionally left unchanged.

### Tests
Integration tests in `AuditITCase` cover exact match (asserting the matched event's payload truly carries the username), multiple values (OR), non-match exclusion, exact-not-prefix matching, and the **deleted-user** case (a user is created then deleted, and is still found by username via the delete event's `before` snapshot). Verified end-to-end against embedded PostgreSQL, Neo4j and Elasticsearch.
