### PR TITLE
hide timestamp in generated OpenAPI code

### DIFF
--- a/ext/openfga/client-openfga/pom.xml
+++ b/ext/openfga/client-openfga/pom.xml
@@ -108,6 +108,7 @@ under the License.
                 <useJakartaEe>true</useJakartaEe>
                 <openApiNullable>false</openApiNullable>
                 <sourceFolder>/</sourceFolder>
+                <hideGenerationTimestamp>true</hideGenerationTimestamp>
               </configOptions>
             </configuration>
           </execution>


### PR DESCRIPTION
should solve the remaining issue for Reproducible Builds https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/apache/syncope/README.md

= `syncope-ext-openfga-client-4.1.3-sources.jar`
```
├── org/apache/syncope/ext/openfga/client/model/WriteAuthorizationModelResponse.java
│ @@ -31,15 +31,15 @@
│  import org.apache.syncope.ext.openfga.client.ApiClient;
│  /**
│   * WriteAuthorizationModelResponse
│   */
│  @JsonPropertyOrder({
│    WriteAuthorizationModelResponse.JSON_PROPERTY_AUTHORIZATION_MODEL_ID
│  })
│ -@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-09-11T08:24:25.043110312+02:00[Europe/Rome]", comments = "Generator version: 7.25.0")
│ +@jakarta.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen", date = "2026-09-12T07:58:56.874168740+02:00[Europe/Paris]", comments = "Generator version: 7.25.0")
│  public class WriteAuthorizationModelResponse {
│    public static final String JSON_PROPERTY_AUTHORIZATION_MODEL_ID = "authorization_model_id";
│    @jakarta.annotation.Nonnull
│    private String authorizationModelId;
│  
│    public WriteAuthorizationModelResponse() { 
│    }

```