### PR TITLE
Set a no-op WriteCallback for successful OIDC back-channel logout

### DIFF
--- a/ext/oidcc4ui/client-common-ui/src/main/java/org/apache/syncope/client/ui/commons/resources/oidcc4ui/LogoutResource.java
+++ b/ext/oidcc4ui/client-common-ui/src/main/java/org/apache/syncope/client/ui/commons/resources/oidcc4ui/LogoutResource.java
@@ -61,6 +61,13 @@ public abstract class LogoutResource extends AbstractResource {
             service.backChannelLogout(logoutToken, request.getRequestURL().toString());
 
             response.setStatusCode(Response.Status.OK.getStatusCode());
+            response.setWriteCallback(new WriteCallback() {
+                
+                @Override
+                public void writeData(final Attributes atrbts) {
+                    // No response body
+                }
+            });
         } catch (Exception e) {
             LOG.error("While requesting back-channel logout for token {}", logoutToken, e);
 


### PR DESCRIPTION
Without a callback, Wicket may throw a NullPointerException while rendering the response